### PR TITLE
Fix for event and scheme attributes parsing

### DIFF
--- a/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
@@ -46,6 +46,82 @@ namespace VersOne.Epub.Test.Unit.Readers
             </package>
             """;
 
+        private const string FULL_OPF_FILE = $"""
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" version="3.0">
+              <metadata>
+                <dc:title>Test title 1</dc:title>
+                <dc:title>Test title 2</dc:title>
+                <dc:creator id="creator-1" opf:role="author" opf:file-as="Doe, John">John Doe</dc:creator>
+                <dc:creator id="creator-2" opf:role="author" opf:file-as="Doe, Jane">Jane Doe</dc:creator>
+                <dc:subject>Test subject 1</dc:subject>
+                <dc:subject>Test subject 2</dc:subject>
+                <dc:description>Test description</dc:description>
+                <dc:publisher>Test publisher 1</dc:publisher>
+                <dc:publisher>Test publisher 2</dc:publisher>
+                <dc:contributor id="contributor-1" opf:role="editor" opf:file-as="Editor, John">John Editor</dc:contributor>
+                <dc:contributor id="contributor-2" opf:role="editor" opf:file-as="Editor, Jane">Jane Editor</dc:contributor>
+                <dc:date opf:event="creation">2021-12-31T23:59:59.123456Z</dc:date>
+                <dc:date opf:event="publication">2022-01-23</dc:date>
+                <dc:type>dictionary</dc:type>
+                <dc:type>preview</dc:type>
+                <dc:format>format-1</dc:format>
+                <dc:format>format-2</dc:format>
+                <dc:identifier id="identifier-1" opf:scheme="URI">https://example.com/books/123</dc:identifier>
+                <dc:identifier id="identifier-2" opf:scheme="ISBN">9781234567890</dc:identifier>
+                <dc:source>https://example.com/books/123/content-1.html</dc:source>
+                <dc:source>https://example.com/books/123/content-2.html</dc:source>
+                <dc:language>en</dc:language>
+                <dc:language>is</dc:language>
+                <dc:relation>https://example.com/books/123/related-1.html</dc:relation>
+                <dc:relation>https://example.com/books/123/related-2.html</dc:relation>
+                <dc:coverage>New York</dc:coverage>
+                <dc:coverage>1700-1850</dc:coverage>
+                <dc:rights>Public domain in the USA</dc:rights>
+                <dc:rights>All rights reserved</dc:rights>
+                <link id="link-1" rel="record" href="front.html#meta-json" media-type="application/xhtml+xml" />
+                <link id="link-2" rel="record onix-record" href="https://example.com/onix/123" media-type="application/xml" properties="onix" />
+                <link id="link-3" rel="record" href="book.atom" media-type="application/atom+xml;type=entry;profile=opds-catalog" />
+                <link id="link-4" rel="voicing" refines="#title" href="title.mp3" media-type="audio/mpeg" />
+                <meta name="cover" content="cover-image" />
+                <meta id="meta-1" property="rendition:orientation">landscape</meta>
+                <meta id="meta-2" property="identifier-type" refines="#identifier-2" scheme="onix:codelist5">123</meta>
+                <meta id="meta-3" property="alternate-script" refines="#creator-1">Brynjólfur Sveinsson</meta>
+              </metadata>
+              <manifest>
+                <item id="item-front" href="front.html" media-type="application/xhtml+xml" />
+                <item id="cover" href="cover.html" media-type="application/xhtml+xml"/>
+                <item id="cover-image" href="cover.jpg" media-type="image/jpeg" properties="cover-image" />
+                <item id="item-css" href="styles.css" media-type="text/css" />
+                <item id="item-font" href="font.ttf" media-type="application/x-font-truetype" />
+                <item id="item-1" href="chapter1.html" media-type="application/xhtml+xml" media-overlay="item-1-audio" />
+                <item id="item-1-audio" href="chapter1-audio.smil" media-type="application/smil+xml" />
+                <item id="item-2" href="chapter2.html" media-type="application/xhtml+xml" />
+                <item id="item-2-fall" href="chapter2.xml" media-type="text/example+xml"
+                      required-namespace="http://example.com/ns/example/" required-modules="ruby, server-side-image-map"
+                      fallback="item-2" fallback-style="item-css" />
+                <item id="item-3" href="chapter3.html" media-type="application/xhtml+xml" />
+                <item id="item-3-fall" href="chapter3.xml" media-type="application/z3998-auth+xml" fallback="item-3" />
+                <item id="item-3-remote-audio" href="http://example.com/audio/123/chapter3.mp4" media-type="audio/mp4" />
+                <item id="item-image" href="image.jpg" media-type="image/jpeg" />
+                <item id="item-title-audio" href="title.mp3" media-type="audio/mpeg" />
+                <item id="item-atom" href="book.atom" media-type="application/atom+xml" />
+                <item id="item-toc" href="toc.html" media-type="application/xhtml+xml" properties="nav" />
+                <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+              </manifest>
+              <spine id="spine" page-progression-direction="ltr" toc="ncx">
+                <itemref id="itemref-1" idref="item-front" linear="yes" />
+                <itemref id="itemref-2" idref="item-toc" linear="no" />
+                <itemref id="itemref-3" idref="item-1" linear="yes" />
+                <itemref id="itemref-4" idref="item-2" linear="yes" properties="page-spread-left" />
+                <itemref id="itemref-5" idref="item-3" linear="yes" properties="page-spread-right" />
+              </spine>
+              <guide>
+                <reference type="toc" title="Contents" href="toc.html" />
+              </guide>
+            </package>
+            """;
+
         private static EpubMetadata EmptyMetadata =>
             new()
             {
@@ -97,6 +173,384 @@ namespace VersOne.Epub.Test.Unit.Readers
                 Spine = new EpubSpine()
             };
 
+        private static EpubPackage FullPackage
+        {
+            get
+            {
+                EpubPackage result = new()
+                {
+                    EpubVersion = EpubVersion.EPUB_3,
+                    Metadata = new EpubMetadata()
+                    {
+                        Titles = new List<string>()
+                        {
+                            "Test title 1",
+                            "Test title 2"
+                        },
+                        Creators = new List<EpubMetadataCreator>()
+                        {
+                            new EpubMetadataCreator()
+                            {
+                                Id = "creator-1",
+                                Role = "author",
+                                FileAs = "Doe, John",
+                                Creator = "John Doe"
+                            },
+                            new EpubMetadataCreator()
+                            {
+                                Id = "creator-2",
+                                Role = "author",
+                                FileAs = "Doe, Jane",
+                                Creator = "Jane Doe"
+                            }
+                        },
+                        Subjects = new List<string>()
+                        {
+                            "Test subject 1",
+                            "Test subject 2"
+                        },
+                        Description = "Test description",
+                        Publishers = new List<string>()
+                        {
+                            "Test publisher 1",
+                            "Test publisher 2"
+                        },
+                        Contributors = new List<EpubMetadataContributor>()
+                        {
+                            new EpubMetadataContributor()
+                            {
+                                Id = "contributor-1",
+                                Role = "editor",
+                                FileAs = "Editor, John",
+                                Contributor = "John Editor"
+                            },
+                            new EpubMetadataContributor()
+                            {
+                                Id = "contributor-2",
+                                Role = "editor",
+                                FileAs = "Editor, Jane",
+                                Contributor = "Jane Editor"
+                            }
+                        },
+                        Dates = new List<EpubMetadataDate>()
+                        {
+                            new EpubMetadataDate()
+                            {
+                                Event = "creation",
+                                Date = "2021-12-31T23:59:59.123456Z"
+                            },
+                            new EpubMetadataDate()
+                            {
+                                Event = "publication",
+                                Date = "2022-01-23"
+                            }
+                        },
+                        Types = new List<string>()
+                        {
+                            "dictionary",
+                            "preview"
+                        },
+                        Formats = new List<string>()
+                        {
+                            "format-1",
+                            "format-2"
+                        },
+                        Identifiers = new List<EpubMetadataIdentifier>()
+                        {
+                            new EpubMetadataIdentifier()
+                            {
+                                Id = "identifier-1",
+                                Scheme = "URI",
+                                Identifier = "https://example.com/books/123"
+                            },
+                            new EpubMetadataIdentifier()
+                            {
+                                Id = "identifier-2",
+                                Scheme = "ISBN",
+                                Identifier = "9781234567890"
+                            }
+                        },
+                        Sources = new List<string>()
+                        {
+                            "https://example.com/books/123/content-1.html",
+                            "https://example.com/books/123/content-2.html"
+                        },
+                        Languages = new List<string>()
+                        {
+                            "en",
+                            "is"
+                        },
+                        Relations = new List<string>()
+                        {
+                            "https://example.com/books/123/related-1.html",
+                            "https://example.com/books/123/related-2.html"
+                        },
+                        Coverages = new List<string>()
+                        {
+                            "New York",
+                            "1700-1850"
+                        },
+                        Rights = new List<string>()
+                        {
+                            "Public domain in the USA",
+                            "All rights reserved"
+                        },
+                        Links = new List<EpubMetadataLink>()
+                        {
+                            new EpubMetadataLink()
+                            {
+                                Id = "link-1",
+                                Relationships = new List<EpubMetadataLinkRelationship>()
+                                {
+                                    EpubMetadataLinkRelationship.RECORD
+                                },
+                                Href = "front.html#meta-json",
+                                MediaType = "application/xhtml+xml"
+                            },
+                            new EpubMetadataLink()
+                            {
+                                Id = "link-2",
+                                Relationships = new List<EpubMetadataLinkRelationship>()
+                                {
+                                    EpubMetadataLinkRelationship.RECORD,
+                                    EpubMetadataLinkRelationship.ONIX_RECORD
+                                },
+                                Href = "https://example.com/onix/123",
+                                MediaType = "application/xml",
+                                Properties = new List<EpubMetadataLinkProperty>()
+                                {
+                                    EpubMetadataLinkProperty.ONIX
+                                }
+                            },
+                            new EpubMetadataLink()
+                            {
+                                Id = "link-3",
+                                Relationships = new List<EpubMetadataLinkRelationship>()
+                                {
+                                    EpubMetadataLinkRelationship.RECORD
+                                },
+                                Href = "book.atom",
+                                MediaType = "application/atom+xml;type=entry;profile=opds-catalog"
+                            },
+                            new EpubMetadataLink()
+                            {
+                                Id = "link-4",
+                                Relationships = new List<EpubMetadataLinkRelationship>()
+                                {
+                                    EpubMetadataLinkRelationship.VOICING
+                                },
+                                Refines = "#title",
+                                Href = "title.mp3",
+                                MediaType = "audio/mpeg"
+                            }
+                        },
+                        MetaItems = new List<EpubMetadataMeta>()
+                        {
+                            new EpubMetadataMeta()
+                            {
+                                Name = "cover",
+                                Content = "cover-image"
+                            },
+                            new EpubMetadataMeta()
+                            {
+                                Id = "meta-1",
+                                Property = "rendition:orientation",
+                                Content = "landscape"
+                            },
+                            new EpubMetadataMeta()
+                            {
+                                Id = "meta-2",
+                                Property = "identifier-type",
+                                Refines = "#identifier-2",
+                                Scheme = "onix:codelist5",
+                                Content = "123"
+                            },
+                            new EpubMetadataMeta()
+                            {
+                                Id = "meta-3",
+                                Property = "alternate-script",
+                                Refines = "#creator-1",
+                                Content = "Brynjólfur Sveinsson"
+                            }
+                        }
+                    },
+                    Manifest = new EpubManifest()
+                    {
+                        new EpubManifestItem()
+                        {
+                            Id = "item-front",
+                            Href = "front.html",
+                            MediaType = "application/xhtml+xml"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "cover",
+                            Href = "cover.html",
+                            MediaType = "application/xhtml+xml"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "cover-image",
+                            Href = "cover.jpg",
+                            MediaType = "image/jpeg",
+                            Properties = new List<EpubManifestProperty>()
+                            {
+                                EpubManifestProperty.COVER_IMAGE
+                            }
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-css",
+                            Href = "styles.css",
+                            MediaType = "text/css"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-font",
+                            Href = "font.ttf",
+                            MediaType = "application/x-font-truetype"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-1",
+                            Href = "chapter1.html",
+                            MediaType = "application/xhtml+xml",
+                            MediaOverlay = "item-1-audio"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-1-audio",
+                            Href = "chapter1-audio.smil",
+                            MediaType = "application/smil+xml"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-2",
+                            Href = "chapter2.html",
+                            MediaType = "application/xhtml+xml"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-2-fall",
+                            Href = "chapter2.xml",
+                            MediaType = "text/example+xml",
+                            RequiredNamespace = "http://example.com/ns/example/",
+                            RequiredModules = "ruby, server-side-image-map",
+                            Fallback = "item-2",
+                            FallbackStyle = "item-css"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-3",
+                            Href = "chapter3.html",
+                            MediaType = "application/xhtml+xml"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-3-fall",
+                            Href = "chapter3.xml",
+                            MediaType = "application/z3998-auth+xml",
+                            Fallback = "item-3"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-3-remote-audio",
+                            Href = "http://example.com/audio/123/chapter3.mp4",
+                            MediaType = "audio/mp4"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-image",
+                            Href = "image.jpg",
+                            MediaType = "image/jpeg"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-title-audio",
+                            Href = "title.mp3",
+                            MediaType = "audio/mpeg"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-atom",
+                            Href = "book.atom",
+                            MediaType = "application/atom+xml"
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "item-toc",
+                            Href = "toc.html",
+                            MediaType = "application/xhtml+xml",
+                            Properties = new List<EpubManifestProperty>()
+                            {
+                                EpubManifestProperty.NAV
+                            }
+                        },
+                        new EpubManifestItem()
+                        {
+                            Id = "ncx",
+                            Href = "toc.ncx",
+                            MediaType = "application/x-dtbncx+xml"
+                        }
+                    },
+                    Spine = new EpubSpine()
+                    {
+                        new EpubSpineItemRef()
+                        {
+                            Id = "itemref-1",
+                            IdRef = "item-front",
+                            IsLinear = true
+                        },
+                        new EpubSpineItemRef()
+                        {
+                            Id = "itemref-2",
+                            IdRef = "item-toc",
+                            IsLinear = false
+                        },
+                        new EpubSpineItemRef()
+                        {
+                            Id = "itemref-3",
+                            IdRef = "item-1",
+                            IsLinear = true
+                        },
+                        new EpubSpineItemRef()
+                        {
+                            Id = "itemref-4",
+                            IdRef = "item-2",
+                            IsLinear = true,
+                            Properties = new List<EpubSpineProperty>()
+                            {
+                                EpubSpineProperty.PAGE_SPREAD_LEFT
+                            }
+                        },
+                        new EpubSpineItemRef()
+                        {
+                            Id = "itemref-5",
+                            IdRef = "item-3",
+                            IsLinear = true,
+                            Properties = new List<EpubSpineProperty>()
+                            {
+                                EpubSpineProperty.PAGE_SPREAD_RIGHT
+                            }
+                        }
+                    },
+                    Guide = new EpubGuide()
+                    {
+                        new EpubGuideReference()
+                        {
+                            Type = "toc",
+                            Title = "Contents",
+                            Href = "toc.html"
+                        }
+                    }
+                };
+                result.Spine.Id = "spine";
+                result.Spine.PageProgressionDirection = EpubPageProgressionDirection.LEFT_TO_RIGHT;
+                result.Spine.Toc = "ncx";
+                return result;
+            }
+        }
+
         public static IEnumerable<object[]> ReadMinimalPackageAsyncTestData
         {
             get
@@ -107,9 +561,28 @@ namespace VersOne.Epub.Test.Unit.Readers
             }
         }
 
+        public static IEnumerable<object[]> ReadFullPackageAsyncTestData
+        {
+            get
+            {
+                yield return new object[] { FULL_OPF_FILE, FullPackage };
+            }
+        }
+
         [Theory(DisplayName = "Reading a minimal OPF package should succeed")]
         [MemberData(nameof(ReadMinimalPackageAsyncTestData))]
         public async void ReadMinimalPackageAsyncTest(string opfFileContent, EpubPackage expectedEpubPackage)
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.AddEntry(CONTAINER_FILE_PATH, CONTAINER_FILE);
+            testZipFile.AddEntry(OPF_FILE_PATH, opfFileContent);
+            EpubPackage actualEpubPackage = await PackageReader.ReadPackageAsync(testZipFile, OPF_FILE_PATH, new EpubReaderOptions());
+            CompareEpubPackages(expectedEpubPackage, actualEpubPackage);
+        }
+
+        [Theory(DisplayName = "Reading a full OPF package should succeed")]
+        [MemberData(nameof(ReadFullPackageAsyncTestData))]
+        public async void ReadFullPackageAsyncTest(string opfFileContent, EpubPackage expectedEpubPackage)
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(CONTAINER_FILE_PATH, CONTAINER_FILE);

--- a/Source/VersOne.Epub/Readers/PackageReader.cs
+++ b/Source/VersOne.Epub/Readers/PackageReader.cs
@@ -211,7 +211,7 @@ namespace VersOne.Epub.Internal
         private static EpubMetadataDate ReadMetadataDate(XElement metadataDateNode)
         {
             EpubMetadataDate result = new EpubMetadataDate();
-            XAttribute eventAttribute = metadataDateNode.Attribute(metadataDateNode.Name.Namespace + "event");
+            XAttribute eventAttribute = metadataDateNode.Attribute(metadataDateNode.Parent.Name.Namespace + "event");
             if (eventAttribute != null)
             {
                 result.Event = eventAttribute.Value;
@@ -231,7 +231,7 @@ namespace VersOne.Epub.Internal
                     case "id":
                         result.Id = attributeValue;
                         break;
-                    case "opf:scheme":
+                    case "scheme":
                         result.Scheme = attributeValue;
                         break;
                 }


### PR DESCRIPTION
# Fix for OPF `event` and OPF `scheme` attributes parsing

This is:
- [x] a bug fix
- [ ] an enhancement

Related issue: #53

## Description

This change fixes the issue where `metadata/date/event` and `metadata/identifier/scheme` XML attributes in the OPF package were not parsed properly.

## Testing steps

1. Open a EPUB 2 book which has these metadata properties and attributes set.
2. Check the `book.Schema.Package.Metadata.Dates[0].Event` and `book.Schema.Package.Metadata.Identifiers[0].Scheme` properties and make sure they are not `null`.