### PR TITLE
Remote manifest items support

### DIFF
--- a/Source/VersOne.Epub.Test/Unit/Comparers/EpubContentComparer.cs
+++ b/Source/VersOne.Epub.Test/Unit/Comparers/EpubContentComparer.cs
@@ -50,6 +50,8 @@ namespace VersOne.Epub.Test.Unit.Comparers
                 Assert.NotNull(actual);
                 Assert.Equal(expected.FileName, actual.FileName);
                 Assert.Equal(expected.FilePathInEpubArchive, actual.FilePathInEpubArchive);
+                Assert.Equal(expected.Href, actual.Href);
+                Assert.Equal(expected.ContentLocation, actual.ContentLocation);
                 Assert.Equal(expected.ContentType, actual.ContentType);
                 Assert.Equal(expected.ContentMimeType, actual.ContentMimeType);
             }

--- a/Source/VersOne.Epub.Test/Unit/Comparers/EpubContentRefComparer.cs
+++ b/Source/VersOne.Epub.Test/Unit/Comparers/EpubContentRefComparer.cs
@@ -27,6 +27,8 @@ namespace VersOne.Epub.Test.Unit.Comparers
                 Assert.Equal(expected.GetType(), actual.GetType());
                 Assert.Equal(expected.FileName, actual.FileName);
                 Assert.Equal(expected.FilePathInEpubArchive, actual.FilePathInEpubArchive);
+                Assert.Equal(expected.Href, actual.Href);
+                Assert.Equal(expected.ContentLocation, actual.ContentLocation);
                 Assert.Equal(expected.ContentType, actual.ContentType);
                 Assert.Equal(expected.ContentMimeType, actual.ContentMimeType);
             }

--- a/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
@@ -305,7 +305,7 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private EpubByteContentFileRef CreateTestImageFileRef(EpubBookRef epubBookRef)
         {
-            return new(epubBookRef, "cover.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
+            return new(epubBookRef, "cover.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg");
         }
 
         private Dictionary<string, EpubByteContentFileRef> CreateImageContentRefs(EpubByteContentFileRef imageFileRef)

--- a/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
@@ -149,27 +149,43 @@ namespace VersOne.Epub.Test.Unit.Readers
                         {
                             EpubManifestProperty.NAV
                         }
+                    },
+                    new EpubManifestItem()
+                    {
+                        Id = "item-19",
+                        Href = "https://example.com/books/123/test.html",
+                        MediaType = "application/xhtml+xml"
+                    },
+                    new EpubManifestItem()
+                    {
+                        Id = "item-20",
+                        Href = "https://example.com/books/123/image.jpg",
+                        MediaType = "image/jpeg"
                     }
                 }
             };
-            EpubTextContentFileRef expectedFileRef1 = new(epubBookRef, "text.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
-            EpubTextContentFileRef expectedFileRef2 = new(epubBookRef, "doc.dtb", EpubContentType.DTBOOK, "application/x-dtbook+xml");
-            EpubTextContentFileRef expectedFileRef3 = new(epubBookRef, "toc.ncx", EpubContentType.DTBOOK_NCX, "application/x-dtbncx+xml");
-            EpubTextContentFileRef expectedFileRef4 = new(epubBookRef, "oeb.html", EpubContentType.OEB1_DOCUMENT, "text/x-oeb1-document");
-            EpubTextContentFileRef expectedFileRef5 = new(epubBookRef, "file.xml", EpubContentType.XML, "application/xml");
-            EpubTextContentFileRef expectedFileRef6 = new(epubBookRef, "styles.css", EpubContentType.CSS, "text/css");
-            EpubTextContentFileRef expectedFileRef7 = new(epubBookRef, "oeb.css", EpubContentType.OEB1_CSS, "text/x-oeb1-css");
-            EpubByteContentFileRef expectedFileRef8 = new(epubBookRef, "image1.gif", EpubContentType.IMAGE_GIF, "image/gif");
-            EpubByteContentFileRef expectedFileRef9 = new(epubBookRef, "image2.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
-            EpubByteContentFileRef expectedFileRef10 = new(epubBookRef, "image3.png", EpubContentType.IMAGE_PNG, "image/png");
-            EpubByteContentFileRef expectedFileRef11 = new(epubBookRef, "image4.svg", EpubContentType.IMAGE_SVG, "image/svg+xml");
-            EpubByteContentFileRef expectedFileRef12 = new(epubBookRef, "font1.ttf", EpubContentType.FONT_TRUETYPE, "font/truetype");
-            EpubByteContentFileRef expectedFileRef13 = new(epubBookRef, "font2.ttf", EpubContentType.FONT_TRUETYPE, "application/x-font-truetype");
-            EpubByteContentFileRef expectedFileRef14 = new(epubBookRef, "font3.otf", EpubContentType.FONT_OPENTYPE, "font/opentype");
-            EpubByteContentFileRef expectedFileRef15 = new(epubBookRef, "font4.otf", EpubContentType.FONT_OPENTYPE, "application/vnd.ms-opentype");
-            EpubByteContentFileRef expectedFileRef16 = new(epubBookRef, "video.mp4", EpubContentType.OTHER, "video/mp4");
-            EpubByteContentFileRef expectedFileRef17 = new(epubBookRef, "cover.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
-            EpubTextContentFileRef expectedFileRef18 = new(epubBookRef, "toc.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubTextContentFileRef expectedFileRef1 = new(epubBookRef, "text.html", EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubTextContentFileRef expectedFileRef2 = new(epubBookRef, "doc.dtb", EpubContentLocation.LOCAL, EpubContentType.DTBOOK, "application/x-dtbook+xml");
+            EpubTextContentFileRef expectedFileRef3 = new(epubBookRef, "toc.ncx", EpubContentLocation.LOCAL, EpubContentType.DTBOOK_NCX, "application/x-dtbncx+xml");
+            EpubTextContentFileRef expectedFileRef4 = new(epubBookRef, "oeb.html", EpubContentLocation.LOCAL, EpubContentType.OEB1_DOCUMENT, "text/x-oeb1-document");
+            EpubTextContentFileRef expectedFileRef5 = new(epubBookRef, "file.xml", EpubContentLocation.LOCAL, EpubContentType.XML, "application/xml");
+            EpubTextContentFileRef expectedFileRef6 = new(epubBookRef, "styles.css", EpubContentLocation.LOCAL, EpubContentType.CSS, "text/css");
+            EpubTextContentFileRef expectedFileRef7 = new(epubBookRef, "oeb.css", EpubContentLocation.LOCAL, EpubContentType.OEB1_CSS, "text/x-oeb1-css");
+            EpubByteContentFileRef expectedFileRef8 = new(epubBookRef, "image1.gif", EpubContentLocation.LOCAL, EpubContentType.IMAGE_GIF, "image/gif");
+            EpubByteContentFileRef expectedFileRef9 = new(epubBookRef, "image2.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg");
+            EpubByteContentFileRef expectedFileRef10 = new(epubBookRef, "image3.png", EpubContentLocation.LOCAL, EpubContentType.IMAGE_PNG, "image/png");
+            EpubByteContentFileRef expectedFileRef11 = new(epubBookRef, "image4.svg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_SVG, "image/svg+xml");
+            EpubByteContentFileRef expectedFileRef12 = new(epubBookRef, "font1.ttf", EpubContentLocation.LOCAL, EpubContentType.FONT_TRUETYPE, "font/truetype");
+            EpubByteContentFileRef expectedFileRef13 = new(epubBookRef, "font2.ttf", EpubContentLocation.LOCAL, EpubContentType.FONT_TRUETYPE, "application/x-font-truetype");
+            EpubByteContentFileRef expectedFileRef14 = new(epubBookRef, "font3.otf", EpubContentLocation.LOCAL, EpubContentType.FONT_OPENTYPE, "font/opentype");
+            EpubByteContentFileRef expectedFileRef15 = new(epubBookRef, "font4.otf", EpubContentLocation.LOCAL, EpubContentType.FONT_OPENTYPE, "application/vnd.ms-opentype");
+            EpubByteContentFileRef expectedFileRef16 = new(epubBookRef, "video.mp4", EpubContentLocation.LOCAL, EpubContentType.OTHER, "video/mp4");
+            EpubByteContentFileRef expectedFileRef17 = new(epubBookRef, "cover.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg");
+            EpubTextContentFileRef expectedFileRef18 = new(epubBookRef, "toc.html", EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubTextContentFileRef expectedFileRef19 =
+                new(epubBookRef, "https://example.com/books/123/test.html", EpubContentLocation.REMOTE, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubByteContentFileRef expectedFileRef20 =
+                new(epubBookRef, "https://example.com/books/123/image.jpg", EpubContentLocation.REMOTE, EpubContentType.IMAGE_JPEG, "image/jpeg");
             EpubContentRef expectedContentMap = new()
             {
                 Html = new Dictionary<string, EpubTextContentFileRef>()
@@ -181,6 +197,10 @@ namespace VersOne.Epub.Test.Unit.Readers
                     {
                         "toc.html",
                         expectedFileRef18
+                    },
+                    {
+                        "https://example.com/books/123/test.html",
+                        expectedFileRef19
                     }
                 },
                 Css = new Dictionary<string, EpubTextContentFileRef>()
@@ -211,6 +231,10 @@ namespace VersOne.Epub.Test.Unit.Readers
                     {
                         "cover.jpg",
                         expectedFileRef17
+                    },
+                    {
+                        "https://example.com/books/123/image.jpg",
+                        expectedFileRef20
                     }
                 },
                 Fonts = new Dictionary<string, EpubByteContentFileRef>()
@@ -305,6 +329,14 @@ namespace VersOne.Epub.Test.Unit.Readers
                     {
                         "toc.html",
                         expectedFileRef18
+                    },
+                    {
+                        "https://example.com/books/123/test.html",
+                        expectedFileRef19
+                    },
+                    {
+                        "https://example.com/books/123/image.jpg",
+                        expectedFileRef20
                     }
                 },
                 NavigationHtmlFile = expectedFileRef18,

--- a/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
@@ -573,7 +573,7 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private EpubTextContentFileRef CreateTestHtmlFile(EpubBookRef epubBookRef, string htmlFileName)
         {
-            return new(epubBookRef, htmlFileName, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            return new(epubBookRef, htmlFileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
         }
 
         private EpubNavigationItemRef CreateNavigationLink(string title, string htmlFileUrl, EpubTextContentFileRef htmlFileRef)

--- a/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
@@ -176,7 +176,7 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private EpubTextContentFileRef CreateTestHtmlFileRef(EpubBookRef epubBookRef, string fileName)
         {
-            return new(epubBookRef, fileName, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            return new(epubBookRef, fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
         }
     }
 }

--- a/Source/VersOne.Epub.Test/Unit/RefEntities/EpubBookRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/RefEntities/EpubBookRefTests.cs
@@ -116,7 +116,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(COVER_FILE_PATH, coverFileContent);
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            epubBookRef.Content.Cover = new EpubByteContentFileRef(epubBookRef, COVER_FILE_NAME, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE);
+            epubBookRef.Content.Cover = new EpubByteContentFileRef(epubBookRef, COVER_FILE_NAME, EpubContentLocation.LOCAL, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE);
             return epubBookRef;
         }
 
@@ -237,7 +237,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
 
         private EpubTextContentFileRef CreateTestHtmlFileRef(EpubBookRef epubBookRef, string fileName)
         {
-            return new(epubBookRef, fileName, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            return new(epubBookRef, fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
         }
 
         private EpubNavigationItemRef CreateTestNavigationLink(string title, string htmlFileUrl, EpubTextContentFileRef htmlFileRef)

--- a/Source/VersOne.Epub.Test/Unit/RefEntities/EpubContentFileRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/RefEntities/EpubContentFileRefTests.cs
@@ -7,22 +7,72 @@ namespace VersOne.Epub.Test.Unit.RefEntities
     public class EpubContentFileRefTests
     {
         private const string CONTENT_DIRECTORY_PATH = "Content";
-        private const string TEXT_FILE_NAME = "test.html";
-        private const string TEXT_FILE_PATH = $"{CONTENT_DIRECTORY_PATH}/{TEXT_FILE_NAME}";
+        private const string LOCAL_TEXT_FILE_NAME = "test.html";
+        private const string TEXT_FILE_PATH = $"{CONTENT_DIRECTORY_PATH}/{LOCAL_TEXT_FILE_NAME}";
+        private const string REMOTE_TEXT_CONTENT_HREF = "https://example.com/books/123/test.html";
         private const string TEXT_FILE_CONTENT = "<html><head><title>Test HTML</title></head><body><h1>Test content</h1></body></html>";
         private const EpubContentType TEXT_FILE_CONTENT_TYPE = EpubContentType.XHTML_1_1;
         private const string TEXT_FILE_CONTENT_MIME_TYPE = "application/xhtml+xml";
-        private const string BYTE_FILE_NAME = "image.jpg";
-        private const string BYTE_FILE_PATH = $"{CONTENT_DIRECTORY_PATH}/{BYTE_FILE_NAME}";
+        private const string LOCAL_BYTE_FILE_NAME = "image.jpg";
+        private const string BYTE_FILE_PATH = $"{CONTENT_DIRECTORY_PATH}/{LOCAL_BYTE_FILE_NAME}";
+        private const string REMOTE_BYTE_CONTENT_HREF = "https://example.com/books/123/image.jpg";
         private const EpubContentType BYTE_FILE_CONTENT_TYPE = EpubContentType.IMAGE_JPEG;
         private const string BYTE_FILE_CONTENT_MIME_TYPE = "image/jpeg";
         
         private static readonly byte[] BYTE_FILE_CONTENT = new byte[] { 0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46 };
 
+        [Fact(DisplayName = "EpubTextContentFileRef with ContentLocation = LOCAL should have non-null FileName and FilePathInEpubArchive properties and null Href property")]
+        public void LocalTextContentItemPropertiesTest()
+        {
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            Assert.Equal(LOCAL_TEXT_FILE_NAME, epubTextContentFileRef.FileName);
+            Assert.Equal(TEXT_FILE_PATH, epubTextContentFileRef.FilePathInEpubArchive);
+            Assert.Null(epubTextContentFileRef.Href);
+        }
+
+        [Fact(DisplayName = "EpubByteContentFileRef with ContentLocation = LOCAL should have non-null FileName and FilePathInEpubArchive properties and null Href property")]
+        public void LocalByteContentItemPropertiesTest()
+        {
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
+            EpubByteContentFileRef epubByteContentFileRef =
+                new(epubBookRef, LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+            Assert.Equal(LOCAL_BYTE_FILE_NAME, epubByteContentFileRef.FileName);
+            Assert.Equal(BYTE_FILE_PATH, epubByteContentFileRef.FilePathInEpubArchive);
+            Assert.Null(epubByteContentFileRef.Href);
+        }
+
+        [Fact(DisplayName = "EpubTextContentFileRef with ContentLocation = REMOTE should have null FileName and FilePathInEpubArchive properties and non-null Href property")]
+        public void RemoteTextContentItemPropertiesTest()
+        {
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(epubBookRef, REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            Assert.Equal(REMOTE_TEXT_CONTENT_HREF, epubTextContentFileRef.Href);
+            Assert.Null(epubTextContentFileRef.FileName);
+            Assert.Null(epubTextContentFileRef.FilePathInEpubArchive);
+        }
+
+        [Fact(DisplayName = "EpubByteContentFileRef with ContentLocation = REMOTE should have null FileName and FilePathInEpubArchive properties and non-null Href property")]
+        public void RemoteByteContentItemPropertiesTest()
+        {
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
+            EpubByteContentFileRef epubByteContentFileRef =
+                new(epubBookRef, REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+            Assert.Equal(REMOTE_BYTE_CONTENT_HREF, epubByteContentFileRef.Href);
+            Assert.Null(epubByteContentFileRef.FileName);
+            Assert.Null(epubByteContentFileRef.FilePathInEpubArchive);
+        }
+
         [Fact(DisplayName = "Reading content of an existing text file synchronously should succeed")]
         public void ReadTextContentTest()
         {
-            EpubTextContentFileRef epubTextContentFileRef = CreateTextContentFileRef();
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
             string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
@@ -30,7 +80,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "Reading content of an existing text file asynchronously should succeed")]
         public async void ReadTextContentAsyncTest()
         {
-            EpubTextContentFileRef epubTextContentFileRef = CreateTextContentFileRef();
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
             string textContent = await epubTextContentFileRef.ReadContentAsync();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
@@ -38,7 +88,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "Reading content of an existing byte file synchronously should succeed")]
         public void ReadByteContentTest()
         {
-            EpubByteContentFileRef epubByteContentFileRef = CreateByteContentFileRef();
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
             byte[] byteContent = epubByteContentFileRef.ReadContent();
             Assert.Equal(BYTE_FILE_CONTENT, byteContent);
         }
@@ -46,7 +96,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "Reading content of an existing byte file asynchronously should succeed")]
         public async void ReadByteContentAsyncTest()
         {
-            EpubByteContentFileRef epubByteContentFileRef = CreateByteContentFileRef();
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
             byte[] byteContent = await epubByteContentFileRef.ReadContentAsync();
             Assert.Equal(BYTE_FILE_CONTENT, byteContent);
         }
@@ -56,7 +106,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         {
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, String.Empty, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, String.Empty, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
             Assert.Throws<EpubPackageException>(() => epubTextContentFileRef.GetContentStream());
         }
 
@@ -65,7 +115,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         {
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
             Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
         }
 
@@ -75,7 +125,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(TEXT_FILE_PATH, new Test4GbZipFileEntry());
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
             Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
         }
 
@@ -86,7 +136,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             contentReaderOptions.ContentFileMissing += (sender, e) => e.SuppressException = true;
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
             string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(String.Empty, textContent);
         }
@@ -98,7 +149,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             contentReaderOptions.ContentFileMissing += (sender, e) => e.ReplacementContentStream = new MemoryStream(Encoding.UTF8.GetBytes(TEXT_FILE_CONTENT));
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
             string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
@@ -110,7 +162,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             contentReaderOptions.ContentFileMissing += (sender, e) => e.ReplacementContentStream = new MemoryStream(Encoding.UTF8.GetBytes(TEXT_FILE_CONTENT));
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
             string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
             textContent = epubTextContentFileRef.ReadContent();
@@ -123,7 +176,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             ContentReaderOptions contentReaderOptions = new();
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
             Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
         }
 
@@ -139,28 +193,78 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             };
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
             epubTextContentFileRef.ReadContent();
-            Assert.Equal(TEXT_FILE_NAME, contentFileMissingEventArgs.FileName);
+            Assert.Equal(LOCAL_TEXT_FILE_NAME, contentFileMissingEventArgs.FileName);
             Assert.Equal(TEXT_FILE_PATH, contentFileMissingEventArgs.FilePathInEpubArchive);
             Assert.Equal(TEXT_FILE_CONTENT_TYPE, contentFileMissingEventArgs.ContentType);
             Assert.Equal(TEXT_FILE_CONTENT_MIME_TYPE, contentFileMissingEventArgs.ContentMimeType);
         }
 
-        private EpubTextContentFileRef CreateTextContentFileRef()
+        [Fact(DisplayName = "ReadContent should throw InvalidOperationException for remote text content items")]
+        public void ReadContentForRemoteTextContentItemTest()
+        {
+            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
+            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.ReadContent());
+        }
+
+        [Fact(DisplayName = "ReadContentAsync should throw InvalidOperationException for remote text content items")]
+        public async void ReadContentAsyncForRemoteTextContentItemTest()
+        {
+            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => epubTextContentFileRef.ReadContentAsync());
+        }
+
+        [Fact(DisplayName = "ReadContent should throw InvalidOperationException for remote byte content items")]
+        public void ReadContentForRemoteByteContentItemTest()
+        {
+            EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef();
+            Assert.Throws<InvalidOperationException>(() => epubByteContentFileRef.ReadContent());
+        }
+
+        [Fact(DisplayName = "ReadContentAsync should throw InvalidOperationException for remote byte content items")]
+        public async void ReadContentAsyncForRemoteByteContentItemTest()
+        {
+            EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => epubByteContentFileRef.ReadContentAsync());
+        }
+
+        [Fact(DisplayName = "GetContentStream should throw InvalidOperationException for remote content items")]
+        public void GetContentStreamForRemoteContentItemTest()
+        {
+            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
+            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.GetContentStream());
+        }
+
+        private EpubTextContentFileRef CreateLocalTextContentFileRef()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(TEXT_FILE_PATH, TEXT_FILE_CONTENT);
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            return new(epubBookRef, TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            return new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
         }
 
-        private EpubByteContentFileRef CreateByteContentFileRef()
+        private EpubByteContentFileRef CreateLocalByteContentFileRef()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(BYTE_FILE_PATH, BYTE_FILE_CONTENT);
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            return new(epubBookRef, BYTE_FILE_NAME, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+            return new(epubBookRef, LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+        }
+
+        private EpubTextContentFileRef CreateRemoteTextContentFileRef()
+        {
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
+            return new(epubBookRef, REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+        }
+
+        private EpubByteContentFileRef CreateRemoteByteContentFileRef()
+        {
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
+            return new(epubBookRef, REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
         }
 
         private EpubBookRef CreateEpubBookRef(TestZipFile testZipFile)

--- a/Source/VersOne.Epub.Test/Unit/Root/EpubReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Root/EpubReaderTests.cs
@@ -47,6 +47,8 @@ namespace VersOne.Epub.Test.Unit.Root
         private const string AUDIO_MPEG_CONTENT_MIME_TYPE = "audio/mpeg";
         private const string AUDIO_FILE_NAME = "audio.mp3";
         private const string AUDIO_FILE_PATH = $"{CONTENT_DIRECTORY_PATH}/{AUDIO_FILE_NAME}";
+        private const string REMOTE_TEXT_CONTENT_ITEM_HREF = "https://example.com/books/123/test.html";
+        private const string REMOTE_BYTE_CONTENT_ITEM_HREF = "https://example.com/books/123/image.jpg";
         private const string BOOK_TITLE = "Test title";
         private const string BOOK_AUTHOR = "John Doe";
         private const string BOOK_DESCRIPTION = "Test description";
@@ -85,7 +87,7 @@ namespace VersOne.Epub.Test.Unit.Root
                 <dc:title>{BOOK_TITLE}</dc:title>
                 <dc:creator>{BOOK_AUTHOR}</dc:creator>
                 <dc:description>{BOOK_DESCRIPTION}</dc:description>
-            </metadata>
+              </metadata>
               <manifest>
                 <item id="item-1" href="{CHAPTER1_FILE_NAME}" media-type="{HTML_CONTENT_MIME_TYPE}" />
                 <item id="item-2" href="{CHAPTER2_FILE_NAME}" media-type="{HTML_CONTENT_MIME_TYPE}" />
@@ -96,6 +98,8 @@ namespace VersOne.Epub.Test.Unit.Root
                 <item id="item-7" href="{FONT1_FILE_NAME}" media-type="{FONT_CONTENT_MIME_TYPE}" />
                 <item id="item-8" href="{FONT2_FILE_NAME}" media-type="{FONT_CONTENT_MIME_TYPE}" />
                 <item id="item-9" href="{AUDIO_FILE_NAME}" media-type="{AUDIO_MPEG_CONTENT_MIME_TYPE}" />
+                <item id="item-10" href="{REMOTE_TEXT_CONTENT_ITEM_HREF}" media-type="{HTML_CONTENT_MIME_TYPE}" />
+                <item id="item-11" href="{REMOTE_BYTE_CONTENT_ITEM_HREF}" media-type="{IMAGE_CONTENT_MIME_TYPE}" />
                 <item id="item-toc" href="{NAV_FILE_NAME}" media-type="{HTML_CONTENT_MIME_TYPE}" properties="nav" />
                 <item id="item-cover" href="{COVER_FILE_NAME}" media-type="{IMAGE_CONTENT_MIME_TYPE}" properties="cover-image" />
                 <item id="ncx" href="{NCX_FILE_NAME}" media-type="{NCX_CONTENT_MIME_TYPE}" />
@@ -406,7 +410,7 @@ namespace VersOne.Epub.Test.Unit.Root
                     Cover = null
                 }
             };
-            EpubTextContentFileRef navFileRef = new(result, NAV_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef navFileRef = new(result, NAV_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
             result.Content.Html[NAV_FILE_NAME] = navFileRef;
             result.Content.AllFiles[NAV_FILE_NAME] = navFileRef;
             result.Content.NavigationHtmlFile = navFileRef;
@@ -419,6 +423,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = NAV_FILE_NAME,
                 FilePathInEpubArchive = NAV_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = HTML_CONTENT_TYPE,
                 ContentMimeType = HTML_CONTENT_MIME_TYPE,
                 Content = MINIMAL_NAV_FILE_CONTENT
@@ -528,18 +534,20 @@ namespace VersOne.Epub.Test.Unit.Root
                 Description = BOOK_DESCRIPTION,
                 Schema = CreateFullExpectedEpubSchema()
             };
-            EpubTextContentFileRef chapter1FileRef = new(result, CHAPTER1_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef chapter2FileRef = new(result, CHAPTER2_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef styles1FileRef = new(result, STYLES1_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef styles2FileRef = new(result, STYLES2_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef image1FileRef = new(result, IMAGE1_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef image2FileRef = new(result, IMAGE2_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef font1FileRef = new(result, FONT1_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef font2FileRef = new(result, FONT2_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef audioFileRef = new(result, AUDIO_FILE_NAME, OTHER_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef navFileRef = new(result, NAV_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef coverFileRef = new(result, COVER_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef ncxFileRef = new(result, NCX_FILE_NAME, NCX_CONTENT_TYPE, NCX_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef chapter1FileRef = new(result, CHAPTER1_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef chapter2FileRef = new(result, CHAPTER2_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef styles1FileRef = new(result, STYLES1_FILE_NAME, EpubContentLocation.LOCAL, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef styles2FileRef = new(result, STYLES2_FILE_NAME, EpubContentLocation.LOCAL, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef image1FileRef = new(result, IMAGE1_FILE_NAME, EpubContentLocation.LOCAL, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef image2FileRef = new(result, IMAGE2_FILE_NAME, EpubContentLocation.LOCAL, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef font1FileRef = new(result, FONT1_FILE_NAME, EpubContentLocation.LOCAL, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef font2FileRef = new(result, FONT2_FILE_NAME, EpubContentLocation.LOCAL, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef audioFileRef = new(result, AUDIO_FILE_NAME, EpubContentLocation.LOCAL, OTHER_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef remoteTextContentItemRef = new(result, REMOTE_TEXT_CONTENT_ITEM_HREF, EpubContentLocation.REMOTE, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef remoteByteContentItemRef = new(result, REMOTE_BYTE_CONTENT_ITEM_HREF, EpubContentLocation.REMOTE, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef navFileRef = new(result, NAV_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef coverFileRef = new(result, COVER_FILE_NAME, EpubContentLocation.LOCAL, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef ncxFileRef = new(result, NCX_FILE_NAME, EpubContentLocation.LOCAL, NCX_CONTENT_TYPE, NCX_CONTENT_MIME_TYPE);
             result.Content = new EpubContentRef()
             {
                 Html = new Dictionary<string, EpubTextContentFileRef>()
@@ -551,6 +559,10 @@ namespace VersOne.Epub.Test.Unit.Root
                     {
                         CHAPTER2_FILE_NAME,
                         chapter2FileRef
+                    },
+                    {
+                        REMOTE_TEXT_CONTENT_ITEM_HREF,
+                        remoteTextContentItemRef
                     },
                     {
                         NAV_FILE_NAME,
@@ -577,6 +589,10 @@ namespace VersOne.Epub.Test.Unit.Root
                     {
                         IMAGE2_FILE_NAME,
                         image2FileRef
+                    },
+                    {
+                        REMOTE_BYTE_CONTENT_ITEM_HREF,
+                        remoteByteContentItemRef
                     },
                     {
                         COVER_FILE_NAME,
@@ -633,6 +649,14 @@ namespace VersOne.Epub.Test.Unit.Root
                         audioFileRef
                     },
                     {
+                        REMOTE_TEXT_CONTENT_ITEM_HREF,
+                        remoteTextContentItemRef
+                    },
+                    {
+                        REMOTE_BYTE_CONTENT_ITEM_HREF,
+                        remoteByteContentItemRef
+                    },
+                    {
                         NAV_FILE_NAME,
                         navFileRef
                     },
@@ -657,6 +681,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = CHAPTER1_FILE_NAME,
                 FilePathInEpubArchive = CHAPTER1_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = HTML_CONTENT_TYPE,
                 ContentMimeType = HTML_CONTENT_MIME_TYPE,
                 Content = CHAPTER1_FILE_CONTENT
@@ -665,6 +691,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = CHAPTER2_FILE_NAME,
                 FilePathInEpubArchive = CHAPTER2_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = HTML_CONTENT_TYPE,
                 ContentMimeType = HTML_CONTENT_MIME_TYPE,
                 Content = CHAPTER2_FILE_CONTENT
@@ -673,6 +701,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = STYLES1_FILE_NAME,
                 FilePathInEpubArchive = STYLES1_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = CSS_CONTENT_TYPE,
                 ContentMimeType = CSS_CONTENT_MIME_TYPE,
                 Content = STYLES1_FILE_CONTENT
@@ -681,6 +711,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = STYLES2_FILE_NAME,
                 FilePathInEpubArchive = STYLES2_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = CSS_CONTENT_TYPE,
                 ContentMimeType = CSS_CONTENT_MIME_TYPE,
                 Content = STYLES2_FILE_CONTENT
@@ -689,6 +721,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = IMAGE1_FILE_NAME,
                 FilePathInEpubArchive = IMAGE1_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = IMAGE_CONTENT_TYPE,
                 ContentMimeType = IMAGE_CONTENT_MIME_TYPE,
                 Content = IMAGE1_FILE_CONTENT
@@ -697,6 +731,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = IMAGE2_FILE_NAME,
                 FilePathInEpubArchive = IMAGE2_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = IMAGE_CONTENT_TYPE,
                 ContentMimeType = IMAGE_CONTENT_MIME_TYPE,
                 Content = IMAGE2_FILE_CONTENT
@@ -705,6 +741,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = FONT1_FILE_NAME,
                 FilePathInEpubArchive = FONT1_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = FONT_CONTENT_TYPE,
                 ContentMimeType = FONT_CONTENT_MIME_TYPE,
                 Content = FONT1_FILE_CONTENT
@@ -713,6 +751,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = FONT2_FILE_NAME,
                 FilePathInEpubArchive = FONT2_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = FONT_CONTENT_TYPE,
                 ContentMimeType = FONT_CONTENT_MIME_TYPE,
                 Content = FONT2_FILE_CONTENT
@@ -721,14 +761,38 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = AUDIO_FILE_NAME,
                 FilePathInEpubArchive = AUDIO_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = OTHER_CONTENT_TYPE,
                 ContentMimeType = AUDIO_MPEG_CONTENT_MIME_TYPE,
                 Content = AUDIO_FILE_CONTENT
+            };
+            EpubTextContentFile remoteTextContentItem = new()
+            {
+                FileName = null,
+                FilePathInEpubArchive = null,
+                Href = REMOTE_TEXT_CONTENT_ITEM_HREF,
+                ContentLocation = EpubContentLocation.REMOTE,
+                ContentType = HTML_CONTENT_TYPE,
+                ContentMimeType = HTML_CONTENT_MIME_TYPE,
+                Content = null
+            };
+            EpubByteContentFile remoteByteContentItem = new()
+            {
+                FileName = null,
+                FilePathInEpubArchive = null,
+                Href = REMOTE_BYTE_CONTENT_ITEM_HREF,
+                ContentLocation = EpubContentLocation.REMOTE,
+                ContentType = IMAGE_CONTENT_TYPE,
+                ContentMimeType = IMAGE_CONTENT_MIME_TYPE,
+                Content = null
             };
             EpubTextContentFile navFile = new()
             {
                 FileName = NAV_FILE_NAME,
                 FilePathInEpubArchive = NAV_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = HTML_CONTENT_TYPE,
                 ContentMimeType = HTML_CONTENT_MIME_TYPE,
                 Content = FULL_NAV_FILE_CONTENT
@@ -737,6 +801,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = COVER_FILE_NAME,
                 FilePathInEpubArchive = COVER_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = IMAGE_CONTENT_TYPE,
                 ContentMimeType = IMAGE_CONTENT_MIME_TYPE,
                 Content = COVER_FILE_CONTENT
@@ -745,6 +811,8 @@ namespace VersOne.Epub.Test.Unit.Root
             {
                 FileName = NCX_FILE_NAME,
                 FilePathInEpubArchive = NCX_FILE_PATH,
+                Href = null,
+                ContentLocation = EpubContentLocation.LOCAL,
                 ContentType = NCX_CONTENT_TYPE,
                 ContentMimeType = NCX_CONTENT_MIME_TYPE,
                 Content = NCX_FILE_CONTENT
@@ -793,6 +861,10 @@ namespace VersOne.Epub.Test.Unit.Root
                             chapter2File
                         },
                         {
+                            REMOTE_TEXT_CONTENT_ITEM_HREF,
+                            remoteTextContentItem
+                        },
+                        {
                             NAV_FILE_NAME,
                             navFile
                         }
@@ -817,6 +889,10 @@ namespace VersOne.Epub.Test.Unit.Root
                         {
                             IMAGE2_FILE_NAME,
                             image2File
+                        },
+                        {
+                            REMOTE_BYTE_CONTENT_ITEM_HREF,
+                            remoteByteContentItem
                         },
                         {
                             COVER_FILE_NAME,
@@ -871,6 +947,14 @@ namespace VersOne.Epub.Test.Unit.Root
                         {
                             AUDIO_FILE_NAME,
                             audioFile
+                        },
+                        {
+                            REMOTE_TEXT_CONTENT_ITEM_HREF,
+                            remoteTextContentItem
+                        },
+                        {
+                            REMOTE_BYTE_CONTENT_ITEM_HREF,
+                            remoteByteContentItem
                         },
                         {
                             NAV_FILE_NAME,
@@ -984,6 +1068,18 @@ namespace VersOne.Epub.Test.Unit.Root
                                 Id = "item-9",
                                 Href = AUDIO_FILE_NAME,
                                 MediaType = AUDIO_MPEG_CONTENT_MIME_TYPE
+                            },
+                            new EpubManifestItem()
+                            {
+                                Id = "item-10",
+                                Href = REMOTE_TEXT_CONTENT_ITEM_HREF,
+                                MediaType = HTML_CONTENT_MIME_TYPE
+                            },
+                            new EpubManifestItem()
+                            {
+                                Id = "item-11",
+                                Href = REMOTE_BYTE_CONTENT_ITEM_HREF,
+                                MediaType = IMAGE_CONTENT_MIME_TYPE
                             },
                             new EpubManifestItem()
                             {

--- a/Source/VersOne.Epub/Entities/EpubByteContentFile.cs
+++ b/Source/VersOne.Epub/Entities/EpubByteContentFile.cs
@@ -7,7 +7,7 @@
     public class EpubByteContentFile : EpubContentFile
     {
         /// <summary>
-        /// Gets the content of the file.
+        /// Gets the content of the file. Returns <c>null</c> if <see cref="EpubContentFile.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         public byte[] Content { get; internal set; }
     }

--- a/Source/VersOne.Epub/Entities/EpubContent.cs
+++ b/Source/VersOne.Epub/Entities/EpubContent.cs
@@ -18,27 +18,27 @@ namespace VersOne.Epub
         public EpubTextContentFile NavigationHtmlFile { get; internal set; }
 
         /// <summary>
-        /// Gets all HTML/XHTML content files of the EPUB book keyed by their relative file paths.
+        /// Gets all HTML/XHTML content files of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubTextContentFile> Html { get; internal set; }
 
         /// <summary>
-        /// Gets all CSS files of the EPUB book keyed by their relative file paths.
+        /// Gets all CSS files of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubTextContentFile> Css { get; internal set; }
 
         /// <summary>
-        /// Gets all image files of the EPUB book keyed by their relative file paths.
+        /// Gets all image files of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubByteContentFile> Images { get; internal set; }
 
         /// <summary>
-        /// Gets all embedded font files of the EPUB book keyed by their relative file paths.
+        /// Gets all embedded font files of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubByteContentFile> Fonts { get; internal set; }
 
         /// <summary>
-        /// Gets all content files of the EPUB book keyed by their relative file paths.
+        /// Gets all content files of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubContentFile> AllFiles { get; internal set; }
     }

--- a/Source/VersOne.Epub/Entities/EpubContentFile.cs
+++ b/Source/VersOne.Epub/Entities/EpubContentFile.cs
@@ -8,13 +8,26 @@
     {
         /// <summary>
         /// Gets the relative file path of the content file (as it is specified in the EPUB manifest).
+        /// Returns <c>null</c> if <see cref="ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         public string FileName { get; internal set; }
 
         /// <summary>
         /// Gets the absolute file path of the content file in the EPUB archive.
+        /// Returns <c>null</c> if <see cref="ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         public string FilePathInEpubArchive { get; internal set; }
+
+        /// <summary>
+        /// Gets the absolute URI of the content item (as it is specified in the EPUB manifest).
+        /// Returns <c>null</c> if <see cref="ContentLocation" /> is <see cref="EpubContentLocation.LOCAL" />.
+        /// </summary>
+        public string Href { get; internal set; }
+
+        /// <summary>
+        /// Gets the location of the content item (local or remote).
+        /// </summary>
+        public EpubContentLocation ContentLocation { get; internal set; }
 
         /// <summary>
         /// Gets the type of the content of the file.

--- a/Source/VersOne.Epub/Entities/EpubContentLocation.cs
+++ b/Source/VersOne.Epub/Entities/EpubContentLocation.cs
@@ -1,0 +1,18 @@
+﻿namespace VersOne.Epub
+{
+    /// <summary>
+    /// The location of a single EPUB content item (e.g. a chapter or an image).
+    /// </summary>
+    public enum EpubContentLocation
+    {
+        /// <summary>
+        /// Content item is located inside the EPUB file.
+        /// </summary>
+        LOCAL = 1,
+
+        /// <summary>
+        /// Content item is located outside the EPUB file and available via absolute URI.
+        /// </summary>
+        REMOTE
+    }
+}

--- a/Source/VersOne.Epub/Entities/EpubTextContentFile.cs
+++ b/Source/VersOne.Epub/Entities/EpubTextContentFile.cs
@@ -7,7 +7,7 @@
     public class EpubTextContentFile : EpubContentFile
     {
         /// <summary>
-        /// Gets the content of the file.
+        /// Gets the content of the file. Returns <c>null</c> if <see cref="EpubContentFile.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         public string Content { get; internal set; }
     }

--- a/Source/VersOne.Epub/Readers/ContentReader.cs
+++ b/Source/VersOne.Epub/Readers/ContentReader.cs
@@ -18,7 +18,8 @@ namespace VersOne.Epub.Internal
             };
             foreach (EpubManifestItem manifestItem in bookRef.Schema.Package.Manifest.Items)
             {
-                string fileName = manifestItem.Href;
+                string href = manifestItem.Href;
+                EpubContentLocation contentLocation = href.Contains("://") ? EpubContentLocation.REMOTE : EpubContentLocation.LOCAL;
                 string contentMimeType = manifestItem.MediaType;
                 EpubContentType contentType = GetContentTypeByContentMimeType(contentMimeType);
                 switch (contentType)
@@ -30,38 +31,40 @@ namespace VersOne.Epub.Internal
                     case EpubContentType.XML:
                     case EpubContentType.DTBOOK:
                     case EpubContentType.DTBOOK_NCX:
-                        EpubTextContentFileRef epubTextContentFile = new EpubTextContentFileRef(bookRef, fileName, contentType, contentMimeType, contentReaderOptions);
+                        EpubTextContentFileRef epubTextContentFile =
+                            new EpubTextContentFileRef(bookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions);
                         switch (contentType)
                         {
                             case EpubContentType.XHTML_1_1:
-                                result.Html[fileName] = epubTextContentFile;
+                                result.Html[href] = epubTextContentFile;
                                 if (result.NavigationHtmlFile == null && manifestItem.Properties != null && manifestItem.Properties.Contains(EpubManifestProperty.NAV))
                                 {
                                     result.NavigationHtmlFile = epubTextContentFile;
                                 }
                                 break;
                             case EpubContentType.CSS:
-                                result.Css[fileName] = epubTextContentFile;
+                                result.Css[href] = epubTextContentFile;
                                 break;
                         }
-                        result.AllFiles[fileName] = epubTextContentFile;
+                        result.AllFiles[href] = epubTextContentFile;
                         break;
                     default:
-                        EpubByteContentFileRef epubByteContentFile = new EpubByteContentFileRef(bookRef, fileName, contentType, contentMimeType, contentReaderOptions);
+                        EpubByteContentFileRef epubByteContentFile =
+                            new EpubByteContentFileRef(bookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions);
                         switch (contentType)
                         {
                             case EpubContentType.IMAGE_GIF:
                             case EpubContentType.IMAGE_JPEG:
                             case EpubContentType.IMAGE_PNG:
                             case EpubContentType.IMAGE_SVG:
-                                result.Images[fileName] = epubByteContentFile;
+                                result.Images[href] = epubByteContentFile;
                                 break;
                             case EpubContentType.FONT_TRUETYPE:
                             case EpubContentType.FONT_OPENTYPE:
-                                result.Fonts[fileName] = epubByteContentFile;
+                                result.Fonts[href] = epubByteContentFile;
                                 break;
                         }
-                        result.AllFiles[fileName] = epubByteContentFile;
+                        result.AllFiles[href] = epubByteContentFile;
                         break;
                 }
             }

--- a/Source/VersOne.Epub/RefEntities/EpubByteContentFileRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubByteContentFileRef.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using VersOne.Epub.Options;
 
 namespace VersOne.Epub
@@ -14,17 +15,20 @@ namespace VersOne.Epub
         /// and a MIME type of the file's content.
         /// </summary>
         /// <param name="epubBookRef">EPUB book reference object which contains this content file reference.</param>
-        /// <param name="fileName">Relative file path of the content file (as it is specified in the EPUB manifest).</param>
+        /// <param name="href">Relative file path or absolute URI of the content item (as it is specified in the EPUB manifest).</param>
+        /// <param name="contentLocation">Location of the content item (local or remote).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
         /// <param name="contentReaderOptions">Optional content reader options determining how to handle missing content files.</param>
-        public EpubByteContentFileRef(EpubBookRef epubBookRef, string fileName, EpubContentType contentType, string contentMimeType, ContentReaderOptions contentReaderOptions = null)
-            : base(epubBookRef, fileName, contentType, contentMimeType, contentReaderOptions)
+        public EpubByteContentFileRef(EpubBookRef epubBookRef, string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType,
+            ContentReaderOptions contentReaderOptions = null)
+            : base(epubBookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions)
         {
         }
 
         /// <summary>
         /// Reads the whole content of the referenced file and returns it as a byte array.
+        /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         /// <returns>Content of the referenced file.</returns>
         public byte[] ReadContent()
@@ -34,6 +38,7 @@ namespace VersOne.Epub
 
         /// <summary>
         /// Asynchronously reads the whole content of the referenced file and returns it as a byte array.
+        /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation. The value of the TResult parameter contains the content of the referenced file.</returns>
         public Task<byte[]> ReadContentAsync()

--- a/Source/VersOne.Epub/RefEntities/EpubContentRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubContentRef.cs
@@ -18,27 +18,27 @@ namespace VersOne.Epub
         public EpubTextContentFileRef NavigationHtmlFile { get; internal set; }
 
         /// <summary>
-        /// Gets all HTML/XHTML content file references of the EPUB book keyed by their relative file paths.
+        /// Gets all HTML/XHTML content file references of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubTextContentFileRef> Html { get; internal set; }
 
         /// <summary>
-        /// Gets all CSS file references of the EPUB book keyed by their relative file paths.
+        /// Gets all CSS file references of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubTextContentFileRef> Css { get; internal set; }
 
         /// <summary>
-        /// Gets all image file references of the EPUB book keyed by their relative file paths.
+        /// Gets all image file references of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubByteContentFileRef> Images { get; internal set; }
 
         /// <summary>
-        /// Gets all embedded font file references of the EPUB book keyed by their relative file paths.
+        /// Gets all embedded font file references of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubByteContentFileRef> Fonts { get; internal set; }
 
         /// <summary>
-        /// Gets all content file references of the EPUB book keyed by their relative file paths.
+        /// Gets all content file references of the EPUB book keyed by their relative file paths (for local content) or absolute URIs (for remote content).
         /// </summary>
         public Dictionary<string, EpubContentFileRef> AllFiles { get; internal set; }
     }

--- a/Source/VersOne.Epub/RefEntities/EpubTextContentFileRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubTextContentFileRef.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using VersOne.Epub.Options;
 
 namespace VersOne.Epub
@@ -14,17 +15,20 @@ namespace VersOne.Epub
         /// and a MIME type of the file's content.
         /// </summary>
         /// <param name="epubBookRef">EPUB book reference object which contains this content file reference.</param>
-        /// <param name="fileName">Relative file path of the content file (as it is specified in the EPUB manifest).</param>
+        /// <param name="href">Relative file path or absolute URI of the content item (as it is specified in the EPUB manifest).</param>
+        /// <param name="contentLocation">Location of the content item (local or remote).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
         /// <param name="contentReaderOptions">Optional content reader options determining how to handle missing content files.</param>
-        public EpubTextContentFileRef(EpubBookRef epubBookRef, string fileName, EpubContentType contentType, string contentMimeType, ContentReaderOptions contentReaderOptions = null)
-            : base(epubBookRef, fileName, contentType, contentMimeType, contentReaderOptions)
+        public EpubTextContentFileRef(EpubBookRef epubBookRef, string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType,
+            ContentReaderOptions contentReaderOptions = null)
+            : base(epubBookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions)
         {
         }
 
         /// <summary>
         /// Reads the whole content of the referenced file and returns it as a string.
+        /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         /// <returns>Content of the referenced file.</returns>
         public string ReadContent()
@@ -34,6 +38,7 @@ namespace VersOne.Epub
 
         /// <summary>
         /// Asynchronously reads the whole content of the referenced file and returns it as a string.
+        /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation. The value of the TResult parameter contains the content of the referenced file.</returns>
         public Task<string> ReadContentAsync()

--- a/Source/VersOne.Epub/Utils/TaskExtensionMethods.cs
+++ b/Source/VersOne.Epub/Utils/TaskExtensionMethods.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace VersOne.Epub.Utils
+{
+    internal static class TaskExtensionMethods
+    {
+        public static T ExecuteAndUnwrapAggregateException<T>(this Task<T> task)
+        {
+            try
+            {
+                return task.Result;
+            }
+            catch (AggregateException aggregateException)
+            {
+                throw aggregateException.InnerException;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Remote manifest items support

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #61

## Description

This pull request adds support for remote manifest items (i.e. files referenced by absolute URLs like `http://example.com/book/123/chapter1.html` as opposed to local files like `Content/chapter1.html` which are packaged within the EPUB file).

## Testing steps

Try to open a EPUB book with the following manifest items:
```xml
<manifest>
  <item id="item-1" href="https://example.com/books/123/test.html" media-type="application/xhtml+xml" />
  <item id="item-2" href="https://example.com/books/123/image.jpg" media-type="image/jpeg" />
  ...
</manifest>
```