### PR TITLE
Fix for EPUB 2 NCX navigation list parsing

### DIFF
--- a/Source/VersOne.Epub.Test/Unit/Mocks/Test4GbZipFileEntry.cs
+++ b/Source/VersOne.Epub.Test/Unit/Mocks/Test4GbZipFileEntry.cs
@@ -1,0 +1,14 @@
+﻿using VersOne.Epub.Environment;
+
+namespace VersOne.Epub.Test.Unit.Mocks
+{
+    internal class Test4GbZipFileEntry : IZipFileEntry
+    {
+        public long Length => (long)4 * 1024 * 1024 * 1024;
+
+        public Stream Open()
+        {
+            return new MemoryStream(); 
+        }
+    }
+}

--- a/Source/VersOne.Epub.Test/Unit/Mocks/TestZipFile.cs
+++ b/Source/VersOne.Epub.Test/Unit/Mocks/TestZipFile.cs
@@ -4,11 +4,16 @@ namespace VersOne.Epub.Test.Unit.Mocks
 {
     internal class TestZipFile : IZipFile
     {
-        readonly Dictionary<string, TestZipFileEntry> entries;
+        readonly Dictionary<string, IZipFileEntry> entries;
 
         public TestZipFile()
         {
-            entries = new Dictionary<string, TestZipFileEntry>();
+            entries = new Dictionary<string, IZipFileEntry>();
+        }
+
+        public void AddEntry(string entryName, IZipFileEntry entry)
+        {
+            entries.Add(entryName, entry);
         }
 
         public void AddEntry(string entryName, string entryContent)
@@ -18,7 +23,7 @@ namespace VersOne.Epub.Test.Unit.Mocks
 
         public IZipFileEntry GetEntry(string entryName)
         {
-            return entries.TryGetValue(entryName, out TestZipFileEntry value) ? value : null;
+            return entries.TryGetValue(entryName, out IZipFileEntry value) ? value : null;
         }
 
         public void Dispose()

--- a/Source/VersOne.Epub.Test/Unit/Readers/Epub2NcxReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/Epub2NcxReaderTests.cs
@@ -1,0 +1,991 @@
+﻿using VersOne.Epub.Internal;
+using VersOne.Epub.Options;
+using VersOne.Epub.Schema;
+using VersOne.Epub.Test.Unit.Mocks;
+using VersOne.Epub.Test.Unit.TestUtils;
+
+namespace VersOne.Epub.Test.Unit.Readers
+{
+    public class Epub2NcxReaderTests
+    {
+        private const string CONTENT_DIRECTORY_PATH = "Content";
+        private const string NCX_FILE_NAME = "toc.ncx";
+        private const string NCX_FILE_PATH_IN_EPUB_ARCHIVE = $"{CONTENT_DIRECTORY_PATH}/{NCX_FILE_NAME}";
+        private const string TOC_ID = "ncx";
+
+        private const string MINIMAL_NCX_FILE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap />
+            </ncx>
+            """;
+
+        private const string FULL_NCX_FILE = """
+            <?xml version='1.0' encoding='UTF-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+              <head>
+                <meta name="dtb:uid" content="9781234567890" />
+                <meta name="dtb:depth" content="1" />
+                <meta name="dtb:generator" content="EpubWriter" />
+                <meta name="dtb:totalPageCount" content="0" />
+                <meta name="dtb:maxPageNumber" content="0" />
+                <meta name="location" content="https://example.com/books/123/ncx" scheme="URI" />
+              </head>
+              <docTitle>
+                <text>Test title</text>
+              </docTitle>
+              <docAuthor>
+                <text>John Doe</text>
+              </docAuthor>
+              <docAuthor>
+                <text>Jane Doe</text>
+              </docAuthor>
+              <navMap>
+                <navPoint id="navpoint-1" class="chapter" playOrder="1">
+                  <navLabel>
+                    <text>Chapter 1</text>
+                  </navLabel>
+                  <navLabel>
+                    <text>Capitolo 1</text>
+                  </navLabel>
+                  <content id="content-1" src="chapter1.html" />
+                  <navPoint id="navpoint-1-1" class="section">
+                    <navLabel>
+                      <text>Chapter 1.1</text>
+                    </navLabel>
+                    <content id="content-1-1" src="chapter1.html#section-1"/>
+                  </navPoint>
+                  <navPoint id="navpoint-1-2" class="section">
+                    <navLabel>
+                      <text>Chapter 1.2</text>
+                    </navLabel>
+                    <content id="content-1-2" src="chapter1.html#section-2"/>
+                  </navPoint>
+                </navPoint>
+                <navPoint id="navpoint-2">
+                  <navLabel>
+                    <text>Chapter 2</text>
+                  </navLabel>
+                  <content src="chapter2.html" />
+                </navPoint>
+              </navMap>
+              <pageList>
+                <pageTarget id="page-target-1" value="1" type="front" class="front-matter" playorder="1">
+                  <navLabel>
+                    <text>1</text>
+                  </navLabel>
+                  <navLabel>
+                    <text>I</text>
+                  </navLabel>
+                  <content src="front.html"/>
+                </pageTarget>
+                <pageTarget type="normal">
+                  <navLabel>
+                    <text>2</text>
+                  </navLabel>
+                  <content id="content-2" src="chapter1.html#page-2"/>
+                </pageTarget>        
+              </pageList>
+              <navList id="navlist-1" class="navlist-illustrations">
+                <navLabel>
+                  <text>List of Illustrations</text>
+                </navLabel>
+                <navLabel>
+                  <text>Illustrazioni</text>
+                </navLabel>
+                <navTarget id="navtarget-1" value="Illustration 1" class="illustration" playorder="1">
+                  <navLabel>
+                    <text>Illustration 1</text>
+                  </navLabel>
+                  <navLabel>
+                    <text>Illustrazione 1</text>
+                  </navLabel>
+                  <content src="chapter1.html#illustration-1"/>
+                </navTarget>
+              </navList>
+              <navList id="navlist-2" class="navlist-tables">
+                <navLabel>
+                  <text>List of Tables</text>
+                </navLabel>
+                <navTarget id="navtarget-2">
+                  <navLabel>
+                    <text>Tables</text>
+                  </navLabel>
+                </navTarget>
+                <navTarget id="navtarget-3">
+                  <navLabel>
+                    <text>Table 1</text>
+                  </navLabel>
+                  <content src="chapter1.html#table-1"/>
+                </navTarget>
+              </navList>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NCX_ELEMENT = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <test />
+            """;
+
+        private const string NCX_FILE_WITHOUT_HEAD_ELEMENT = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <test />
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_DOCTITLE_ELEMENT = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <test />
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVMAP_ELEMENT = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <test />
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_META_NAME_ATTRIBUTE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head>
+                <meta content="9781234567890" />
+              </head>
+              <docTitle />
+              <navMap />
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_META_CONTENT_ATTRIBUTE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head>
+                <meta name="dtb:uid" />
+              </head>
+              <docTitle />
+              <navMap />
+            </ncx>
+            """;
+
+        private const string MINIMAL_NCX_FILE_WITH_UNKNOWN_ELEMENT_IN_DOCTITLE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle>
+                <test />
+              </docTitle>
+              <navMap />
+            </ncx>
+            """;
+
+        private const string MINIMAL_NCX_FILE_WITH_UNKNOWN_ELEMENT_IN_DOCAUTHOR = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <docAuthor>
+                <test />
+              </docAuthor>
+              <navMap />
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVPOINT_ID_ATTRIBUTE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap>
+                <navPoint>
+                  <navLabel>
+                    <text>Chapter 1</text>
+                  </navLabel>
+                  <content src="chapter1.html" />
+                </navPoint>
+              </navMap>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVPOINT_NAVLABEL_ELEMENTS = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap>
+                <navPoint id="navpoint-1">
+                  <content src="chapter1.html" />
+                </navPoint>
+              </navMap>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVPOINT_CONTENT_ELEMENT = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap>
+                <navPoint id="navpoint-1">
+                  <navLabel>
+                    <text>Chapter 1</text>
+                  </navLabel>
+                </navPoint>
+              </navMap>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVLABEL_TEXT_ELEMENT = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap>
+                <navPoint id="navpoint-1">
+                  <navLabel />
+                  <content src="chapter1.html" />
+                </navPoint>
+              </navMap>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_CONTENT_SRC_ATTRIBUTE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap>
+                <navPoint id="navpoint-1">
+                  <navLabel>
+                    <text>Chapter 1</text>
+                  </navLabel>
+                  <content />
+                </navPoint>
+              </navMap>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_PAGETARGET_TYPE_ATTRIBUTE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap />
+              <pageList>
+                <pageTarget>
+                  <navLabel>
+                    <text>1</text>
+                  </navLabel>
+                  <content src="chapter1.html#page-1"/>
+                </pageTarget>
+              </pageList>
+            </ncx>
+            """;
+
+        private const string MINIMAL_NCX_FILE_WITH_UNKNOWN_PAGETARGET_TYPE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap />
+              <pageList>
+                <pageTarget type="test">
+                  <navLabel>
+                    <text>1</text>
+                  </navLabel>
+                  <content src="chapter1.html#page-1"/>
+                </pageTarget>
+              </pageList>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_PAGETARGET_NAVLABEL_ELEMENTS = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap />
+              <pageList>
+                <pageTarget type="normal">
+                  <content src="chapter1.html#page-1"/>
+                </pageTarget>
+              </pageList>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVLIST_NAVLABEL_ELEMENTS = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap />
+              <navList id="navlist-1">
+                <navTarget id="navtarget-1">
+                  <navLabel>
+                    <text>Tables</text>
+                  </navLabel>
+                </navTarget>
+              </navList>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVTARGET_ID_ATTRIBUTE = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap />
+              <navList id="navlist-1">
+                <navLabel>
+                  <text>List of Tables</text>
+                </navLabel>
+                <navTarget>
+                  <navLabel>
+                    <text>Tables</text>
+                  </navLabel>
+                </navTarget>
+              </navList>
+            </ncx>
+            """;
+
+        private const string NCX_FILE_WITHOUT_NAVTARGET_NAVLABEL_ELEMENTS = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+              <head />
+              <docTitle />
+              <navMap />
+              <navList id="navlist-1">
+                <navLabel>
+                  <text>List of Tables</text>
+                </navLabel>
+                <navTarget id="navtarget-1" />
+              </navList>
+            </ncx>
+            """;
+
+        private EpubPackage MinimalEpubPackageWithNcx =>
+            new()
+            {
+                Manifest = new EpubManifest()
+                {
+                    new EpubManifestItem()
+                    {
+                        Id = TOC_ID,
+                        Href = NCX_FILE_NAME,
+                        MediaType = "application/x-dtbncx+xml"
+                    }
+                },
+                Spine = new EpubSpine()
+                {
+                    Toc = TOC_ID
+                }
+            };
+
+        private Epub2Ncx MinimalEpub2Ncx =>
+            new()
+            {
+                Head = new Epub2NcxHead(),
+                DocTitle = null,
+                DocAuthors = new List<string>(),
+                NavMap = new Epub2NcxNavigationMap(),
+                PageList = null,
+                NavLists = new List<Epub2NcxNavigationList>()
+            };
+
+        private Epub2Ncx FullEpub2Ncx =>
+            new()
+            {
+                Head = new Epub2NcxHead()
+                {
+                    new Epub2NcxHeadMeta()
+                    {
+                        Name = "dtb:uid",
+                        Content = "9781234567890"
+                    },
+                    new Epub2NcxHeadMeta()
+                    {
+                        Name = "dtb:depth",
+                        Content = "1"
+                    },
+                    new Epub2NcxHeadMeta()
+                    {
+                        Name = "dtb:generator",
+                        Content = "EpubWriter"
+                    },
+                    new Epub2NcxHeadMeta()
+                    {
+                        Name = "dtb:totalPageCount",
+                        Content = "0"
+                    },
+                    new Epub2NcxHeadMeta()
+                    {
+                        Name = "dtb:maxPageNumber",
+                        Content = "0"
+                    },
+                    new Epub2NcxHeadMeta()
+                    {
+                        Name = "location",
+                        Content = "https://example.com/books/123/ncx",
+                        Scheme = "URI"
+                    }
+                },
+                DocTitle = "Test title",
+                DocAuthors = new List<string>()
+                {
+                    "John Doe",
+                    "Jane Doe"
+                },
+                NavMap = new Epub2NcxNavigationMap()
+                {
+                    new Epub2NcxNavigationPoint()
+                    {
+                        Id = "navpoint-1",
+                        Class = "chapter",
+                        PlayOrder = "1",
+                        NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                        {
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "Chapter 1"
+                            },
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "Capitolo 1"
+                            }
+                        },
+                        Content = new Epub2NcxContent()
+                        {
+                            Id = "content-1",
+                            Source = "chapter1.html"
+                        },
+                        ChildNavigationPoints = new List<Epub2NcxNavigationPoint>()
+                        {
+                            new Epub2NcxNavigationPoint()
+                            {
+                                Id = "navpoint-1-1",
+                                Class = "section",
+                                NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                                {
+                                    new Epub2NcxNavigationLabel()
+                                    {
+                                        Text = "Chapter 1.1"
+                                    }
+                                },
+                                Content = new Epub2NcxContent()
+                                {
+                                    Id = "content-1-1",
+                                    Source = "chapter1.html#section-1"
+                                },
+                                ChildNavigationPoints = new List<Epub2NcxNavigationPoint>()
+                            },
+                            new Epub2NcxNavigationPoint()
+                            {
+                                Id = "navpoint-1-2",
+                                Class = "section",
+                                NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                                {
+                                    new Epub2NcxNavigationLabel()
+                                    {
+                                        Text = "Chapter 1.2"
+                                    }
+                                },
+                                Content = new Epub2NcxContent()
+                                {
+                                    Id = "content-1-2",
+                                    Source = "chapter1.html#section-2"
+                                },
+                                ChildNavigationPoints = new List<Epub2NcxNavigationPoint>()
+                            }
+                        }
+                    },
+                    new Epub2NcxNavigationPoint()
+                    {
+                        Id = "navpoint-2",
+                        NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                        {
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "Chapter 2"
+                            }
+                        },
+                        Content = new Epub2NcxContent()
+                        {
+                            Source = "chapter2.html"
+                        },
+                        ChildNavigationPoints = new List<Epub2NcxNavigationPoint>()
+                    }
+                },
+                PageList = new Epub2NcxPageList()
+                {
+                    new Epub2NcxPageTarget()
+                    {
+                        Id = "page-target-1",
+                        Value = "1",
+                        Type = Epub2NcxPageTargetType.FRONT,
+                        Class = "front-matter",
+                        PlayOrder = "1",
+                        NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                        {
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "1"
+                            },
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "I"
+                            }
+                        },
+                        Content = new Epub2NcxContent()
+                        {
+                            Source = "front.html"
+                        }
+                    },
+                    new Epub2NcxPageTarget()
+                    {
+                        Type = Epub2NcxPageTargetType.NORMAL,
+                        NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                        {
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "2"
+                            }
+                        },
+                        Content = new Epub2NcxContent
+                        {
+                            Id = "content-2",
+                            Source = "chapter1.html#page-2"
+                        }
+                    }
+                },
+                NavLists = new List<Epub2NcxNavigationList>()
+                {
+                    new Epub2NcxNavigationList()
+                    {
+                        Id = "navlist-1",
+                        Class = "navlist-illustrations",
+                        NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                        {
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "List of Illustrations"
+                            },
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "Illustrazioni"
+                            }
+                        },
+                        NavigationTargets = new List<Epub2NcxNavigationTarget>()
+                        {
+                            new Epub2NcxNavigationTarget()
+                            {
+                                Id = "navtarget-1",
+                                Value = "Illustration 1",
+                                Class = "illustration",
+                                PlayOrder = "1",
+                                NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                                {
+                                    new Epub2NcxNavigationLabel()
+                                    {
+                                        Text = "Illustration 1"
+                                    },
+                                    new Epub2NcxNavigationLabel()
+                                    {
+                                        Text = "Illustrazione 1"
+                                    }
+                                },
+                                Content = new Epub2NcxContent()
+                                {
+                                    Source = "chapter1.html#illustration-1"
+                                }
+                            }
+                        }
+                    },
+                    new Epub2NcxNavigationList()
+                    {
+                        Id = "navlist-2",
+                        Class = "navlist-tables",
+                        NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                        {
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "List of Tables"
+                            }
+                        },
+                        NavigationTargets = new List<Epub2NcxNavigationTarget>()
+                        {
+                            new Epub2NcxNavigationTarget()
+                            {
+                                Id = "navtarget-2",
+                                NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                                {
+                                    new Epub2NcxNavigationLabel()
+                                    {
+                                        Text = "Tables"
+                                    }
+                                }
+                            },
+                            new Epub2NcxNavigationTarget()
+                            {
+                                Id = "navtarget-3",
+                                NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                                {
+                                    new Epub2NcxNavigationLabel()
+                                    {
+                                        Text = "Table 1"
+                                    }
+                                },
+                                Content = new Epub2NcxContent()
+                                {
+                                    Source = "chapter1.html#table-1"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+        private Epub2Ncx MinimalEpub2NcxWithUnknownPageTargetType =>
+            new()
+            {
+                Head = new Epub2NcxHead(),
+                DocTitle = null,
+                DocAuthors = new List<string>(),
+                NavMap = new Epub2NcxNavigationMap(),
+                PageList = new Epub2NcxPageList()
+                {
+                    new Epub2NcxPageTarget()
+                    {
+                        Type = Epub2NcxPageTargetType.UNKNOWN,
+                        NavigationLabels = new List<Epub2NcxNavigationLabel>()
+                        {
+                            new Epub2NcxNavigationLabel()
+                            {
+                                Text = "1"
+                            }
+                        },
+                        Content = new Epub2NcxContent()
+                        {
+                            Source = "chapter1.html#page-1"
+                        }
+                    }
+                },
+                NavLists = new List<Epub2NcxNavigationList>()
+            };
+
+
+        [Fact(DisplayName = "Reading a minimal NCX file should succeed")]
+        public async void ReadEpub2NcxAsyncWithMinimalNcxFileTest()
+        {
+            await TestSuccessfulReadOperation(MINIMAL_NCX_FILE, MinimalEpub2Ncx);
+        }
+
+        [Fact(DisplayName = "Reading a full NCX file should succeed")]
+        public async void ReadEpub2NcxAsyncWithFullNcxFileTest()
+        {
+            await TestSuccessfulReadOperation(FULL_NCX_FILE, FullEpub2Ncx);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should return null if EpubPackage is missing spine TOC")]
+        public async void ReadEpub2NcxAsyncWithoutTocTest()
+        {
+            TestZipFile testZipFile = new();
+            EpubPackage epubPackage = new()
+            {
+                Spine = new EpubSpine()
+            };
+            Epub2Ncx epub2Ncx = await Epub2NcxReader.ReadEpub2NcxAsync(testZipFile, CONTENT_DIRECTORY_PATH, epubPackage, new EpubReaderOptions());
+            Assert.Null(epub2Ncx);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if EpubPackage is missing the manifest item referenced by the spine TOC")]
+        public async void ReadEpub2NcxAsyncWithoutTocManifestItemTest()
+        {
+            TestZipFile testZipFile = new();
+            EpubPackage epubPackage = new()
+            {
+                Manifest = new EpubManifest(),
+                Spine = new EpubSpine()
+                {
+                    Toc = TOC_ID
+                }
+            };
+            await Assert.ThrowsAsync<Epub2NcxException>(() => Epub2NcxReader.ReadEpub2NcxAsync(testZipFile, CONTENT_DIRECTORY_PATH, epubPackage, new EpubReaderOptions()));
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if EPUB file is missing the NCX file specified in the EpubPackage")]
+        public async void ReadEpub2NcxAsyncWithoutNcxFileTest()
+        {
+            TestZipFile testZipFile = new();
+            await Assert.ThrowsAsync<Epub2NcxException>(() =>
+                Epub2NcxReader.ReadEpub2NcxAsync(testZipFile, CONTENT_DIRECTORY_PATH, MinimalEpubPackageWithNcx, new EpubReaderOptions()));
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file is larger than 2 GB")]
+        public async void ReadEpub2NcxAsyncWithLargeNcxFileTest()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.AddEntry(NCX_FILE_PATH_IN_EPUB_ARCHIVE, new Test4GbZipFileEntry());
+            await Assert.ThrowsAsync<Epub2NcxException>(() =>
+                Epub2NcxReader.ReadEpub2NcxAsync(testZipFile, CONTENT_DIRECTORY_PATH, MinimalEpubPackageWithNcx, new EpubReaderOptions()));
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'ncx' XML element")]
+        public async void ReadEpub2NcxAsyncWithoutNcxElementTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NCX_ELEMENT);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'head' XML element")]
+        public async void ReadEpub2NcxAsyncWithoutHeadElementTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_HEAD_ELEMENT);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'docTitle' XML element")]
+        public async void ReadEpub2NcxAsyncWithoutDocTitleElementTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_DOCTITLE_ELEMENT);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'navMap' XML element")]
+        public async void ReadEpub2NcxAsyncWithoutNavMapElementTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVMAP_ELEMENT);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'meta' XML element has no 'name' attribute")]
+        public async void ReadEpub2NcxAsyncWithoutMetaNameTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_META_NAME_ATTRIBUTE);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'meta' XML element has no 'content' attribute")]
+        public async void ReadEpub2NcxAsyncWithoutMetaContentTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_META_CONTENT_ATTRIBUTE);
+        }
+
+        [Fact(DisplayName = "Reading an NCX file with unknown XML element in the 'docTitle' element should succeed")]
+        public async void ReadEpub2NcxAsyncWithUnknownElementInDocTitleTest()
+        {
+            await TestSuccessfulReadOperation(MINIMAL_NCX_FILE_WITH_UNKNOWN_ELEMENT_IN_DOCTITLE, MinimalEpub2Ncx);
+        }
+
+        [Fact(DisplayName = "Reading an NCX file with unknown XML element in the 'docAuthor' element should succeed")]
+        public async void ReadEpub2NcxAsyncWithUnknownElementInDocAuthorTest()
+        {
+            await TestSuccessfulReadOperation(MINIMAL_NCX_FILE_WITH_UNKNOWN_ELEMENT_IN_DOCAUTHOR, MinimalEpub2Ncx);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navpoint' XML element has no 'id' attribute")]
+        public async void ReadEpub2NcxAsyncWithoutNavPointIdTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVPOINT_ID_ATTRIBUTE);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navpoint' XML element has no 'navlabel' elements")]
+        public async void ReadEpub2NcxAsyncWithoutNavPointNavLabelsTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVPOINT_NAVLABEL_ELEMENTS);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navpoint' XML element has no 'content' element")]
+        public async void ReadEpub2NcxAsyncWithoutNavPointContentTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVPOINT_CONTENT_ELEMENT);
+        }
+
+        [Fact(DisplayName = "Reading an NCX file without 'content' element in a 'navpoint' XML element with IgnoreMissingContentForNavigationPoints = true should succeed")]
+        public async void ReadEpub2NcxAsyncWithoutNavPointContentWithIgnoreMissingContentForNavigationPointsTest()
+        {
+            EpubReaderOptions epubReaderOptions = new()
+            {
+                Epub2NcxReaderOptions = new Epub2NcxReaderOptions()
+                {
+                    IgnoreMissingContentForNavigationPoints = true
+                }
+            };
+            await TestSuccessfulReadOperation(NCX_FILE_WITHOUT_NAVPOINT_CONTENT_ELEMENT, MinimalEpub2Ncx, epubReaderOptions);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navlabel' XML element has no 'text' element")]
+        public async void ReadEpub2NcxAsyncWithoutNavLabelTextTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVLABEL_TEXT_ELEMENT);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'content' XML element has no 'src' attribute")]
+        public async void ReadEpub2NcxAsyncWithoutContentSrcTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_CONTENT_SRC_ATTRIBUTE);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'pageTarget' XML element has no 'type' attribute")]
+        public async void ReadEpub2NcxAsyncWithoutPageTargetTypeTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_PAGETARGET_TYPE_ATTRIBUTE);
+        }
+
+        [Fact(DisplayName = "Reading an NCX file with unknown value of the 'type' attribute of a 'pageTarget' XML element should succeed")]
+        public async void ReadEpub2NcxAsyncWithUnknownPageTargetTypeTest()
+        {
+            await TestSuccessfulReadOperation(MINIMAL_NCX_FILE_WITH_UNKNOWN_PAGETARGET_TYPE, MinimalEpub2NcxWithUnknownPageTargetType);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'pageTarget' XML element has no 'navlabel' elements")]
+        public async void ReadEpub2NcxAsyncWithoutPageTargetNavLabelsTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_PAGETARGET_NAVLABEL_ELEMENTS);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navList' XML element has no 'navlabel' elements")]
+        public async void ReadEpub2NcxAsyncWithoutNavListNavLabelsTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVLIST_NAVLABEL_ELEMENTS);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navTarget' XML element has no 'id' attribute")]
+        public async void ReadEpub2NcxAsyncWithoutNavTargetIdTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVTARGET_ID_ATTRIBUTE);
+        }
+
+        [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navTarget' XML element has no 'navlabel' elements")]
+        public async void ReadEpub2NcxAsyncWithoutNavTargetNavLabelsTest()
+        {
+            await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVTARGET_NAVLABEL_ELEMENTS);
+        }
+
+        private async Task TestSuccessfulReadOperation(string ncxFileContent, Epub2Ncx expectedEpub2Ncx, EpubReaderOptions epubReaderOptions = null)
+        {
+            TestZipFile testZipFile = CreateTestZipFileWithNcxFile(ncxFileContent);
+            Epub2Ncx actualEpub2Ncx =
+                await Epub2NcxReader.ReadEpub2NcxAsync(testZipFile, CONTENT_DIRECTORY_PATH, MinimalEpubPackageWithNcx, epubReaderOptions ?? new EpubReaderOptions());
+            CompareEpub2Ncxes(expectedEpub2Ncx, actualEpub2Ncx);
+        }
+
+        private async Task TestFailingReadOperation(string ncxFileContent)
+        {
+            TestZipFile testZipFile = CreateTestZipFileWithNcxFile(ncxFileContent);
+            await Assert.ThrowsAsync<Epub2NcxException>(() =>
+                Epub2NcxReader.ReadEpub2NcxAsync(testZipFile, CONTENT_DIRECTORY_PATH, MinimalEpubPackageWithNcx, new EpubReaderOptions()));
+        }
+
+        private TestZipFile CreateTestZipFileWithNcxFile(string ncxFileContent)
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.AddEntry(NCX_FILE_PATH_IN_EPUB_ARCHIVE, new TestZipFileEntry(ncxFileContent));
+            return testZipFile;
+        }
+
+        private void CompareEpub2Ncxes(Epub2Ncx expected, Epub2Ncx actual)
+        {
+            Assert.NotNull(actual);
+            CompareEpub2NcxHeads(expected.Head, actual.Head);
+            Assert.Equal(expected.DocTitle, actual.DocTitle);
+            Assert.Equal(expected.DocAuthors, actual.DocAuthors);
+            CompareEpub2NcxNavigationMaps(expected.NavMap, actual.NavMap);
+            CompareEpub2NcxPageLists(expected.PageList, actual.PageList);
+            AssertUtils.CollectionsEqual(expected.NavLists, actual.NavLists, CompareEpub2NcxNavigationLists);
+        }
+
+        private void CompareEpub2NcxHeads(Epub2NcxHead expected, Epub2NcxHead actual)
+        {
+            Assert.NotNull(actual);
+            AssertUtils.CollectionsEqual(expected, actual, ComprareEpub2NcxHeadMetas);
+        }
+
+        private void ComprareEpub2NcxHeadMetas(Epub2NcxHeadMeta expected, Epub2NcxHeadMeta actual)
+        {
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Content, actual.Content);
+            Assert.Equal(expected.Scheme, actual.Scheme);
+        }
+
+        private void CompareEpub2NcxNavigationMaps(Epub2NcxNavigationMap expected, Epub2NcxNavigationMap actual)
+        {
+            Assert.NotNull(actual);
+            AssertUtils.CollectionsEqual(expected, actual, CompareEpub2NcxNavigationPoints);
+        }
+
+        private void CompareEpub2NcxNavigationPoints(Epub2NcxNavigationPoint expected, Epub2NcxNavigationPoint actual)
+        {
+            Assert.NotNull(actual);
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.Class, actual.Class);
+            Assert.Equal(expected.PlayOrder, actual.PlayOrder);
+            AssertUtils.CollectionsEqual(expected.NavigationLabels, actual.NavigationLabels, CompareEpub2NcxNavigationLabels);
+            CompareEpub2NcxContents(expected.Content, actual.Content);
+            AssertUtils.CollectionsEqual(expected.ChildNavigationPoints, actual.ChildNavigationPoints, CompareEpub2NcxNavigationPoints);
+        }
+
+        private void CompareEpub2NcxNavigationLabels(Epub2NcxNavigationLabel expected, Epub2NcxNavigationLabel actual)
+        {
+            Assert.NotNull(actual);
+            Assert.Equal(expected.Text, actual.Text);
+        }
+
+        private void CompareEpub2NcxContents(Epub2NcxContent expected, Epub2NcxContent actual)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+            }
+            else
+            {
+                Assert.NotNull(actual);
+                Assert.Equal(expected.Id, actual.Id);
+                Assert.Equal(expected.Source, actual.Source);
+            }
+        }
+
+        private void CompareEpub2NcxPageLists(Epub2NcxPageList expected, Epub2NcxPageList actual)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+            }
+            else
+            {
+                Assert.NotNull(actual);
+                AssertUtils.CollectionsEqual(expected, actual, CompareEpub2NcxPageTargets);
+            }
+        }
+
+        private void CompareEpub2NcxPageTargets(Epub2NcxPageTarget expected, Epub2NcxPageTarget actual)
+        {
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.Value, actual.Value);
+            Assert.Equal(expected.Type, actual.Type);
+            Assert.Equal(expected.Class, actual.Class);
+            Assert.Equal(expected.PlayOrder, actual.PlayOrder);
+            AssertUtils.CollectionsEqual(expected.NavigationLabels, actual.NavigationLabels, CompareEpub2NcxNavigationLabels);
+            CompareEpub2NcxContents(expected.Content, actual.Content);
+        }
+
+        private void CompareEpub2NcxNavigationLists(Epub2NcxNavigationList expected, Epub2NcxNavigationList actual)
+        {
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.Class, actual.Class);
+            AssertUtils.CollectionsEqual(expected.NavigationLabels, actual.NavigationLabels, CompareEpub2NcxNavigationLabels);
+            AssertUtils.CollectionsEqual(expected.NavigationTargets, actual.NavigationTargets, CompareEpub2NcxNavigationTargets);
+        }
+
+        private void CompareEpub2NcxNavigationTargets(Epub2NcxNavigationTarget expected, Epub2NcxNavigationTarget actual)
+        {
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.Value, actual.Value);
+            Assert.Equal(expected.Class, actual.Class);
+            Assert.Equal(expected.PlayOrder, actual.PlayOrder);
+            AssertUtils.CollectionsEqual(expected.NavigationLabels, actual.NavigationLabels, CompareEpub2NcxNavigationLabels);
+            CompareEpub2NcxContents(expected.Content, actual.Content);
+        }
+    }
+}

--- a/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
@@ -2,6 +2,7 @@
 using VersOne.Epub.Options;
 using VersOne.Epub.Schema;
 using VersOne.Epub.Test.Unit.Mocks;
+using VersOne.Epub.Test.Unit.TestUtils;
 
 namespace VersOne.Epub.Test.Unit.Readers
 {
@@ -803,97 +804,97 @@ namespace VersOne.Epub.Test.Unit.Readers
             await TestFailingReadOperation(OPF_FILE_WITH_NON_SUPPORTED_EPUB_VERSION);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without package XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'package' XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutPackageNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_PACKAGE);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without metadata XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'metadata' XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutMetadataNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_METADATA);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without manifest XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'manifest' XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutManifestNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_MANIFEST);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without spine XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'spine' XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutSpineNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_SPINE);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without ID attribute in a manifest item XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'id' attribute in a manifest item XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutManifestItemIdTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_ID_IN_MANIFEST_ITEM);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package with empty ID attribute in a manifest item XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package with empty 'id' attribute in a manifest item XML node should fail with EpubPackageException")]
         public async void ReadPackageWithEmptyManifestItemIdTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITH_EMPTY_ID_IN_MANIFEST_ITEM);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without ID attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
+        [Fact(DisplayName = "Trying to read OPF package without 'id' attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
         public async void ReadPackageWithoutManifestItemIdWithSkippingInvalidManifestItemsTest()
         {
             await TestSuccessfulReadOperationWithSkippingInvalidManifestItems(OPF_FILE_WITHOUT_ID_IN_MANIFEST_ITEM, MinimalEpub3Package);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without href attribute in a manifest item XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'href' attribute in a manifest item XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutManifestItemHrefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_HREF_IN_MANIFEST_ITEM);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package with empty href attribute in a manifest item XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package with empty 'href' attribute in a manifest item XML node should fail with EpubPackageException")]
         public async void ReadPackageWithEmptyManifestItemHrefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITH_EMPTY_HREF_IN_MANIFEST_ITEM);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without href attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
+        [Fact(DisplayName = "Trying to read OPF package without 'href' attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
         public async void ReadPackageWithoutManifestItemHrefWithSkippingInvalidManifestItemsTest()
         {
             await TestSuccessfulReadOperationWithSkippingInvalidManifestItems(OPF_FILE_WITHOUT_HREF_IN_MANIFEST_ITEM, MinimalEpub3Package);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without media type attribute in a manifest item XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'media-type' attribute in a manifest item XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutManifestItemMediaTypeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_MEDIA_TYPE_IN_MANIFEST_ITEM);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package with empty media type attribute in a manifest item XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package with empty 'media-type' attribute in a manifest item XML node should fail with EpubPackageException")]
         public async void ReadPackageWithEmptyManifestItemMediaTypeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITH_EMPTY_MEDIA_TYPE_IN_MANIFEST_ITEM);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without media type attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
+        [Fact(DisplayName = "Trying to read OPF package without 'media-type' attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
         public async void ReadPackageWithoutManifestItemMediaTypeWithSkippingInvalidManifestItemsTest()
         {
             await TestSuccessfulReadOperationWithSkippingInvalidManifestItems(OPF_FILE_WITHOUT_MEDIA_TYPE_IN_MANIFEST_ITEM, MinimalEpub3Package);
         }
 
-        [Fact(DisplayName = "Trying to read EPUB 2 OPF package without toc attribute in the spine XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read EPUB 2 OPF package without 'toc' attribute in the spine XML node should fail with EpubPackageException")]
         public async void ReadEpub2PackageWithoutSpineTocTest()
         {
             await TestFailingReadOperation(EPUB2_OPF_FILE_WITHOUT_SPINE_TOC);
         }
 
-        [Fact(DisplayName = "Trying to read EPUB 2 OPF package with empty toc attribute in the spine XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read EPUB 2 OPF package with empty 'toc' attribute in the spine XML node should fail with EpubPackageException")]
         public async void ReadEpub2PackageWithEmptySpineTocTest()
         {
             await TestFailingReadOperation(EPUB2_OPF_FILE_WITH_EMPTY_SPINE_TOC);
         }
 
-        [Fact(DisplayName = "Trying to read EPUB 2 OPF package without toc attribute in the spine XML node with IgnoreMissingToc = true should succeed")]
+        [Fact(DisplayName = "Trying to read EPUB 2 OPF package without 'toc' attribute in the spine XML node with IgnoreMissingToc = true should succeed")]
         public async void ReadEpub2PackageWithoutSpineTocWithIgnoreMissingTocTest()
         {
             EpubReaderOptions epubReaderOptions = new()
@@ -906,37 +907,37 @@ namespace VersOne.Epub.Test.Unit.Readers
             await TestSuccessfulReadOperation(EPUB2_OPF_FILE_WITHOUT_SPINE_TOC, Epub2PackageWithoutSpineToc, epubReaderOptions);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without ID ref attribute in a spine item ref XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'idref' attribute in a spine item ref XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutSpineItemRefIdRefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_IDREF_IN_SPINE_ITEMREF);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package with empty ID ref attribute in a spine item ref XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package with empty 'idref' attribute in a spine item ref XML node should fail with EpubPackageException")]
         public async void ReadPackageWithEmptySpineItemRefIdRefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITH_EMPTY_IDREF_IN_SPINE_ITEMREF);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without type attribute in a guide reference XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'type' attribute in a guide reference XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutGuideReferenceTypeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_TYPE_IN_GUIDE_REFERENCE);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package with empty type attribute in a guide reference XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package with empty 'type' attribute in a guide reference XML node should fail with EpubPackageException")]
         public async void ReadPackageWithEmptyGuideReferenceTypeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITH_EMPTY_TYPE_IN_GUIDE_REFERENCE);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package without href attribute in a guide reference XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package without 'href' attribute in a guide reference XML node should fail with EpubPackageException")]
         public async void ReadPackageWithoutGuideReferenceHrefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_HREF_IN_GUIDE_REFERENCE);
         }
 
-        [Fact(DisplayName = "Trying to read OPF package with empty href attribute in a guide reference XML node should fail with EpubPackageException")]
+        [Fact(DisplayName = "Trying to read OPF package with empty 'href' attribute in a guide reference XML node should fail with EpubPackageException")]
         public async void ReadPackageWithEmptyGuideReferenceHrefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITH_EMPTY_HREF_IN_GUIDE_REFERENCE);
@@ -989,46 +990,22 @@ namespace VersOne.Epub.Test.Unit.Readers
         {
             Assert.NotNull(actual);
             Assert.Equal(expected.Titles, actual.Titles);
-            Assert.Equal(expected.Creators.Count, actual.Creators.Count);
-            for (int i = 0; i < expected.Creators.Count; i++)
-            {
-                CompareEpubMetadataCreators(expected.Creators[i], actual.Creators[i]);
-            }
+            AssertUtils.CollectionsEqual(expected.Creators, actual.Creators, CompareEpubMetadataCreators);
             Assert.Equal(expected.Subjects, actual.Subjects);
             Assert.Equal(expected.Description, actual.Description);
             Assert.Equal(expected.Publishers, actual.Publishers);
-            Assert.Equal(expected.Contributors.Count, actual.Contributors.Count);
-            for (int i = 0; i < expected.Contributors.Count; i++)
-            {
-                CompareEpubMetadataContributors(expected.Contributors[i], actual.Contributors[i]);
-            }
-            Assert.Equal(expected.Dates.Count, actual.Dates.Count);
-            for (int i = 0; i < expected.Dates.Count; i++)
-            {
-                CompareEpubMetadataDates(expected.Dates[i], actual.Dates[i]);
-            }
+            AssertUtils.CollectionsEqual(expected.Contributors, actual.Contributors, CompareEpubMetadataContributors);
+            AssertUtils.CollectionsEqual(expected.Dates, actual.Dates, CompareEpubMetadataDates);
             Assert.Equal(expected.Types, actual.Types);
             Assert.Equal(expected.Formats, actual.Formats);
-            Assert.Equal(expected.Identifiers.Count, actual.Identifiers.Count);
-            for (int i = 0; i < expected.Identifiers.Count; i++)
-            {
-                CompareEpubMetadataIdentifiers(expected.Identifiers[i], actual.Identifiers[i]);
-            }
+            AssertUtils.CollectionsEqual(expected.Identifiers, actual.Identifiers, CompareEpubMetadataIdentifiers);
             Assert.Equal(expected.Sources, actual.Sources);
             Assert.Equal(expected.Languages, actual.Languages);
             Assert.Equal(expected.Relations, actual.Relations);
             Assert.Equal(expected.Coverages, actual.Coverages);
             Assert.Equal(expected.Rights, actual.Rights);
-            Assert.Equal(expected.Links.Count, actual.Links.Count);
-            for (int i = 0; i < expected.Links.Count; i++)
-            {
-                CompareEpubMetadataLinks(expected.Links[i], actual.Links[i]);
-            }
-            Assert.Equal(expected.MetaItems.Count, actual.MetaItems.Count);
-            for (int i = 0; i < expected.Links.Count; i++)
-            {
-                CompareEpubMetadataMetas(expected.MetaItems[i], actual.MetaItems[i]);
-            }
+            AssertUtils.CollectionsEqual(expected.Links, actual.Links, CompareEpubMetadataLinks);
+            AssertUtils.CollectionsEqual(expected.MetaItems, actual.MetaItems, CompareEpubMetadataMetas);
         }
 
         private void CompareEpubMetadataCreators(EpubMetadataCreator expected, EpubMetadataCreator actual)
@@ -1089,11 +1066,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         private void CompareEpubManifests(EpubManifest expected, EpubManifest actual)
         {
             Assert.NotNull(actual);
-            Assert.Equal(expected.Count, actual.Count);
-            for (int i = 0; i < expected.Count; i++)
-            {
-                CompareEpubManifestItems(expected[i], actual[i]);
-            }
+            AssertUtils.CollectionsEqual(expected, actual, CompareEpubManifestItems);
         }
 
         private void CompareEpubManifestItems(EpubManifestItem expected, EpubManifestItem actual)
@@ -1116,11 +1089,7 @@ namespace VersOne.Epub.Test.Unit.Readers
             Assert.Equal(expected.Id, actual.Id);
             Assert.Equal(expected.PageProgressionDirection, actual.PageProgressionDirection);
             Assert.Equal(expected.Toc, actual.Toc);
-            Assert.Equal(expected.Count, actual.Count);
-            for (int i = 0; i < expected.Count; i++)
-            {
-                CompareEpubSpineItemRefs(expected[i], actual[i]);
-            }
+            AssertUtils.CollectionsEqual(expected, actual, CompareEpubSpineItemRefs);
         }
 
         private void CompareEpubSpineItemRefs(EpubSpineItemRef expected, EpubSpineItemRef actual)
@@ -1141,11 +1110,7 @@ namespace VersOne.Epub.Test.Unit.Readers
             else
             {
                 Assert.NotNull(actual);
-                Assert.Equal(expected.Count, actual.Count);
-                for (int i = 0; i < expected.Count; i++)
-                {
-                    CompareEpubGuideReferences(expected[i], actual[i]);
-                }
+                AssertUtils.CollectionsEqual(expected, actual, CompareEpubGuideReferences);
             }
         }
 

--- a/Source/VersOne.Epub.Test/Unit/Readers/RootFilePathReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/RootFilePathReaderTests.cs
@@ -43,8 +43,7 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private const string INCORRECT_CONTAINER_FILE_NO_CONTAINER_ELEMENT = $"""
             <?xml version='1.0' encoding='utf-8'?>
-            <test>
-            </test>
+            <test />
             """;
 
         [Fact(DisplayName = "Getting root file path from a ZIP archive with a correct container file should succeed")]

--- a/Source/VersOne.Epub.Test/Unit/TestUtils/AssertUtils.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestUtils/AssertUtils.cs
@@ -1,0 +1,14 @@
+﻿namespace VersOne.Epub.Test.Unit.TestUtils
+{
+    internal static class AssertUtils
+    {
+        public static void CollectionsEqual<T>(IList<T> expected, IList<T> actual, Action<T, T> elementComparer)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                elementComparer(expected[i], actual[i]);
+            }
+        }
+    }
+}

--- a/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
@@ -358,6 +358,8 @@ namespace VersOne.Epub.Internal
                         break;
                 }
             }
+            result.NavigationLabels = new List<Epub2NcxNavigationLabel>();
+            result.NavigationTargets = new List<Epub2NcxNavigationTarget>();
             foreach (XElement navigationListChildNode in navigationListNode.Elements())
             {
                 switch (navigationListChildNode.GetLowerCaseLocalName())
@@ -366,7 +368,7 @@ namespace VersOne.Epub.Internal
                         Epub2NcxNavigationLabel navigationLabel = ReadNavigationLabel(navigationListChildNode);
                         result.NavigationLabels.Add(navigationLabel);
                         break;
-                    case "navTarget":
+                    case "navtarget":
                         Epub2NcxNavigationTarget navigationTarget = ReadNavigationTarget(navigationListChildNode);
                         result.NavigationTargets.Add(navigationTarget);
                         break;
@@ -405,6 +407,7 @@ namespace VersOne.Epub.Internal
             {
                 throw new Epub2NcxException("Incorrect EPUB navigation target: navigation target ID is missing.");
             }
+            result.NavigationLabels = new List<Epub2NcxNavigationLabel>();
             foreach (XElement navigationTargetChildNode in navigationTargetNode.Elements())
             {
                 switch (navigationTargetChildNode.GetLowerCaseLocalName())


### PR DESCRIPTION
# Fix for EPUB 2 NCX navigation list parsing

This is:
- [x] a bug fix
- [ ] an enhancement

Related issue: #55

## Description

This pull request fixes the EPUB 2 NCX navigation list parsing issues described in the issue linked above. It also adds unit tests for the EPUB 2 NCX reader.

## Testing steps

1. Open a EPUB 2 book which has at least one navigation list in the NCX file.
2. Check the `book.Schema.Schema.Epub2Ncx.NavLists[0].NavigationTargets` property and make sure it contains at least one element.