### PR TITLE
Decouple EpubContentFileRef from EpubBookRef

### DIFF
--- a/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
@@ -35,7 +35,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 Href = "cover.jpg",
                 MediaType = "image/jpeg"
             });
-            EpubByteContentFileRef expectedCoverImageFileRef = CreateTestImageFileRef(epubBookRef);
+            EpubByteContentFileRef expectedCoverImageFileRef = CreateTestImageFileRef();
             TestSuccessfulReadOperation(epubBookRef, expectedCoverImageFileRef);
         }
 
@@ -54,7 +54,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubByteContentFileRef expectedCoverImageFileRef = CreateTestImageFileRef(epubBookRef);
+            EpubByteContentFileRef expectedCoverImageFileRef = CreateTestImageFileRef();
             TestSuccessfulReadOperation(epubBookRef, expectedCoverImageFileRef);
         }
 
@@ -72,7 +72,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     EpubManifestProperty.COVER_IMAGE
                 }
             });
-            EpubByteContentFileRef expectedCoverImageFileRef = CreateTestImageFileRef(epubBookRef);
+            EpubByteContentFileRef expectedCoverImageFileRef = CreateTestImageFileRef();
             TestSuccessfulReadOperation(epubBookRef, expectedCoverImageFileRef);
         }
 
@@ -303,9 +303,9 @@ namespace VersOne.Epub.Test.Unit.Readers
             };
         }
 
-        private EpubByteContentFileRef CreateTestImageFileRef(EpubBookRef epubBookRef)
+        private EpubByteContentFileRef CreateTestImageFileRef()
         {
-            return new(epubBookRef, "cover.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg");
+            return new("cover.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg", String.Empty);
         }
 
         private Dictionary<string, EpubByteContentFileRef> CreateImageContentRefs(EpubByteContentFileRef imageFileRef)

--- a/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
@@ -164,28 +164,28 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef expectedFileRef1 = new(epubBookRef, "text.html", EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
-            EpubTextContentFileRef expectedFileRef2 = new(epubBookRef, "doc.dtb", EpubContentLocation.LOCAL, EpubContentType.DTBOOK, "application/x-dtbook+xml");
-            EpubTextContentFileRef expectedFileRef3 = new(epubBookRef, "toc.ncx", EpubContentLocation.LOCAL, EpubContentType.DTBOOK_NCX, "application/x-dtbncx+xml");
-            EpubTextContentFileRef expectedFileRef4 = new(epubBookRef, "oeb.html", EpubContentLocation.LOCAL, EpubContentType.OEB1_DOCUMENT, "text/x-oeb1-document");
-            EpubTextContentFileRef expectedFileRef5 = new(epubBookRef, "file.xml", EpubContentLocation.LOCAL, EpubContentType.XML, "application/xml");
-            EpubTextContentFileRef expectedFileRef6 = new(epubBookRef, "styles.css", EpubContentLocation.LOCAL, EpubContentType.CSS, "text/css");
-            EpubTextContentFileRef expectedFileRef7 = new(epubBookRef, "oeb.css", EpubContentLocation.LOCAL, EpubContentType.OEB1_CSS, "text/x-oeb1-css");
-            EpubByteContentFileRef expectedFileRef8 = new(epubBookRef, "image1.gif", EpubContentLocation.LOCAL, EpubContentType.IMAGE_GIF, "image/gif");
-            EpubByteContentFileRef expectedFileRef9 = new(epubBookRef, "image2.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg");
-            EpubByteContentFileRef expectedFileRef10 = new(epubBookRef, "image3.png", EpubContentLocation.LOCAL, EpubContentType.IMAGE_PNG, "image/png");
-            EpubByteContentFileRef expectedFileRef11 = new(epubBookRef, "image4.svg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_SVG, "image/svg+xml");
-            EpubByteContentFileRef expectedFileRef12 = new(epubBookRef, "font1.ttf", EpubContentLocation.LOCAL, EpubContentType.FONT_TRUETYPE, "font/truetype");
-            EpubByteContentFileRef expectedFileRef13 = new(epubBookRef, "font2.ttf", EpubContentLocation.LOCAL, EpubContentType.FONT_TRUETYPE, "application/x-font-truetype");
-            EpubByteContentFileRef expectedFileRef14 = new(epubBookRef, "font3.otf", EpubContentLocation.LOCAL, EpubContentType.FONT_OPENTYPE, "font/opentype");
-            EpubByteContentFileRef expectedFileRef15 = new(epubBookRef, "font4.otf", EpubContentLocation.LOCAL, EpubContentType.FONT_OPENTYPE, "application/vnd.ms-opentype");
-            EpubByteContentFileRef expectedFileRef16 = new(epubBookRef, "video.mp4", EpubContentLocation.LOCAL, EpubContentType.OTHER, "video/mp4");
-            EpubByteContentFileRef expectedFileRef17 = new(epubBookRef, "cover.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg");
-            EpubTextContentFileRef expectedFileRef18 = new(epubBookRef, "toc.html", EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubTextContentFileRef expectedFileRef1 = CreateLocalTextFileRef("text.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubTextContentFileRef expectedFileRef2 = CreateLocalTextFileRef("doc.dtb", EpubContentType.DTBOOK, "application/x-dtbook+xml");
+            EpubTextContentFileRef expectedFileRef3 = CreateLocalTextFileRef("toc.ncx", EpubContentType.DTBOOK_NCX, "application/x-dtbncx+xml");
+            EpubTextContentFileRef expectedFileRef4 = CreateLocalTextFileRef("oeb.html", EpubContentType.OEB1_DOCUMENT, "text/x-oeb1-document");
+            EpubTextContentFileRef expectedFileRef5 = CreateLocalTextFileRef("file.xml", EpubContentType.XML, "application/xml");
+            EpubTextContentFileRef expectedFileRef6 = CreateLocalTextFileRef("styles.css", EpubContentType.CSS, "text/css");
+            EpubTextContentFileRef expectedFileRef7 = CreateLocalTextFileRef("oeb.css", EpubContentType.OEB1_CSS, "text/x-oeb1-css");
+            EpubByteContentFileRef expectedFileRef8 = CreateLocalByteFileRef("image1.gif", EpubContentType.IMAGE_GIF, "image/gif");
+            EpubByteContentFileRef expectedFileRef9 = CreateLocalByteFileRef("image2.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
+            EpubByteContentFileRef expectedFileRef10 = CreateLocalByteFileRef("image3.png", EpubContentType.IMAGE_PNG, "image/png");
+            EpubByteContentFileRef expectedFileRef11 = CreateLocalByteFileRef("image4.svg", EpubContentType.IMAGE_SVG, "image/svg+xml");
+            EpubByteContentFileRef expectedFileRef12 = CreateLocalByteFileRef("font1.ttf", EpubContentType.FONT_TRUETYPE, "font/truetype");
+            EpubByteContentFileRef expectedFileRef13 = CreateLocalByteFileRef("font2.ttf", EpubContentType.FONT_TRUETYPE, "application/x-font-truetype");
+            EpubByteContentFileRef expectedFileRef14 = CreateLocalByteFileRef("font3.otf", EpubContentType.FONT_OPENTYPE, "font/opentype");
+            EpubByteContentFileRef expectedFileRef15 = CreateLocalByteFileRef("font4.otf", EpubContentType.FONT_OPENTYPE, "application/vnd.ms-opentype");
+            EpubByteContentFileRef expectedFileRef16 = CreateLocalByteFileRef("video.mp4", EpubContentType.OTHER, "video/mp4");
+            EpubByteContentFileRef expectedFileRef17 = CreateLocalByteFileRef("cover.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
+            EpubTextContentFileRef expectedFileRef18 = CreateLocalTextFileRef("toc.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
             EpubTextContentFileRef expectedFileRef19 =
-                new(epubBookRef, "https://example.com/books/123/test.html", EpubContentLocation.REMOTE, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+                new("https://example.com/books/123/test.html", EpubContentLocation.REMOTE, EpubContentType.XHTML_1_1, "application/xhtml+xml", String.Empty);
             EpubByteContentFileRef expectedFileRef20 =
-                new(epubBookRef, "https://example.com/books/123/image.jpg", EpubContentLocation.REMOTE, EpubContentType.IMAGE_JPEG, "image/jpeg");
+                new("https://example.com/books/123/image.jpg", EpubContentLocation.REMOTE, EpubContentType.IMAGE_JPEG, "image/jpeg", String.Empty);
             EpubContentRef expectedContentMap = new()
             {
                 Html = new Dictionary<string, EpubTextContentFileRef>()
@@ -382,6 +382,16 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
+        }
+
+        private EpubTextContentFileRef CreateLocalTextFileRef(string href, EpubContentType contentType, string contentMimeType)
+        {
+            return new(href, EpubContentLocation.LOCAL, contentType, contentMimeType, String.Empty);
+        }
+
+        private EpubByteContentFileRef CreateLocalByteFileRef(string href, EpubContentType contentType, string contentMimeType)
+        {
+            return new(href, EpubContentLocation.LOCAL, contentType, contentMimeType, String.Empty);
         }
     }
 }

--- a/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
@@ -110,7 +110,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile(epubBookRef, "chapter1.html");
+            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile("chapter1.html");
             epubBookRef.Content = CreateContentRef(null, testTextContentFileRef);
             EpubNavigationItemRef expectedNavigationItem1 = CreateNavigationLink("Test label 1", "chapter1.html", testTextContentFileRef);
             EpubNavigationItemRef expectedNavigationItem2 = CreateNavigationLink("Test label 3", "chapter1.html#section-1", testTextContentFileRef);
@@ -229,9 +229,9 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(epubBookRef);
-            EpubTextContentFileRef testTextContentFileRef1 = CreateTestHtmlFile(epubBookRef, "chapter1.html");
-            EpubTextContentFileRef testTextContentFileRef2 = CreateTestHtmlFile(epubBookRef, "chapter2.html");
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
+            EpubTextContentFileRef testTextContentFileRef1 = CreateTestHtmlFile("chapter1.html");
+            EpubTextContentFileRef testTextContentFileRef2 = CreateTestHtmlFile("chapter2.html");
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef, testTextContentFileRef1, testTextContentFileRef2);
             EpubNavigationItemRef expectedNavigationItem1 = CreateNavigationHeader("Test header");
             EpubNavigationItemRef expectedNavigationItem2 = CreateNavigationLink("Test text 1", "chapter1.html", testTextContentFileRef1);
@@ -289,8 +289,8 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(epubBookRef);
-            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile(epubBookRef, "chapter1.html");
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
+            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile("chapter1.html");
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef, testTextContentFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
@@ -336,7 +336,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(epubBookRef);
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new();
             List<EpubNavigationItemRef> actualNavigationItems = NavigationReader.GetNavigationItems(epubBookRef);
@@ -391,7 +391,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(epubBookRef);
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
@@ -544,8 +544,8 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(epubBookRef);
-            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile(epubBookRef, "chapter1.html");
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
+            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile("chapter1.html");
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef, testTextContentFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
@@ -566,14 +566,14 @@ namespace VersOne.Epub.Test.Unit.Readers
             EpubNavigationItemRefComparer.CompareNavigationItemRefLists(expectedNavigationItems, actualNavigationItems);
         }
 
-        private EpubTextContentFileRef CreateTestNavigationFile(EpubBookRef epubBookRef)
+        private EpubTextContentFileRef CreateTestNavigationFile()
         {
-            return CreateTestHtmlFile(epubBookRef, "toc.html");
+            return CreateTestHtmlFile("toc.html");
         }
 
-        private EpubTextContentFileRef CreateTestHtmlFile(EpubBookRef epubBookRef, string htmlFileName)
+        private EpubTextContentFileRef CreateTestHtmlFile(string htmlFileName)
         {
-            return new(epubBookRef, htmlFileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            return new(htmlFileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", CONTENT_DIRECTORY_PATH);
         }
 
         private EpubNavigationItemRef CreateNavigationLink(string title, string htmlFileUrl, EpubTextContentFileRef htmlFileRef)

--- a/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
@@ -51,8 +51,8 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef expectedHtmlFileRef1 = CreateTestHtmlFileRef(epubBookRef, "chapter1.html");
-            EpubTextContentFileRef expectedHtmlFileRef2 = CreateTestHtmlFileRef(epubBookRef, "chapter2.html");
+            EpubTextContentFileRef expectedHtmlFileRef1 = CreateTestHtmlFileRef("chapter1.html");
+            EpubTextContentFileRef expectedHtmlFileRef2 = CreateTestHtmlFileRef("chapter2.html");
             epubBookRef.Content.Html = new Dictionary<string, EpubTextContentFileRef>()
             {
                 {
@@ -174,9 +174,9 @@ namespace VersOne.Epub.Test.Unit.Readers
             };
         }
 
-        private EpubTextContentFileRef CreateTestHtmlFileRef(EpubBookRef epubBookRef, string fileName)
+        private EpubTextContentFileRef CreateTestHtmlFileRef(string fileName)
         {
-            return new(epubBookRef, fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            return new(fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", String.Empty);
         }
     }
 }

--- a/Source/VersOne.Epub.Test/Unit/RefEntities/EpubBookRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/RefEntities/EpubBookRefTests.cs
@@ -148,7 +148,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(COVER_FILE_PATH, coverFileContent);
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile, EpubVersion.EPUB_3);
-            epubBookRef.Content.Cover = new EpubByteContentFileRef(epubBookRef, COVER_FILE_NAME, EpubContentLocation.LOCAL, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE);
+            epubBookRef.Content.Cover =
+                new EpubByteContentFileRef(COVER_FILE_NAME, EpubContentLocation.LOCAL, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
             return epubBookRef;
         }
 
@@ -177,7 +178,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
                     }
                 }
             };
-            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(epubBookRef, htmlFileName);
+            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName);
             epubBookRef.Content.Html = new Dictionary<string, EpubTextContentFileRef>()
             {
                 {
@@ -215,10 +216,10 @@ namespace VersOne.Epub.Test.Unit.RefEntities
                     }
                 }
             };
-            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(epubBookRef, htmlFileName);
+            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName);
             epubBookRef.Content = new EpubContentRef()
             {
-                NavigationHtmlFile = CreateTestHtmlFileRef(epubBookRef, "toc.html"),
+                NavigationHtmlFile = CreateTestHtmlFileRef("toc.html"),
                 Html = new Dictionary<string, EpubTextContentFileRef>()
                 {
                     {
@@ -267,9 +268,9 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             };
         }
 
-        private EpubTextContentFileRef CreateTestHtmlFileRef(EpubBookRef epubBookRef, string fileName)
+        private EpubTextContentFileRef CreateTestHtmlFileRef(string fileName)
         {
-            return new(epubBookRef, fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            return new(fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", CONTENT_DIRECTORY_PATH);
         }
 
         private EpubNavigationItemRef CreateTestNavigationLink(string title, string htmlFileUrl, EpubTextContentFileRef htmlFileRef)

--- a/Source/VersOne.Epub.Test/Unit/RefEntities/EpubContentFileRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/RefEntities/EpubContentFileRefTests.cs
@@ -24,10 +24,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "EpubTextContentFileRef with ContentLocation = LOCAL should have non-null FileName and FilePathInEpubArchive properties and null Href property")]
         public void LocalTextContentItemPropertiesTest()
         {
-            TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubTextContentFileRef epubTextContentFileRef =
-                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
             Assert.Equal(LOCAL_TEXT_FILE_NAME, epubTextContentFileRef.FileName);
             Assert.Equal(TEXT_FILE_PATH, epubTextContentFileRef.FilePathInEpubArchive);
             Assert.Null(epubTextContentFileRef.Href);
@@ -36,10 +34,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "EpubByteContentFileRef with ContentLocation = LOCAL should have non-null FileName and FilePathInEpubArchive properties and null Href property")]
         public void LocalByteContentItemPropertiesTest()
         {
-            TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubByteContentFileRef epubByteContentFileRef =
-                new(epubBookRef, LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+                new(LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
             Assert.Equal(LOCAL_BYTE_FILE_NAME, epubByteContentFileRef.FileName);
             Assert.Equal(BYTE_FILE_PATH, epubByteContentFileRef.FilePathInEpubArchive);
             Assert.Null(epubByteContentFileRef.Href);
@@ -48,10 +44,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "EpubTextContentFileRef with ContentLocation = REMOTE should have null FileName and FilePathInEpubArchive properties and non-null Href property")]
         public void RemoteTextContentItemPropertiesTest()
         {
-            TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubTextContentFileRef epubTextContentFileRef =
-                new(epubBookRef, REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+                new(REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
             Assert.Equal(REMOTE_TEXT_CONTENT_HREF, epubTextContentFileRef.Href);
             Assert.Null(epubTextContentFileRef.FileName);
             Assert.Null(epubTextContentFileRef.FilePathInEpubArchive);
@@ -60,10 +54,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "EpubByteContentFileRef with ContentLocation = REMOTE should have null FileName and FilePathInEpubArchive properties and non-null Href property")]
         public void RemoteByteContentItemPropertiesTest()
         {
-            TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubByteContentFileRef epubByteContentFileRef =
-                new(epubBookRef, REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+                new(REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
             Assert.Equal(REMOTE_BYTE_CONTENT_HREF, epubByteContentFileRef.Href);
             Assert.Null(epubByteContentFileRef.FileName);
             Assert.Null(epubByteContentFileRef.FilePathInEpubArchive);
@@ -72,32 +64,36 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         [Fact(DisplayName = "Reading content of an existing text file synchronously should succeed")]
         public void ReadTextContentTest()
         {
+            TestZipFile testZipFile = CreateTestZipFileWithTextFile();
             EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
-            string textContent = epubTextContentFileRef.ReadContent();
+            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
         [Fact(DisplayName = "Reading content of an existing text file asynchronously should succeed")]
         public async void ReadTextContentAsyncTest()
         {
+            TestZipFile testZipFile = CreateTestZipFileWithTextFile();
             EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
-            string textContent = await epubTextContentFileRef.ReadContentAsync();
+            string textContent = await epubTextContentFileRef.ReadContentAsync(testZipFile);
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
         [Fact(DisplayName = "Reading content of an existing byte file synchronously should succeed")]
         public void ReadByteContentTest()
         {
+            TestZipFile testZipFile = CreateTestZipFileWithByteFile();
             EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
-            byte[] byteContent = epubByteContentFileRef.ReadContent();
+            byte[] byteContent = epubByteContentFileRef.ReadContent(testZipFile);
             Assert.Equal(BYTE_FILE_CONTENT, byteContent);
         }
 
         [Fact(DisplayName = "Reading content of an existing byte file asynchronously should succeed")]
         public async void ReadByteContentAsyncTest()
         {
+            TestZipFile testZipFile = CreateTestZipFileWithByteFile();
             EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
-            byte[] byteContent = await epubByteContentFileRef.ReadContentAsync();
+            byte[] byteContent = await epubByteContentFileRef.ReadContentAsync(testZipFile);
             Assert.Equal(BYTE_FILE_CONTENT, byteContent);
         }
 
@@ -105,18 +101,18 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public void GetContentStreamWithEmptyFileNameTest()
         {
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, String.Empty, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
-            Assert.Throws<EpubPackageException>(() => epubTextContentFileRef.GetContentStream());
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(String.Empty, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            Assert.Throws<EpubPackageException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
         }
 
         [Fact(DisplayName = "GetContentStream should throw EpubContentException if the file is missing in the EPUB archive")]
         public void GetContentStreamWithMissingFileTest()
         {
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
-            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
         }
 
         [Fact(DisplayName = "GetContentStream should throw EpubContentException if the file is larger than 2 GB")]
@@ -124,9 +120,9 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(TEXT_FILE_PATH, new Test4GbZipFileEntry());
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            EpubTextContentFileRef epubTextContentFileRef = new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
-            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
+            EpubTextContentFileRef epubTextContentFileRef =
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
         }
 
         [Fact(DisplayName = "EpubContentFileRef should return an empty content if the file is missing and SuppressException is true")]
@@ -135,10 +131,9 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             ContentReaderOptions contentReaderOptions = new();
             contentReaderOptions.ContentFileMissing += (sender, e) => e.SuppressException = true;
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubTextContentFileRef epubTextContentFileRef =
-                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
-            string textContent = epubTextContentFileRef.ReadContent();
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
             Assert.Equal(String.Empty, textContent);
         }
 
@@ -148,10 +143,9 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             ContentReaderOptions contentReaderOptions = new();
             contentReaderOptions.ContentFileMissing += (sender, e) => e.ReplacementContentStream = new MemoryStream(Encoding.UTF8.GetBytes(TEXT_FILE_CONTENT));
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubTextContentFileRef epubTextContentFileRef =
-                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
-            string textContent = epubTextContentFileRef.ReadContent();
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
@@ -161,12 +155,11 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             ContentReaderOptions contentReaderOptions = new();
             contentReaderOptions.ContentFileMissing += (sender, e) => e.ReplacementContentStream = new MemoryStream(Encoding.UTF8.GetBytes(TEXT_FILE_CONTENT));
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubTextContentFileRef epubTextContentFileRef =
-                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
-            string textContent = epubTextContentFileRef.ReadContent();
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
-            textContent = epubTextContentFileRef.ReadContent();
+            textContent = epubTextContentFileRef.ReadContent(testZipFile);
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
@@ -175,10 +168,9 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         {
             ContentReaderOptions contentReaderOptions = new();
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubTextContentFileRef epubTextContentFileRef =
-                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
-            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
         }
 
         [Fact(DisplayName = "ContentFileMissingEventArgs should contain details of the missing file")]
@@ -192,79 +184,122 @@ namespace VersOne.Epub.Test.Unit.RefEntities
                 contentFileMissingEventArgs = e;
             };
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
             EpubTextContentFileRef epubTextContentFileRef =
-                new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, contentReaderOptions);
-            epubTextContentFileRef.ReadContent();
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            epubTextContentFileRef.ReadContent(testZipFile);
             Assert.Equal(LOCAL_TEXT_FILE_NAME, contentFileMissingEventArgs.FileName);
             Assert.Equal(TEXT_FILE_PATH, contentFileMissingEventArgs.FilePathInEpubArchive);
             Assert.Equal(TEXT_FILE_CONTENT_TYPE, contentFileMissingEventArgs.ContentType);
             Assert.Equal(TEXT_FILE_CONTENT_MIME_TYPE, contentFileMissingEventArgs.ContentMimeType);
         }
 
+        [Fact(DisplayName = "ReadContent should throw ArgumentNullException if the supplied EPUB file is null")]
+        public void ReadContentForLocalTextContentItemWithNullEpubFileTest()
+        {
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
+            Assert.Throws<ArgumentNullException>(() => epubTextContentFileRef.ReadContent(null));
+        }
+
+        [Fact(DisplayName = "ReadContentAsync should throw ArgumentNullException if the supplied EPUB file is null")]
+        public async void ReadContentAsyncForLocalTextContentItemWithNullEpubFileTest()
+        {
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => epubTextContentFileRef.ReadContentAsync(null));
+        }
+
+        [Fact(DisplayName = "ReadContent should throw ArgumentNullException if the supplied EPUB file is null")]
+        public void ReadContentForLocalByteContentItemWithNullEpubFileTest()
+        {
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
+            Assert.Throws<ArgumentNullException>(() => epubByteContentFileRef.ReadContent(null));
+        }
+
+        [Fact(DisplayName = "ReadContentAsync should throw ArgumentNullException if the supplied EPUB file is null")]
+        public async void ReadContentAsyncForLocalByteContentItemWithNullEpubFileTest()
+        {
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => epubByteContentFileRef.ReadContentAsync(null));
+        }
+
+        [Fact(DisplayName = "GetContentStream should throw ArgumentNullException if the supplied EPUB file is null")]
+        public void GetContentStreamForLocalContentItemWithNullEpubFileTest()
+        {
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
+            Assert.Throws<ArgumentNullException>(() => epubTextContentFileRef.GetContentStream(null));
+        }
+
         [Fact(DisplayName = "ReadContent should throw InvalidOperationException for remote text content items")]
         public void ReadContentForRemoteTextContentItemTest()
         {
+            TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
-            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.ReadContent());
+            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.ReadContent(testZipFile));
         }
 
         [Fact(DisplayName = "ReadContentAsync should throw InvalidOperationException for remote text content items")]
         public async void ReadContentAsyncForRemoteTextContentItemTest()
         {
+            TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
-            await Assert.ThrowsAsync<InvalidOperationException>(() => epubTextContentFileRef.ReadContentAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => epubTextContentFileRef.ReadContentAsync(testZipFile));
         }
 
         [Fact(DisplayName = "ReadContent should throw InvalidOperationException for remote byte content items")]
         public void ReadContentForRemoteByteContentItemTest()
         {
+            TestZipFile testZipFile = new();
             EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef();
-            Assert.Throws<InvalidOperationException>(() => epubByteContentFileRef.ReadContent());
+            Assert.Throws<InvalidOperationException>(() => epubByteContentFileRef.ReadContent(testZipFile));
         }
 
         [Fact(DisplayName = "ReadContentAsync should throw InvalidOperationException for remote byte content items")]
         public async void ReadContentAsyncForRemoteByteContentItemTest()
         {
+            TestZipFile testZipFile = new();
             EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef();
-            await Assert.ThrowsAsync<InvalidOperationException>(() => epubByteContentFileRef.ReadContentAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => epubByteContentFileRef.ReadContentAsync(testZipFile));
         }
 
         [Fact(DisplayName = "GetContentStream should throw InvalidOperationException for remote content items")]
         public void GetContentStreamForRemoteContentItemTest()
         {
+            TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
-            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.GetContentStream());
+            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
+        }
+
+        private TestZipFile CreateTestZipFileWithTextFile()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.AddEntry(TEXT_FILE_PATH, TEXT_FILE_CONTENT);
+            return testZipFile;
+        }
+
+        private TestZipFile CreateTestZipFileWithByteFile()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.AddEntry(BYTE_FILE_PATH, BYTE_FILE_CONTENT);
+            return testZipFile;
         }
 
         private EpubTextContentFileRef CreateLocalTextContentFileRef()
         {
-            TestZipFile testZipFile = new();
-            testZipFile.AddEntry(TEXT_FILE_PATH, TEXT_FILE_CONTENT);
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            return new(epubBookRef, LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            return new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
         }
 
         private EpubByteContentFileRef CreateLocalByteContentFileRef()
         {
-            TestZipFile testZipFile = new();
-            testZipFile.AddEntry(BYTE_FILE_PATH, BYTE_FILE_CONTENT);
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            return new(epubBookRef, LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+            return new(LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
         }
 
         private EpubTextContentFileRef CreateRemoteTextContentFileRef()
         {
-            TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            return new(epubBookRef, REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
+            return new(REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
         }
 
         private EpubByteContentFileRef CreateRemoteByteContentFileRef()
         {
-            TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile);
-            return new(epubBookRef, REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE);
+            return new(REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
         }
 
         private EpubBookRef CreateEpubBookRef(TestZipFile testZipFile)

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubBookRefs.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubBookRefs.cs
@@ -25,7 +25,7 @@ namespace VersOne.Epub.Test.Unit.TestData
                     Cover = null
                 }
             };
-            EpubTextContentFileRef navFileRef = new(result, NAV_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef navFileRef = new(NAV_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
             result.Content.Html[NAV_FILE_NAME] = navFileRef;
             result.Content.AllFiles[NAV_FILE_NAME] = navFileRef;
             result.Content.NavigationHtmlFile = navFileRef;
@@ -43,20 +43,20 @@ namespace VersOne.Epub.Test.Unit.TestData
                 Description = BOOK_DESCRIPTION,
                 Schema = TestEpubSchemas.CreateFullTestEpubSchema()
             };
-            EpubTextContentFileRef chapter1FileRef = new(result, CHAPTER1_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef chapter2FileRef = new(result, CHAPTER2_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef styles1FileRef = new(result, STYLES1_FILE_NAME, EpubContentLocation.LOCAL, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef styles2FileRef = new(result, STYLES2_FILE_NAME, EpubContentLocation.LOCAL, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef image1FileRef = new(result, IMAGE1_FILE_NAME, EpubContentLocation.LOCAL, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef image2FileRef = new(result, IMAGE2_FILE_NAME, EpubContentLocation.LOCAL, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef font1FileRef = new(result, FONT1_FILE_NAME, EpubContentLocation.LOCAL, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef font2FileRef = new(result, FONT2_FILE_NAME, EpubContentLocation.LOCAL, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef audioFileRef = new(result, AUDIO_FILE_NAME, EpubContentLocation.LOCAL, OTHER_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef remoteTextContentItemRef = new(result, REMOTE_TEXT_CONTENT_ITEM_HREF, EpubContentLocation.REMOTE, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef remoteByteContentItemRef = new(result, REMOTE_BYTE_CONTENT_ITEM_HREF, EpubContentLocation.REMOTE, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef navFileRef = new(result, NAV_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef coverFileRef = new(result, COVER_FILE_NAME, EpubContentLocation.LOCAL, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef ncxFileRef = new(result, NCX_FILE_NAME, EpubContentLocation.LOCAL, NCX_CONTENT_TYPE, NCX_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef chapter1FileRef = CreateLocalTextContentFileRef(CHAPTER1_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef chapter2FileRef = CreateLocalTextContentFileRef(CHAPTER2_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef styles1FileRef = CreateLocalTextContentFileRef(STYLES1_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef styles2FileRef = CreateLocalTextContentFileRef(STYLES2_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef image1FileRef = CreateLocalByteContentFileRef(IMAGE1_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef image2FileRef = CreateLocalByteContentFileRef(IMAGE2_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef font1FileRef = CreateLocalByteContentFileRef(FONT1_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef font2FileRef = CreateLocalByteContentFileRef(FONT2_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef audioFileRef = CreateLocalByteContentFileRef(AUDIO_FILE_NAME, OTHER_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef remoteTextContentItemRef = CreateRemoteTextContentFileRef(REMOTE_TEXT_CONTENT_ITEM_HREF, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef remoteByteContentItemRef = CreateRemoteByteContentFileRef(REMOTE_BYTE_CONTENT_ITEM_HREF, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef navFileRef = CreateLocalTextContentFileRef(NAV_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef coverFileRef = CreateLocalByteContentFileRef(COVER_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef ncxFileRef = CreateLocalTextContentFileRef(NCX_FILE_NAME, NCX_CONTENT_TYPE, NCX_CONTENT_MIME_TYPE);
             result.Content = new EpubContentRef()
             {
                 Html = new Dictionary<string, EpubTextContentFileRef>()
@@ -182,6 +182,26 @@ namespace VersOne.Epub.Test.Unit.TestData
                 Cover = coverFileRef
             };
             return result;
+        }
+
+        private static EpubTextContentFileRef CreateLocalTextContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
+        {
+            return new(fileName, EpubContentLocation.LOCAL, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
+        }
+
+        private static EpubByteContentFileRef CreateLocalByteContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
+        {
+            return new(fileName, EpubContentLocation.LOCAL, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
+        }
+
+        private static EpubTextContentFileRef CreateRemoteTextContentFileRef(string href, EpubContentType contentType, string contentMimeType)
+        {
+            return new(href, EpubContentLocation.REMOTE, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
+        }
+
+        private static EpubByteContentFileRef CreateRemoteByteContentFileRef(string href, EpubContentType contentType, string contentMimeType)
+        {
+            return new(href, EpubContentLocation.REMOTE, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
         }
     }
 }

--- a/Source/VersOne.Epub/Readers/ContentReader.cs
+++ b/Source/VersOne.Epub/Readers/ContentReader.cs
@@ -22,6 +22,7 @@ namespace VersOne.Epub.Internal
                 EpubContentLocation contentLocation = href.Contains("://") ? EpubContentLocation.REMOTE : EpubContentLocation.LOCAL;
                 string contentMimeType = manifestItem.MediaType;
                 EpubContentType contentType = GetContentTypeByContentMimeType(contentMimeType);
+                string contentDirectoryPath = bookRef.Schema.ContentDirectoryPath;
                 switch (contentType)
                 {
                     case EpubContentType.XHTML_1_1:
@@ -32,7 +33,7 @@ namespace VersOne.Epub.Internal
                     case EpubContentType.DTBOOK:
                     case EpubContentType.DTBOOK_NCX:
                         EpubTextContentFileRef epubTextContentFile =
-                            new EpubTextContentFileRef(bookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions);
+                            new EpubTextContentFileRef(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions);
                         switch (contentType)
                         {
                             case EpubContentType.XHTML_1_1:
@@ -50,7 +51,7 @@ namespace VersOne.Epub.Internal
                         break;
                     default:
                         EpubByteContentFileRef epubByteContentFile =
-                            new EpubByteContentFileRef(bookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions);
+                            new EpubByteContentFileRef(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions);
                         switch (contentType)
                         {
                             case EpubContentType.IMAGE_GIF:

--- a/Source/VersOne.Epub/RefEntities/EpubBookRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubBookRef.cs
@@ -92,7 +92,7 @@ namespace VersOne.Epub
             {
                 return null;
             }
-            return await Content.Cover.ReadContentAsBytesAsync().ConfigureAwait(false);
+            return await Content.Cover.ReadContentAsBytesAsync(EpubFile).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/VersOne.Epub/RefEntities/EpubByteContentFileRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubByteContentFileRef.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using VersOne.Epub.Environment;
 using VersOne.Epub.Options;
 
 namespace VersOne.Epub
@@ -14,15 +15,15 @@ namespace VersOne.Epub
         /// Initializes a new instance of the <see cref="EpubByteContentFileRef" /> class with a specified EPUB book reference, a file name, a content type of the file,
         /// and a MIME type of the file's content.
         /// </summary>
-        /// <param name="epubBookRef">EPUB book reference object which contains this content file reference.</param>
         /// <param name="href">Relative file path or absolute URI of the content item (as it is specified in the EPUB manifest).</param>
         /// <param name="contentLocation">Location of the content item (local or remote).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
+        /// <param name="contentDirectoryPath">The content directory path which acts as a root directory for all content files within the EPUB book.</param>
         /// <param name="contentReaderOptions">Optional content reader options determining how to handle missing content files.</param>
-        public EpubByteContentFileRef(EpubBookRef epubBookRef, string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType,
+        public EpubByteContentFileRef(string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType, string contentDirectoryPath,
             ContentReaderOptions contentReaderOptions = null)
-            : base(epubBookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions)
+            : base(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions)
         {
         }
 
@@ -30,20 +31,22 @@ namespace VersOne.Epub
         /// Reads the whole content of the referenced file and returns it as a byte array.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
+        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>Content of the referenced file.</returns>
-        public byte[] ReadContent()
+        public byte[] ReadContent(IZipFile epubFile)
         {
-            return ReadContentAsBytes();
+            return ReadContentAsBytes(epubFile);
         }
 
         /// <summary>
         /// Asynchronously reads the whole content of the referenced file and returns it as a byte array.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
+        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>A task that represents the asynchronous read operation. The value of the TResult parameter contains the content of the referenced file.</returns>
-        public Task<byte[]> ReadContentAsync()
+        public Task<byte[]> ReadContentAsync(IZipFile epubFile)
         {
-            return ReadContentAsBytesAsync();
+            return ReadContentAsBytesAsync(epubFile);
         }
     }
 }

--- a/Source/VersOne.Epub/RefEntities/EpubTextContentFileRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubTextContentFileRef.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using VersOne.Epub.Environment;
 using VersOne.Epub.Options;
 
 namespace VersOne.Epub
@@ -14,15 +15,15 @@ namespace VersOne.Epub
         /// Initializes a new instance of the <see cref="EpubTextContentFileRef" /> class with a specified EPUB book reference, a file name, a content type of the file,
         /// and a MIME type of the file's content.
         /// </summary>
-        /// <param name="epubBookRef">EPUB book reference object which contains this content file reference.</param>
         /// <param name="href">Relative file path or absolute URI of the content item (as it is specified in the EPUB manifest).</param>
         /// <param name="contentLocation">Location of the content item (local or remote).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
+        /// <param name="contentDirectoryPath">The content directory path which acts as a root directory for all content files within the EPUB book.</param>
         /// <param name="contentReaderOptions">Optional content reader options determining how to handle missing content files.</param>
-        public EpubTextContentFileRef(EpubBookRef epubBookRef, string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType,
+        public EpubTextContentFileRef(string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType, string contentDirectoryPath,
             ContentReaderOptions contentReaderOptions = null)
-            : base(epubBookRef, href, contentLocation, contentType, contentMimeType, contentReaderOptions)
+            : base(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions)
         {
         }
 
@@ -30,20 +31,22 @@ namespace VersOne.Epub
         /// Reads the whole content of the referenced file and returns it as a string.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
+        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>Content of the referenced file.</returns>
-        public string ReadContent()
+        public string ReadContent(IZipFile epubFile)
         {
-            return ReadContentAsText();
+            return ReadContentAsText(epubFile);
         }
 
         /// <summary>
         /// Asynchronously reads the whole content of the referenced file and returns it as a string.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
+        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>A task that represents the asynchronous read operation. The value of the TResult parameter contains the content of the referenced file.</returns>
-        public Task<string> ReadContentAsync()
+        public Task<string> ReadContentAsync(IZipFile epubFile)
         {
-            return ReadContentAsTextAsync();
+            return ReadContentAsTextAsync(epubFile);
         }
     }
 }


### PR DESCRIPTION
# Decouple EpubContentFileRef from EpubBookRef

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #66

## Description

1. `EpubBookRef epubBookRef` argument has been replaced with `string contentDirectoryPath` in constructors of `EpubContentFileRef`, `EpubTextContentFileRef`, and `EpubByteContentFileRef` classes.
2.  `IZipFile epubFile` argument has been added to the following public methods:
    * `EpubContentFileRef.ReadContentAsBytes`
    * `EpubContentFileRef.ReadContentAsBytesAsync`
    * `EpubContentFileRef.ReadContentAsText`
    * `EpubContentFileRef.ReadContentAsTextAsync`
    * `EpubContentFileRef.GetContentStream`
    * `EpubByteContentFileRef.ReadContent`
    * `EpubByteContentFileRef.ReadContentAsync`
    * `EpubTextContentFileRef.ReadContent`
    * `EpubTextContentFileRef.ReadContentAsync`
3. Affected unit tests have been updated.

## Testing steps

All unit tests should pass.