### PR TITLE
Fix AggregateException when trying to fix xml version 1.1

### DIFF
--- a/Source/VersOne.Epub/Utils/XmlUtils.cs
+++ b/Source/VersOne.Epub/Utils/XmlUtils.cs
@@ -20,16 +20,16 @@ namespace VersOne.Epub.Internal
                 };
                 using (XmlReader xmlReader = XmlReader.Create(memoryStream, xmlReaderSettings))
                 {
-                    return await Task.Run(() => LoadXDocument(memoryStream)).ConfigureAwait(false);
+                    return LoadXDocument(xmlReader, memoryStream, xmlReaderSettings);
                 }
             }
         }
 
-        private static XDocument LoadXDocument(MemoryStream memoryStream)
+        private static XDocument LoadXDocument(XmlReader xmlReader, MemoryStream memoryStream, XmlReaderSettings xmlReaderSettings)
         {
             try
             {
-                return XDocument.Load(memoryStream);
+                return XDocument.Load(xmlReader);
             }
             catch (System.Xml.XmlException xx)
             {
@@ -49,7 +49,10 @@ namespace VersOne.Epub.Internal
                             memoryStream.Seek(i, SeekOrigin.Begin); // seek to index i
                             memoryStream.WriteByte(0x30);           // replace by '0' to get version number "1.0"
                             memoryStream.Seek(0, SeekOrigin.Begin); // rewind memory stream
-                            return XDocument.Load(memoryStream);
+                            using (var xmlReaderInException = XmlReader.Create(memoryStream, xmlReaderSettings))
+                            {
+                                return XDocument.Load(xmlReaderInException);
+                            }
                         }
                     }
                 }

--- a/Source/VersOne.Epub/Utils/XmlUtils.cs
+++ b/Source/VersOne.Epub/Utils/XmlUtils.cs
@@ -35,6 +35,9 @@ namespace VersOne.Epub.Internal
             {
                 if (xx.Message.Contains("'1.1'")) // try to solve the known problem that .NET framework does not support XML version 1.1
                 {
+                    // Make sure the Stream position placed at the beginning to read the entire stream
+                    memoryStream.Position = 0;
+
                     memoryStream.Seek(0, SeekOrigin.Begin);
                     var buffer = new byte[512];
                     var read = memoryStream.Read(buffer, 0, buffer.Length); // read first 512 byte

--- a/Source/VersOne.Epub/VersOne.Epub.csproj
+++ b/Source/VersOne.Epub/VersOne.Epub.csproj
@@ -6,7 +6,7 @@
         <Product />
         <Description />
         <Copyright>vers, 2015-2019</Copyright>
-        <Version>3.0.3</Version>
+        <Version>3.1.0</Version>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
Fixes #34 

For some reason XDocument.Load changing the Position of the stream, so the fix is to make sure Position is resetted to 0