### PR TITLE
Workaround for XML 1.1 schema files

### DIFF
--- a/Source/VersOne.Epub/Options/EpubReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/EpubReaderOptions.cs
@@ -9,6 +9,7 @@
         {
             PackageReaderOptions = new PackageReaderOptions();
             Epub2NcxReaderOptions = new Epub2NcxReaderOptions();
+            XmlReaderOptions = new XmlReaderOptions();
         }
 
         /// <summary>
@@ -20,5 +21,10 @@
         /// Gets or sets EPUB 2 NCX (Navigation Center eXtended) reader options.
         /// </summary>
         public Epub2NcxReaderOptions Epub2NcxReaderOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets XML reader options.
+        /// </summary>
+        public XmlReaderOptions XmlReaderOptions { get; set; }
     }
 }

--- a/Source/VersOne.Epub/Options/XmlReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/XmlReaderOptions.cs
@@ -1,0 +1,25 @@
+﻿namespace VersOne.Epub.Options
+{
+    /// <summary>
+    /// Various options to configure how EPUB reader handles XML files.
+    /// </summary>
+    public class XmlReaderOptions
+    {
+        public XmlReaderOptions()
+        {
+            SkipXmlHeaders = false;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether XML reader should skip XML headers for all schema files before attempting to read them.
+        /// This is a workaround for handling XML 1.1 files due to the lack of their support in .NET (only XML 1.0 files are currently supported).
+        /// If this property is set to true, XML reader will check if an XML file contains a declaration (&lt;?xml version="..." encoding="UTF-8"?&gt;)
+        /// in which case the reader will skip it before passing the file to the underlying .NET XDocument class. This lets the library to handle
+        /// EPUB files containing XML 1.1 files at the expense of an additional processing overhead for every schema file inside the EPUB file.
+        /// If this property is set to false, then there is no overhead for processing XML files. However in an attempt to open an EPUB with an XML 1.1
+        /// file, an XmlException "Version number '1.1' is invalid" will be thrown.
+        /// Default value is false.
+        /// </summary>
+        public bool SkipXmlHeaders { get; set; }
+    }
+}

--- a/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
@@ -13,7 +13,7 @@ namespace VersOne.Epub.Internal
 {
     internal static class Epub2NcxReader
     {
-        public static async Task<Epub2Ncx> ReadEpub2NcxAsync(IZipFile epubFile, string contentDirectoryPath, EpubPackage package, Epub2NcxReaderOptions epub2NcxReaderOptions)
+        public static async Task<Epub2Ncx> ReadEpub2NcxAsync(IZipFile epubFile, string contentDirectoryPath, EpubPackage package, EpubReaderOptions epubReaderOptions)
         {
             Epub2Ncx result = new Epub2Ncx();
             string tocId = package.Spine.Toc;
@@ -39,7 +39,7 @@ namespace VersOne.Epub.Internal
             XDocument containerDocument;
             using (Stream containerStream = tocFileEntry.Open())
             {
-                containerDocument = await XmlUtils.LoadDocumentAsync(containerStream).ConfigureAwait(false);
+                containerDocument = await XmlUtils.LoadDocumentAsync(containerStream, epubReaderOptions.XmlReaderOptions).ConfigureAwait(false);
             }
             XNamespace ncxNamespace = "http://www.daisy.org/z3986/2005/ncx/";
             XElement ncxNode = containerDocument.Element(ncxNamespace + "ncx");
@@ -72,7 +72,7 @@ namespace VersOne.Epub.Internal
             {
                 throw new Exception("EPUB parsing error: TOC file does not contain navMap element.");
             }
-            Epub2NcxNavigationMap navMap = ReadNavigationMap(navMapNode, epub2NcxReaderOptions);
+            Epub2NcxNavigationMap navMap = ReadNavigationMap(navMapNode, epubReaderOptions.Epub2NcxReaderOptions);
             result.NavMap = navMap;
             XElement pageListNode = ncxNode.Element(ncxNamespace + "pageList");
             if (pageListNode != null)

--- a/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using VersOne.Epub.Environment;
+using VersOne.Epub.Options;
 using VersOne.Epub.Schema;
 using VersOne.Epub.Utils;
 
@@ -12,7 +13,7 @@ namespace VersOne.Epub.Internal
 {
     internal static class Epub3NavDocumentReader
     {
-        public static async Task<Epub3NavDocument> ReadEpub3NavDocumentAsync(IZipFile epubFile, string contentDirectoryPath, EpubPackage package)
+        public static async Task<Epub3NavDocument> ReadEpub3NavDocumentAsync(IZipFile epubFile, string contentDirectoryPath, EpubPackage package, EpubReaderOptions epubReaderOptions)
         {
             Epub3NavDocument result = new Epub3NavDocument();
             EpubManifestItem navManifestItem =
@@ -41,7 +42,7 @@ namespace VersOne.Epub.Internal
             XDocument navDocument;
             using (Stream containerStream = navFileEntry.Open())
             {
-                navDocument = await XmlUtils.LoadDocumentAsync(containerStream).ConfigureAwait(false);
+                navDocument = await XmlUtils.LoadDocumentAsync(containerStream, epubReaderOptions.XmlReaderOptions).ConfigureAwait(false);
             }
             XNamespace xhtmlNamespace = navDocument.Root.Name.Namespace;
             XElement htmlNode = navDocument.Element(xhtmlNamespace + "html");

--- a/Source/VersOne.Epub/Readers/PackageReader.cs
+++ b/Source/VersOne.Epub/Readers/PackageReader.cs
@@ -12,7 +12,7 @@ namespace VersOne.Epub.Internal
 {
     internal static class PackageReader
     {
-        public static async Task<EpubPackage> ReadPackageAsync(IZipFile epubFile, string rootFilePath, PackageReaderOptions packageReaderOptions)
+        public static async Task<EpubPackage> ReadPackageAsync(IZipFile epubFile, string rootFilePath, EpubReaderOptions epubReaderOptions)
         {
             IZipFileEntry rootFileEntry = epubFile.GetEntry(rootFilePath);
             if (rootFileEntry == null)
@@ -22,7 +22,7 @@ namespace VersOne.Epub.Internal
             XDocument containerDocument;
             using (Stream containerStream = rootFileEntry.Open())
             {
-                containerDocument = await XmlUtils.LoadDocumentAsync(containerStream).ConfigureAwait(false);
+                containerDocument = await XmlUtils.LoadDocumentAsync(containerStream, epubReaderOptions.XmlReaderOptions).ConfigureAwait(false);
             }
             XNamespace opfNamespace = "http://www.idpf.org/2007/opf";
             XElement packageNode = containerDocument.Element(opfNamespace + "package");
@@ -56,14 +56,14 @@ namespace VersOne.Epub.Internal
             {
                 throw new Exception("EPUB parsing error: manifest not found in the package.");
             }
-            EpubManifest manifest = ReadManifest(manifestNode, packageReaderOptions);
+            EpubManifest manifest = ReadManifest(manifestNode, epubReaderOptions.PackageReaderOptions);
             result.Manifest = manifest;
             XElement spineNode = packageNode.Element(opfNamespace + "spine");
             if (spineNode == null)
             {
                 throw new Exception("EPUB parsing error: spine not found in the package.");
             }
-            EpubSpine spine = ReadSpine(spineNode, epubVersion, packageReaderOptions);
+            EpubSpine spine = ReadSpine(spineNode, epubVersion, epubReaderOptions.PackageReaderOptions);
             result.Spine = spine;
             XElement guideNode = packageNode.Element(opfNamespace + "guide");
             if (guideNode != null)

--- a/Source/VersOne.Epub/Readers/RootFilePathReader.cs
+++ b/Source/VersOne.Epub/Readers/RootFilePathReader.cs
@@ -3,12 +3,13 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using VersOne.Epub.Environment;
+using VersOne.Epub.Options;
 
 namespace VersOne.Epub.Internal
 {
     internal static class RootFilePathReader
     {
-        public static async Task<string> GetRootFilePathAsync(IZipFile epubFile)
+        public static async Task<string> GetRootFilePathAsync(IZipFile epubFile, EpubReaderOptions epubReaderOptions)
         {
             const string EPUB_CONTAINER_FILE_PATH = "META-INF/container.xml";
             IZipFileEntry containerFileEntry = epubFile.GetEntry(EPUB_CONTAINER_FILE_PATH);
@@ -19,7 +20,7 @@ namespace VersOne.Epub.Internal
             XDocument containerDocument;
             using (Stream containerStream = containerFileEntry.Open())
             {
-                containerDocument = await XmlUtils.LoadDocumentAsync(containerStream).ConfigureAwait(false);
+                containerDocument = await XmlUtils.LoadDocumentAsync(containerStream, epubReaderOptions.XmlReaderOptions).ConfigureAwait(false);
             }
             XNamespace cnsNamespace = "urn:oasis:names:tc:opendocument:xmlns:container";
             XAttribute fullPathAttribute = containerDocument.Element(cnsNamespace + "container")?.Element(cnsNamespace + "rootfiles")?.Element(cnsNamespace + "rootfile")?.Attribute("full-path");

--- a/Source/VersOne.Epub/Readers/SchemaReader.cs
+++ b/Source/VersOne.Epub/Readers/SchemaReader.cs
@@ -10,13 +10,13 @@ namespace VersOne.Epub.Internal
         public static async Task<EpubSchema> ReadSchemaAsync(IZipFile epubFile, EpubReaderOptions epubReaderOptions)
         {
             EpubSchema result = new EpubSchema();
-            string rootFilePath = await RootFilePathReader.GetRootFilePathAsync(epubFile).ConfigureAwait(false);
+            string rootFilePath = await RootFilePathReader.GetRootFilePathAsync(epubFile, epubReaderOptions).ConfigureAwait(false);
             string contentDirectoryPath = ZipPathUtils.GetDirectoryPath(rootFilePath);
             result.ContentDirectoryPath = contentDirectoryPath;
-            EpubPackage package = await PackageReader.ReadPackageAsync(epubFile, rootFilePath, epubReaderOptions.PackageReaderOptions).ConfigureAwait(false);
+            EpubPackage package = await PackageReader.ReadPackageAsync(epubFile, rootFilePath, epubReaderOptions).ConfigureAwait(false);
             result.Package = package;
-            result.Epub2Ncx = await Epub2NcxReader.ReadEpub2NcxAsync(epubFile, contentDirectoryPath, package, epubReaderOptions.Epub2NcxReaderOptions).ConfigureAwait(false);
-            result.Epub3NavDocument = await Epub3NavDocumentReader.ReadEpub3NavDocumentAsync(epubFile, contentDirectoryPath, package).ConfigureAwait(false);
+            result.Epub2Ncx = await Epub2NcxReader.ReadEpub2NcxAsync(epubFile, contentDirectoryPath, package, epubReaderOptions).ConfigureAwait(false);
+            result.Epub3NavDocument = await Epub3NavDocumentReader.ReadEpub3NavDocumentAsync(epubFile, contentDirectoryPath, package, epubReaderOptions).ConfigureAwait(false);
             return result;
         }
     }

--- a/Source/VersOne.Epub/Utils/XmlUtils.cs
+++ b/Source/VersOne.Epub/Utils/XmlUtils.cs
@@ -1,20 +1,27 @@
-﻿#pragma warning disable // code analysis warnings have been temporarily disabled but need to be fixed in the future
-
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using VersOne.Epub.Options;
 
 namespace VersOne.Epub.Internal
 {
     internal static class XmlUtils
     {
-        public static async Task<XDocument> LoadDocumentAsync(Stream stream)
+        private const string XML_DECLARATION_FIRST_CHARS = "<?xml";
+
+        public static async Task<XDocument> LoadDocumentAsync(Stream stream, XmlReaderOptions xmlReaderOptions)
         {
             using (MemoryStream memoryStream = new MemoryStream())
             {
                 await stream.CopyToAsync(memoryStream).ConfigureAwait(false);
                 memoryStream.Position = 0;
+                if (xmlReaderOptions.SkipXmlHeaders)
+                {
+                    SkipXmlHeader(memoryStream);
+                }
                 XmlReaderSettings xmlReaderSettings = new XmlReaderSettings
                 {
                     DtdProcessing = DtdProcessing.Ignore,
@@ -22,38 +29,60 @@ namespace VersOne.Epub.Internal
                 };
                 using (XmlReader xmlReader = XmlReader.Create(memoryStream, xmlReaderSettings))
                 {
-                    return await Task.Run(() => LoadXDocument(memoryStream)).ConfigureAwait(false);
+                    return await Task.Run(() => XDocument.Load(xmlReader)).ConfigureAwait(false);
                 }
             }
         }
 
-        private static XDocument LoadXDocument(MemoryStream memoryStream)
+        // This is a workaround for an issue that XML 1.1 files are not supported in .NET.
+        // See https://github.com/vers-one/EpubReader/issues/34 for more details.
+        // This method checks if the stream content starts with an XML declaration (<?xml ...)
+        // in which case it moves the stream position to the next '<' character
+        // (i.e. to the first XML content node, effectively skipping the XML header).
+        // Files with no XML declaration are treated as XML 1.0 files by .NET.
+        // If the stream content doesn't contain XML declaration, this method does not change its position.
+        private static void SkipXmlHeader(MemoryStream memoryStream)
         {
-            try
+            bool IsMatch(IList<byte> buffer, string pattern, int startPosition)
             {
-                return XDocument.Load(memoryStream);
-            }
-            catch (System.Xml.XmlException xx)
-            {
-                if (xx.Message.Contains("'1.1'")) // try to solve the known problem that .NET framework does not support XML version 1.1
+                if (startPosition > buffer.Count - pattern.Length)
                 {
-                    memoryStream.Seek(0, SeekOrigin.Begin);
-                    var buffer = new byte[512];
-                    var read = memoryStream.Read(buffer, 0, buffer.Length); // read first 512 byte
-
-                    for (int i = 2; i < read; ++i) // search for "1.1" in the buffer
+                    return false;
+                }
+                for (int i = 0; i < pattern.Length; i++)
+                {
+                    if (buffer[startPosition + i] != pattern[i])
                     {
-                        if (buffer[i - 2] == 0x31 && buffer[i - 1] == 0x2E && buffer[i] == 0x31) // if string is "1.1"
-                        {
-                            memoryStream.Seek(i, SeekOrigin.Begin); // seek to index i
-                            memoryStream.WriteByte(0x30);           // replace by '0' to get version number "1.0"
-                            memoryStream.Seek(0, SeekOrigin.Begin); // rewind memory stream
-                            return XDocument.Load(memoryStream);
-                        }
+                        return false;
                     }
                 }
-                throw;
+                return true;
             }
+
+            int IndexOf(IList<byte> buffer, string pattern, int startPosition)
+            {
+                for (int i = startPosition; i < buffer.Count - pattern.Length; i++)
+                {
+                    if (IsMatch(buffer, pattern, i))
+                    {
+                        return i;
+                    }
+                }
+                return -1;
+            }
+
+            memoryStream.TryGetBuffer(out ArraySegment<byte> memoryStreamBuffer);
+            int position = IndexOf(memoryStreamBuffer, XML_DECLARATION_FIRST_CHARS, 0);
+            if (position == -1)
+            {
+                return;
+            }
+            position = IndexOf(memoryStreamBuffer, "<", position + XML_DECLARATION_FIRST_CHARS.Length);
+            if (position == -1)
+            {
+                return;
+            }
+            memoryStream.Position = position;
         }
     }
 }


### PR DESCRIPTION
# Workaround for XML 1.1 schema files

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #34

## Description

This pull request replaces the XML 1.1 workaround code that relied on an `XmlException` and a specific error message to be thrown with an alternative workaround that simply skips the XML header if it is present. This workaround is possible because .NET treats all XML files without headers as XML 1.0 files.

Additionally, this pull request introduces an `XmlReaderOptions.SkipXmlHeaders` configuration parameter allowing the applications to enable or disable this workaround.

## Testing steps

Try to open a EPUB with an XML 1.1 schema file in WPF demo application with `XmlReaderOptions.SkipXmlHeaders` configuration parameter on and off.