### PR TITLE
Add explicit .NET Standard 2.0 support

### DIFF
--- a/Source/VersOne.Epub/VersOne.Epub.csproj
+++ b/Source/VersOne.Epub/VersOne.Epub.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+        <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
         <Authors>vers</Authors>
         <Company />
         <Product />

--- a/Source/VersOne.Epub/VersOne.Epub.nuspec
+++ b/Source/VersOne.Epub/VersOne.Epub.nuspec
@@ -18,6 +18,8 @@
             <group targetFramework="netstandard1.3">
                 <dependency id="System.IO.Compression" version="4.3.0" exclude="Build,Analyzers" />
             </group>
+            <group targetFramework="netstandard2.0">
+            </group>
         </dependencies>
     </metadata>
     <files>
@@ -25,5 +27,7 @@
         <file src="bin\Release\net46\VersOne.Epub.xml" target="lib\net46" />
         <file src="bin\Release\netstandard1.3\VersOne.Epub.dll" target="lib\netstandard1.3" />
         <file src="bin\Release\netstandard1.3\VersOne.Epub.xml" target="lib\netstandard1.3" />
+        <file src="bin\Release\netstandard2.0\VersOne.Epub.dll" target="lib\netstandard2.0" />
+        <file src="bin\Release\netstandard2.0\VersOne.Epub.xml" target="lib\netstandard2.0" />
     </files>
 </package>


### PR DESCRIPTION
# Add explicit .NET Standard 2.0 support

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #51

## Description

1. Adds `netstandard2.0` to the list of target frameworks in *VersOne.Epub* project.
2. Adds explicit support for .NET Standard 2.0 in *VersOne.Epub.nuspec*.

## Testing steps

1. Generate the Nuget package.
2. Add it to a .NET 6 project.

**Expected result:** Preview Changes window in the Nuget Package Manager in Visual Studio should show an empty list of dependencies to be installed (other than *VersOne.Epub* itself).
