### PR TITLE
Fix PackageReader to pick up cover images as generated on Adobe Indesign

### DIFF
--- a/Source/VersOne.Epub/Readers/PackageReader.cs
+++ b/Source/VersOne.Epub/Readers/PackageReader.cs
@@ -275,9 +275,18 @@ namespace VersOne.Epub.Internal
                     case "scheme":
                         result.Scheme = attributeValue;
                         break;
+                    case "name":
+                        result.Name = attributeValue;
+                        break;
+                    case "content":
+                        result.Content = attributeValue;
+                        break;
                 }
             }
-            result.Content = metadataMetaNode.Value;
+            if (string.IsNullOrEmpty(result.Content))
+            {
+                result.Content = metadataMetaNode.Value;
+            }
             return result;
         }
 


### PR DESCRIPTION
Adobe InDesign generates cover images on EPUBs using "name" and "content" attributes on a 3.0 EPUB.