### PR TITLE
Some fixes for non-standard ebooks

### DIFF
--- a/Source/VersOne.Epub/Readers/BookCoverReader.cs
+++ b/Source/VersOne.Epub/Readers/BookCoverReader.cs
@@ -29,17 +29,35 @@ namespace VersOne.Epub.Internal
             {
                 // 2019-08-20 Hotfix: if coverManifestItem is not found by its Id, then try it with its Href - some ebooks refer to the image directly!
                 coverManifestItem = epubSchema.Package.Manifest.FirstOrDefault(manifestItem => manifestItem.Href.CompareOrdinalIgnoreCase(coverMetaItem.Content));
+                if (null == coverManifestItem)
+                {
+                    throw new Exception($"Incorrect EPUB manifest: item with ID = \"{coverMetaItem.Content}\" is missing.");
+                }
+            }
+            if (imageContentRefs.TryGetValue(coverManifestItem.Href, out EpubByteContentFileRef coverImageContentFileRef))
+            {
+                return coverImageContentFileRef;
+            }
+
+            // 2019-08-21 Fix some ebooks seem to contain more than one item with Id="cover"
+            // thus we test if there is a second item....
+
+            coverManifestItem = epubSchema.Package.Manifest.Where(manifestItem => manifestItem.Id.CompareOrdinalIgnoreCase(coverMetaItem.Content)).Skip(1).FirstOrDefault(); ;
+            if (coverManifestItem == null)
+            {
+                // 2019-08-20 Hotfix: if coverManifestItem is not found by its Id, then try it with its Href - some ebooks refer to the image directly!
+                coverManifestItem = epubSchema.Package.Manifest.FirstOrDefault(manifestItem => manifestItem.Href.CompareOrdinalIgnoreCase(coverMetaItem.Content));
 
                 if (null == coverManifestItem)
                 {
                     throw new Exception($"Incorrect EPUB manifest: item with ID = \"{coverMetaItem.Content}\" is missing.");
                 }
             }
-            if (!imageContentRefs.TryGetValue(coverManifestItem.Href, out EpubByteContentFileRef coverImageContentFileRef))
+            if (imageContentRefs.TryGetValue(coverManifestItem.Href, out EpubByteContentFileRef coverImageContentFileRef2))
             {
-                throw new Exception($"Incorrect EPUB manifest: item with href = \"{coverManifestItem.Href}\" is missing.");
+                return coverImageContentFileRef2;
             }
-            return coverImageContentFileRef;
+            throw new Exception($"Incorrect EPUB manifest: item with href = \"{coverManifestItem.Href}\" is missing.");
         }
     }
 }

--- a/Source/VersOne.Epub/Readers/BookCoverReader.cs
+++ b/Source/VersOne.Epub/Readers/BookCoverReader.cs
@@ -27,7 +27,13 @@ namespace VersOne.Epub.Internal
             EpubManifestItem coverManifestItem = epubSchema.Package.Manifest.FirstOrDefault(manifestItem => manifestItem.Id.CompareOrdinalIgnoreCase(coverMetaItem.Content));
             if (coverManifestItem == null)
             {
-                throw new Exception($"Incorrect EPUB manifest: item with ID = \"{coverMetaItem.Content}\" is missing.");
+                // 2019-08-20 Hotfix: if coverManifestItem is not found by its Id, then try it with its Href - some ebooks refer to the image directly!
+                coverManifestItem = epubSchema.Package.Manifest.FirstOrDefault(manifestItem => manifestItem.Href.CompareOrdinalIgnoreCase(coverMetaItem.Content));
+
+                if (null == coverManifestItem)
+                {
+                    throw new Exception($"Incorrect EPUB manifest: item with ID = \"{coverMetaItem.Content}\" is missing.");
+                }
             }
             if (!imageContentRefs.TryGetValue(coverManifestItem.Href, out EpubByteContentFileRef coverImageContentFileRef))
             {

--- a/Source/VersOne.Epub/Readers/SpineReader.cs
+++ b/Source/VersOne.Epub/Readers/SpineReader.cs
@@ -12,16 +12,31 @@ namespace VersOne.Epub.Internal
             List<EpubTextContentFileRef> result = new List<EpubTextContentFileRef>();
             foreach (EpubSpineItemRef spineItemRef in bookRef.Schema.Package.Spine)
             {
+
                 EpubManifestItem manifestItem = bookRef.Schema.Package.Manifest.FirstOrDefault(item => item.Id == spineItemRef.IdRef);
                 if (manifestItem == null)
                 {
                     throw new Exception($"Incorrect EPUB spine: item with IdRef = \"{spineItemRef.IdRef}\" is missing in the manifest.");
                 }
-                if (!bookRef.Content.Html.TryGetValue(manifestItem.Href, out EpubTextContentFileRef htmlContentFileRef))
+                if (bookRef.Content.Html.TryGetValue(manifestItem.Href, out EpubTextContentFileRef htmlContentFileRef))
                 {
-                    throw new Exception($"Incorrect EPUB manifest: item with href = \"{spineItemRef.IdRef}\" is missing in the book.");
+                    result.Add(htmlContentFileRef);
+                    continue;
                 }
-                result.Add(htmlContentFileRef);
+
+                // 2019-08-21 Fix: some ebooks seem to contain two items with id="cover", one of them is an image, and the other an XHTML file
+                // thus, if the first attempt to get the HTML item fails, we try for a second item with the same Id
+                manifestItem = bookRef.Schema.Package.Manifest.Where(item => item.Id == spineItemRef.IdRef).Skip(1).FirstOrDefault();
+                if (manifestItem == null)
+                {
+                    throw new Exception($"Incorrect EPUB spine: item with IdRef = \"{spineItemRef.IdRef}\" is not HTML content");
+                }
+                if (bookRef.Content.Html.TryGetValue(manifestItem.Href, out EpubTextContentFileRef htmlContentFileRef2))
+                {
+                    result.Add(htmlContentFileRef2);
+                    continue;
+                }
+                throw new Exception($"Incorrect EPUB manifest: item with href = \"{spineItemRef.IdRef}\" is missing in the book.");
             }
             return result;
         }

--- a/Source/VersOne.Epub/Utils/XmlUtils.cs
+++ b/Source/VersOne.Epub/Utils/XmlUtils.cs
@@ -20,8 +20,37 @@ namespace VersOne.Epub.Internal
                 };
                 using (XmlReader xmlReader = XmlReader.Create(memoryStream, xmlReaderSettings))
                 {
-                    return await Task.Run(() => XDocument.Load(memoryStream)).ConfigureAwait(false);
+                    return await Task.Run(() => LoadXDocument(memoryStream)).ConfigureAwait(false);
                 }
+            }
+        }
+
+        private static XDocument LoadXDocument(MemoryStream memoryStream)
+        {
+            try
+            {
+                return XDocument.Load(memoryStream);
+            }
+            catch (System.Xml.XmlException xx)
+            {
+                if (xx.Message.StartsWith("Version number '1.1'")) // try to solve the known problem that .NET framework does not support XML version 1.1
+                {
+                    memoryStream.Seek(0, SeekOrigin.Begin);
+                    var buffer = new byte[512];
+                    var read = memoryStream.Read(buffer, 0, buffer.Length); // read first 512 byte
+
+                    for (int i = 2; i < read; ++i) // search for "1.1" in the buffer
+                    {
+                        if (buffer[i - 2] == 0x31 && buffer[i - 1] == 0x2E && buffer[i] == 0x31) // if string is "1.1"
+                        {
+                            memoryStream.Seek(i, SeekOrigin.Begin); // seek to index i
+                            memoryStream.WriteByte(0x30);           // replace by '0' to get version number "1.0"
+                            memoryStream.Seek(0, SeekOrigin.Begin); // rewind memory stream
+                            return XDocument.Load(memoryStream);
+                        }
+                    }
+                }
+                throw;
             }
         }
     }


### PR DESCRIPTION
This fixes avoid exceptions if the .opf file is encoded with XML version 1.1, if the cover content is referenced by its Href by its Id, or if there are two items with Id='cover'