### PR TITLE
Fix chapters parsing

### DIFF
--- a/Source/VersOne.Epub.WpfDemo/Controls/BookHtmlContent.cs
+++ b/Source/VersOne.Epub.WpfDemo/Controls/BookHtmlContent.cs
@@ -92,7 +92,7 @@ namespace VersOne.Epub.WpfDemo.Controls
                 basePath = Path.GetDirectoryName(basePath);
             }
             string fullPath = String.Concat(basePath.Replace('\\', '/'), '/', relativePath);
-            return fullPath.Length > 1 ? fullPath.StartsWith("/") ? fullPath.Substring(1) : fullPath : String.Empty;
+            return fullPath.StartsWith("/") ? fullPath.Length > 1 ? fullPath.Substring(1) : String.Empty : fullPath;
         }
 
         private void RegisterFonts()

--- a/Source/VersOne.Epub/Readers/ChapterReader.cs
+++ b/Source/VersOne.Epub/Readers/ChapterReader.cs
@@ -10,7 +10,6 @@ namespace VersOne.Epub.Internal
     {
         public static List<EpubChapterRef> GetChapters(EpubBookRef bookRef)
         {
-            // return GetChapters(bookRef, bookRef.Schema.Navigation.NavMap);
             return GetChapters(bookRef, bookRef.Schema.Package.Spine, bookRef.Schema.Navigation.NavMap);
         }
 
@@ -42,39 +41,6 @@ namespace VersOne.Epub.Internal
                     chapterRef.Title = $"Chapter {s + 1}";
                 }                
                 chapterRef.SubChapters = new List<EpubChapterRef>();
-                result.Add(chapterRef);
-            }
-            return result;
-        }
-
-        public static List<EpubChapterRef> GetChapters(EpubBookRef bookRef, List<EpubNavigationPoint> navigationPoints, EpubChapterRef parentChapter = null)
-        {
-            List<EpubChapterRef> result = new List<EpubChapterRef>();
-            foreach (EpubNavigationPoint navigationPoint in navigationPoints)
-            {
-                string contentFileName;
-                string anchor;
-                int contentSourceAnchorCharIndex = navigationPoint.Content.Source.IndexOf('#');
-                if (contentSourceAnchorCharIndex == -1)
-                {
-                    contentFileName = WebUtility.UrlDecode(navigationPoint.Content.Source);
-                    anchor = null;
-                }
-                else
-                {
-                    contentFileName = WebUtility.UrlDecode(navigationPoint.Content.Source.Substring(0, contentSourceAnchorCharIndex));
-                    anchor = navigationPoint.Content.Source.Substring(contentSourceAnchorCharIndex + 1);
-                }
-                if (!bookRef.Content.Html.TryGetValue(contentFileName, out EpubTextContentFileRef htmlContentFileRef))
-                {
-                    throw new Exception(String.Format("Incorrect EPUB manifest: item with href = \"{0}\" is missing.", contentFileName));
-                }
-                EpubChapterRef chapterRef = new EpubChapterRef(htmlContentFileRef);
-                chapterRef.ContentFileName = contentFileName;
-                chapterRef.Anchor = anchor;
-                chapterRef.Parent = parentChapter;
-                chapterRef.Title = navigationPoint.NavigationLabels.First().Text;
-                chapterRef.SubChapters = GetChapters(bookRef, navigationPoint.ChildNavigationPoints, chapterRef);
                 result.Add(chapterRef);
             }
             return result;

--- a/Source/VersOne.Epub/Readers/ChapterReader.cs
+++ b/Source/VersOne.Epub/Readers/ChapterReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using VersOne.Epub.Schema;
 
 namespace VersOne.Epub.Internal
@@ -9,10 +10,44 @@ namespace VersOne.Epub.Internal
     {
         public static List<EpubChapterRef> GetChapters(EpubBookRef bookRef)
         {
-            return GetChapters(bookRef, bookRef.Schema.Navigation.NavMap);
+            // return GetChapters(bookRef, bookRef.Schema.Navigation.NavMap);
+            return GetChapters(bookRef, bookRef.Schema.Package.Spine, bookRef.Schema.Navigation.NavMap);
         }
 
-        public static List<EpubChapterRef> GetChapters(EpubBookRef bookRef, List<EpubNavigationPoint> navigationPoints)
+        public static List<EpubChapterRef> GetChapters(EpubBookRef bookRef, EpubSpine spine, List<EpubNavigationPoint> navigationPoints)
+        {
+            List<EpubChapterRef> result = new List<EpubChapterRef>();
+            for (int s = 0; s < spine.Count; s++)
+            {
+                EpubSpineItemRef itemRef = spine[s];
+                string contentFileName;
+                string anchor;
+                contentFileName = WebUtility.UrlDecode(bookRef.Schema.Package.Manifest.FirstOrDefault(e => e.Id == itemRef.IdRef)?.Href);
+                anchor = null;
+                if (!bookRef.Content.Html.TryGetValue(contentFileName, out EpubTextContentFileRef htmlContentFileRef))
+                {
+                    throw new Exception(String.Format("Incorrect EPUB manifest: item with href = \"{0}\" is missing.", contentFileName));
+                }
+                EpubChapterRef chapterRef = new EpubChapterRef(htmlContentFileRef);
+                chapterRef.ContentFileName = contentFileName;
+                chapterRef.Anchor = anchor;
+                chapterRef.Parent = null;
+                var navPoint = navigationPoints.LastOrDefault(nav => spine.Take(s + 1).Select(sp => bookRef.Schema.Package.Manifest.FirstOrDefault(e => e.Id == sp.IdRef)?.Href).Contains(nav.Content.Source.Split('#')[0]));
+                if (navPoint != null)
+                {
+                    chapterRef.Title = navPoint.NavigationLabels.First().Text;
+                }
+                else
+                {
+                    chapterRef.Title = $"Chapter {s + 1}";
+                }                
+                chapterRef.SubChapters = new List<EpubChapterRef>();
+                result.Add(chapterRef);
+            }
+            return result;
+        }
+
+        public static List<EpubChapterRef> GetChapters(EpubBookRef bookRef, List<EpubNavigationPoint> navigationPoints, EpubChapterRef parentChapter = null)
         {
             List<EpubChapterRef> result = new List<EpubChapterRef>();
             foreach (EpubNavigationPoint navigationPoint in navigationPoints)
@@ -22,12 +57,12 @@ namespace VersOne.Epub.Internal
                 int contentSourceAnchorCharIndex = navigationPoint.Content.Source.IndexOf('#');
                 if (contentSourceAnchorCharIndex == -1)
                 {
-                    contentFileName = navigationPoint.Content.Source;
+                    contentFileName = WebUtility.UrlDecode(navigationPoint.Content.Source);
                     anchor = null;
                 }
                 else
                 {
-                    contentFileName = navigationPoint.Content.Source.Substring(0, contentSourceAnchorCharIndex);
+                    contentFileName = WebUtility.UrlDecode(navigationPoint.Content.Source.Substring(0, contentSourceAnchorCharIndex));
                     anchor = navigationPoint.Content.Source.Substring(contentSourceAnchorCharIndex + 1);
                 }
                 if (!bookRef.Content.Html.TryGetValue(contentFileName, out EpubTextContentFileRef htmlContentFileRef))
@@ -37,8 +72,9 @@ namespace VersOne.Epub.Internal
                 EpubChapterRef chapterRef = new EpubChapterRef(htmlContentFileRef);
                 chapterRef.ContentFileName = contentFileName;
                 chapterRef.Anchor = anchor;
+                chapterRef.Parent = parentChapter;
                 chapterRef.Title = navigationPoint.NavigationLabels.First().Text;
-                chapterRef.SubChapters = GetChapters(bookRef, navigationPoint.ChildNavigationPoints);
+                chapterRef.SubChapters = GetChapters(bookRef, navigationPoint.ChildNavigationPoints, chapterRef);
                 result.Add(chapterRef);
             }
             return result;

--- a/Source/VersOne.Epub/RefEntities/EpubChapterRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubChapterRef.cs
@@ -6,7 +6,7 @@ namespace VersOne.Epub
 {
     public class EpubChapterRef
     {
-        private readonly EpubTextContentFileRef epubTextContentFileRef;
+        private readonly EpubTextContentFileRef epubTextContentFileRef;        
 
         public EpubChapterRef(EpubTextContentFileRef epubTextContentFileRef)
         {
@@ -17,6 +17,7 @@ namespace VersOne.Epub
         public string ContentFileName { get; set; }
         public string Anchor { get; set; }
         public List<EpubChapterRef> SubChapters { get; set; }
+        public EpubChapterRef Parent { get; set; }
 
         public string ReadHtmlContent()
         {


### PR DESCRIPTION
Hello I'm using this (amazing) library for the project [QuickLook](https://github.com/xupefei/QuickLook).
I noticed that on a number of ebooks not all chapters were displayed. This is because the _navmap_ in _toc.ncx_ often does not contain all the ebook content while the _spine_ element in _content.opf_ does.
I'm posting here my edits to the _ChapterReader_: basically it now uses _bookRef.Schema.Package.Spine_ instead of _bookRef.Schema.Navigation.NavMap_.
