### PR TITLE
Book cover extracting enhancements

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -12,6 +12,9 @@ dotnet_diagnostic.IDE0008.severity = error
 # IDE0017: Use object initializers
 dotnet_diagnostic.IDE0017.severity = none
 
+# IDE0018: Inline variable declaration
+dotnet_diagnostic.IDE0018.severity = error
+
 # IDE0060: Remove unused parameter
 dotnet_diagnostic.IDE0060.severity = error
 

--- a/Source/VersOne.Epub/Readers/PackageReader.cs
+++ b/Source/VersOne.Epub/Readers/PackageReader.cs
@@ -49,7 +49,7 @@ namespace VersOne.Epub.Internal
             {
                 throw new Exception("EPUB parsing error: metadata not found in the package.");
             }
-            EpubMetadata metadata = ReadMetadata(metadataNode, result.EpubVersion);
+            EpubMetadata metadata = ReadMetadata(metadataNode);
             result.Metadata = metadata;
             XElement manifestNode = packageNode.Element(opfNamespace + "manifest");
             if (manifestNode == null)
@@ -74,7 +74,7 @@ namespace VersOne.Epub.Internal
             return result;
         }
 
-        private static EpubMetadata ReadMetadata(XElement metadataNode, EpubVersion epubVersion)
+        private static EpubMetadata ReadMetadata(XElement metadataNode)
         {
             EpubMetadata result = new EpubMetadata
             {
@@ -149,16 +149,8 @@ namespace VersOne.Epub.Internal
                         result.Rights.Add(innerText);
                         break;
                     case "meta":
-                        if (epubVersion == EpubVersion.EPUB_2)
-                        {
-                            EpubMetadataMeta meta = ReadMetadataMetaVersion2(metadataItemNode);
-                            result.MetaItems.Add(meta);
-                        }
-                        else if (epubVersion == EpubVersion.EPUB_3 || epubVersion == EpubVersion.EPUB_3_1)
-                        {
-                            EpubMetadataMeta meta = ReadMetadataMetaVersion3(metadataItemNode);
-                            result.MetaItems.Add(meta);
-                        }
+                        EpubMetadataMeta meta = ReadMetadataMeta(metadataItemNode);
+                        result.MetaItems.Add(meta);
                         break;
                 }
             }
@@ -243,7 +235,7 @@ namespace VersOne.Epub.Internal
             return result;
         }
 
-        private static EpubMetadataMeta ReadMetadataMetaVersion2(XElement metadataMetaNode)
+        private static EpubMetadataMeta ReadMetadataMeta(XElement metadataMetaNode)
         {
             EpubMetadataMeta result = new EpubMetadataMeta();
             foreach (XAttribute metadataMetaNodeAttribute in metadataMetaNode.Attributes())
@@ -257,19 +249,6 @@ namespace VersOne.Epub.Internal
                     case "content":
                         result.Content = attributeValue;
                         break;
-                }
-            }
-            return result;
-        }
-
-        private static EpubMetadataMeta ReadMetadataMetaVersion3(XElement metadataMetaNode)
-        {
-            EpubMetadataMeta result = new EpubMetadataMeta();
-            foreach (XAttribute metadataMetaNodeAttribute in metadataMetaNode.Attributes())
-            {
-                string attributeValue = metadataMetaNodeAttribute.Value;
-                switch (metadataMetaNodeAttribute.GetLowerCaseLocalName())
-                {
                     case "id":
                         result.Id = attributeValue;
                         break;
@@ -284,7 +263,10 @@ namespace VersOne.Epub.Internal
                         break;
                 }
             }
-            result.Content = metadataMetaNode.Value;
+            if (result.Content == null)
+            {
+                result.Content = metadataMetaNode.Value;
+            }
             return result;
         }
 


### PR DESCRIPTION
# Book cover extracting enhancements

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #48

## Description

1. All prior `BookCoverReader` hacks and heuristics have been removed.
2. The new implementation will try to extract the EPUB 2 cover using the `<meta name="cover" content="..." />` element (this approach is used by most EPUB 2 books). If such element was not found, the implementation will try to find a `<guide>/<reference type="cover" href="...">` element whose `href` attribute points to a known image.
3. Proper support for EPUB 3 covers have been added.
4. `PackageReader` will try to read all known EPUB 2 and EPUB 3 `<metadata>/<meta>` attributes, regardless of the actual version of the EPUB file (this was suggested in https://github.com/vers-one/EpubReader/pull/32).
5. Code has been refactored to fix all code style warnings.

## Testing steps

Try to open various EPUB 2 and EPUB 3 books in the WPF Demo app and make sure that their covers are being rendered properly.