### PR TITLE
Fix: Ensure all image key are unique

### DIFF
--- a/Source/VersOne.Epub/Readers/ContentReader.cs
+++ b/Source/VersOne.Epub/Readers/ContentReader.cs
@@ -59,14 +59,18 @@ namespace VersOne.Epub.Internal
                             case EpubContentType.IMAGE_JPEG:
                             case EpubContentType.IMAGE_PNG:
                             case EpubContentType.IMAGE_SVG:
-                                result.Images.Add(fileName, epubByteContentFile);
+                                // ensure the image key is unique
+                                if (!result.Images.ContainsKey(fileName))
+                                    result.Images.Add(fileName, epubByteContentFile);
                                 break;
                             case EpubContentType.FONT_TRUETYPE:
                             case EpubContentType.FONT_OPENTYPE:
                                 result.Fonts.Add(fileName, epubByteContentFile);
                                 break;
                         }
-                        result.AllFiles.Add(fileName, epubByteContentFile);
+                        // ensure the image key is unique
+                        if (!result.Images.ContainsKey(fileName))
+                            result.AllFiles.Add(fileName, epubByteContentFile);
                         break;
                 }
             }


### PR DESCRIPTION
Double check the image key to ensure is unique, in case the epub file is not created correctly. 

Feel free to drop it if it's not necessary. :smile: