### PR TITLE
Parse creator ID on metadata iteration

### DIFF
--- a/Source/VersOne.Epub/Readers/PackageReader.cs
+++ b/Source/VersOne.Epub/Readers/PackageReader.cs
@@ -178,7 +178,7 @@ namespace VersOne.Epub.Internal
                     case "file-as":
                         result.FileAs = attributeValue;
                         break;
-                    case "id" ;
+                    case "id":
                         result.Id = attributeValue;
                         break;
                 }

--- a/Source/VersOne.Epub/Readers/PackageReader.cs
+++ b/Source/VersOne.Epub/Readers/PackageReader.cs
@@ -178,6 +178,9 @@ namespace VersOne.Epub.Internal
                     case "file-as":
                         result.FileAs = attributeValue;
                         break;
+                    case "id" ;
+                        result.Id = attributeValue;
+                        break;
                 }
             }
             result.Creator = metadataCreatorNode.Value;

--- a/Source/VersOne.Epub/Schema/Opf/EpubMetadataCreator.cs
+++ b/Source/VersOne.Epub/Schema/Opf/EpubMetadataCreator.cs
@@ -5,5 +5,6 @@
         public string Creator { get; set; }
         public string FileAs { get; set; }
         public string Role { get; set; }
+        public string Id { get; set; }
     }
 }


### PR DESCRIPTION
We need to have the ID of each Creator tag, since we use meta tags for refinement.
In our case the list of Creators only contains the names and empty roles. We need to fetch the role from the meta data tags.
Having the creator ID on the Creator object would allow us to match the refinement in the meta tags.

    <dc:creator id="pub-author">Author name</dc:creator>
    <meta refines="#pub-author" property="role" scheme="marc:relators">aut</meta>

The ID will be parsed as such:
![billede](https://user-images.githubusercontent.com/3624301/113113315-737f8f80-920a-11eb-9257-109c947c7d00.png)
