### PR TITLE
Decouple EpubContentFileRef from EpubBookRef, part 2

### DIFF
--- a/Source/VersOne.Epub.Test/Unit/Mocks/TestZipFile.cs
+++ b/Source/VersOne.Epub.Test/Unit/Mocks/TestZipFile.cs
@@ -4,12 +4,15 @@ namespace VersOne.Epub.Test.Unit.Mocks
 {
     internal class TestZipFile : IZipFile
     {
-        readonly Dictionary<string, IZipFileEntry> entries;
+        private readonly Dictionary<string, IZipFileEntry> entries;
 
         public TestZipFile()
         {
             entries = new Dictionary<string, IZipFileEntry>();
+            IsDisposed = false;
         }
+
+        public bool IsDisposed { get; private set; }
 
         public void AddEntry(string entryName, IZipFileEntry entry)
         {
@@ -33,6 +36,7 @@ namespace VersOne.Epub.Test.Unit.Mocks
 
         public void Dispose()
         {
+            IsDisposed = true;
         }
     }
 }

--- a/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
@@ -303,9 +303,9 @@ namespace VersOne.Epub.Test.Unit.Readers
             };
         }
 
-        private EpubByteContentFileRef CreateTestImageFileRef()
+        private EpubByteContentFileRef CreateTestImageFileRef(TestZipFile testZipFile = null)
         {
-            return new("cover.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg", String.Empty);
+            return new("cover.jpg", EpubContentLocation.LOCAL, EpubContentType.IMAGE_JPEG, "image/jpeg", testZipFile ?? new TestZipFile(), String.Empty);
         }
 
         private Dictionary<string, EpubByteContentFileRef> CreateImageContentRefs(EpubByteContentFileRef imageFileRef)

--- a/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
@@ -11,7 +11,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         [Fact(DisplayName = "Parsing content map from a minimal EPUB book ref should succeed")]
         public void ParseContentMapWithMinimalEpubBookRefTest()
         {
-            EpubBookRef epubBookRef = CreateEmptyEpubBookRef();
+            EpubBookRef epubBookRef = CreateEmptyEpubBookRef(new TestZipFile());
             EpubContentRef expectedContentMap = new()
             {
                 Html = new Dictionary<string, EpubTextContentFileRef>(),
@@ -29,7 +29,8 @@ namespace VersOne.Epub.Test.Unit.Readers
         [Fact(DisplayName = "Parsing content map from a full EPUB book ref should succeed")]
         public void ParseContentMapWithFullEpubBookRefTest()
         {
-            EpubBookRef epubBookRef = CreateEmptyEpubBookRef();
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEmptyEpubBookRef(testZipFile);
             epubBookRef.Schema.Package.Manifest = new EpubManifest()
             {
                 Items = new List<EpubManifestItem>()
@@ -164,28 +165,28 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef expectedFileRef1 = CreateLocalTextFileRef("text.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
-            EpubTextContentFileRef expectedFileRef2 = CreateLocalTextFileRef("doc.dtb", EpubContentType.DTBOOK, "application/x-dtbook+xml");
-            EpubTextContentFileRef expectedFileRef3 = CreateLocalTextFileRef("toc.ncx", EpubContentType.DTBOOK_NCX, "application/x-dtbncx+xml");
-            EpubTextContentFileRef expectedFileRef4 = CreateLocalTextFileRef("oeb.html", EpubContentType.OEB1_DOCUMENT, "text/x-oeb1-document");
-            EpubTextContentFileRef expectedFileRef5 = CreateLocalTextFileRef("file.xml", EpubContentType.XML, "application/xml");
-            EpubTextContentFileRef expectedFileRef6 = CreateLocalTextFileRef("styles.css", EpubContentType.CSS, "text/css");
-            EpubTextContentFileRef expectedFileRef7 = CreateLocalTextFileRef("oeb.css", EpubContentType.OEB1_CSS, "text/x-oeb1-css");
-            EpubByteContentFileRef expectedFileRef8 = CreateLocalByteFileRef("image1.gif", EpubContentType.IMAGE_GIF, "image/gif");
-            EpubByteContentFileRef expectedFileRef9 = CreateLocalByteFileRef("image2.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
-            EpubByteContentFileRef expectedFileRef10 = CreateLocalByteFileRef("image3.png", EpubContentType.IMAGE_PNG, "image/png");
-            EpubByteContentFileRef expectedFileRef11 = CreateLocalByteFileRef("image4.svg", EpubContentType.IMAGE_SVG, "image/svg+xml");
-            EpubByteContentFileRef expectedFileRef12 = CreateLocalByteFileRef("font1.ttf", EpubContentType.FONT_TRUETYPE, "font/truetype");
-            EpubByteContentFileRef expectedFileRef13 = CreateLocalByteFileRef("font2.ttf", EpubContentType.FONT_TRUETYPE, "application/x-font-truetype");
-            EpubByteContentFileRef expectedFileRef14 = CreateLocalByteFileRef("font3.otf", EpubContentType.FONT_OPENTYPE, "font/opentype");
-            EpubByteContentFileRef expectedFileRef15 = CreateLocalByteFileRef("font4.otf", EpubContentType.FONT_OPENTYPE, "application/vnd.ms-opentype");
-            EpubByteContentFileRef expectedFileRef16 = CreateLocalByteFileRef("video.mp4", EpubContentType.OTHER, "video/mp4");
-            EpubByteContentFileRef expectedFileRef17 = CreateLocalByteFileRef("cover.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
-            EpubTextContentFileRef expectedFileRef18 = CreateLocalTextFileRef("toc.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubTextContentFileRef expectedFileRef1 = CreateLocalTextFileRef(testZipFile, "text.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
+            EpubTextContentFileRef expectedFileRef2 = CreateLocalTextFileRef(testZipFile, "doc.dtb", EpubContentType.DTBOOK, "application/x-dtbook+xml");
+            EpubTextContentFileRef expectedFileRef3 = CreateLocalTextFileRef(testZipFile, "toc.ncx", EpubContentType.DTBOOK_NCX, "application/x-dtbncx+xml");
+            EpubTextContentFileRef expectedFileRef4 = CreateLocalTextFileRef(testZipFile, "oeb.html", EpubContentType.OEB1_DOCUMENT, "text/x-oeb1-document");
+            EpubTextContentFileRef expectedFileRef5 = CreateLocalTextFileRef(testZipFile, "file.xml", EpubContentType.XML, "application/xml");
+            EpubTextContentFileRef expectedFileRef6 = CreateLocalTextFileRef(testZipFile, "styles.css", EpubContentType.CSS, "text/css");
+            EpubTextContentFileRef expectedFileRef7 = CreateLocalTextFileRef(testZipFile, "oeb.css", EpubContentType.OEB1_CSS, "text/x-oeb1-css");
+            EpubByteContentFileRef expectedFileRef8 = CreateLocalByteFileRef(testZipFile, "image1.gif", EpubContentType.IMAGE_GIF, "image/gif");
+            EpubByteContentFileRef expectedFileRef9 = CreateLocalByteFileRef(testZipFile, "image2.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
+            EpubByteContentFileRef expectedFileRef10 = CreateLocalByteFileRef(testZipFile, "image3.png", EpubContentType.IMAGE_PNG, "image/png");
+            EpubByteContentFileRef expectedFileRef11 = CreateLocalByteFileRef(testZipFile, "image4.svg", EpubContentType.IMAGE_SVG, "image/svg+xml");
+            EpubByteContentFileRef expectedFileRef12 = CreateLocalByteFileRef(testZipFile, "font1.ttf", EpubContentType.FONT_TRUETYPE, "font/truetype");
+            EpubByteContentFileRef expectedFileRef13 = CreateLocalByteFileRef(testZipFile, "font2.ttf", EpubContentType.FONT_TRUETYPE, "application/x-font-truetype");
+            EpubByteContentFileRef expectedFileRef14 = CreateLocalByteFileRef(testZipFile, "font3.otf", EpubContentType.FONT_OPENTYPE, "font/opentype");
+            EpubByteContentFileRef expectedFileRef15 = CreateLocalByteFileRef(testZipFile, "font4.otf", EpubContentType.FONT_OPENTYPE, "application/vnd.ms-opentype");
+            EpubByteContentFileRef expectedFileRef16 = CreateLocalByteFileRef(testZipFile, "video.mp4", EpubContentType.OTHER, "video/mp4");
+            EpubByteContentFileRef expectedFileRef17 = CreateLocalByteFileRef(testZipFile, "cover.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
+            EpubTextContentFileRef expectedFileRef18 = CreateLocalTextFileRef(testZipFile, "toc.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
             EpubTextContentFileRef expectedFileRef19 =
-                new("https://example.com/books/123/test.html", EpubContentLocation.REMOTE, EpubContentType.XHTML_1_1, "application/xhtml+xml", String.Empty);
+                new("https://example.com/books/123/test.html", EpubContentLocation.REMOTE, EpubContentType.XHTML_1_1, "application/xhtml+xml", testZipFile, String.Empty);
             EpubByteContentFileRef expectedFileRef20 =
-                new("https://example.com/books/123/image.jpg", EpubContentLocation.REMOTE, EpubContentType.IMAGE_JPEG, "image/jpeg", String.Empty);
+                new("https://example.com/books/123/image.jpg", EpubContentLocation.REMOTE, EpubContentType.IMAGE_JPEG, "image/jpeg", testZipFile, String.Empty);
             EpubContentRef expectedContentMap = new()
             {
                 Html = new Dictionary<string, EpubTextContentFileRef>()
@@ -346,9 +347,9 @@ namespace VersOne.Epub.Test.Unit.Readers
             EpubContentRefComparer.CompareEpubContentRefs(expectedContentMap, actualContentMap);
         }
 
-        private EpubBookRef CreateEmptyEpubBookRef()
+        private EpubBookRef CreateEmptyEpubBookRef(TestZipFile testZipFile)
         {
-            return new(new TestZipFile())
+            return new(testZipFile)
             {
                 Schema = new EpubSchema()
                 {
@@ -384,14 +385,14 @@ namespace VersOne.Epub.Test.Unit.Readers
             };
         }
 
-        private EpubTextContentFileRef CreateLocalTextFileRef(string href, EpubContentType contentType, string contentMimeType)
+        private EpubTextContentFileRef CreateLocalTextFileRef(TestZipFile testZipFile, string href, EpubContentType contentType, string contentMimeType)
         {
-            return new(href, EpubContentLocation.LOCAL, contentType, contentMimeType, String.Empty);
+            return new(href, EpubContentLocation.LOCAL, contentType, contentMimeType, testZipFile, String.Empty);
         }
 
-        private EpubByteContentFileRef CreateLocalByteFileRef(string href, EpubContentType contentType, string contentMimeType)
+        private EpubByteContentFileRef CreateLocalByteFileRef(TestZipFile testZipFile, string href, EpubContentType contentType, string contentMimeType)
         {
-            return new(href, EpubContentLocation.LOCAL, contentType, contentMimeType, String.Empty);
+            return new(href, EpubContentLocation.LOCAL, contentType, contentMimeType, testZipFile, String.Empty);
         }
     }
 }

--- a/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
@@ -110,7 +110,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile("chapter1.html");
+            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile(testZipFile, "chapter1.html");
             epubBookRef.Content = CreateContentRef(null, testTextContentFileRef);
             EpubNavigationItemRef expectedNavigationItem1 = CreateNavigationLink("Test label 1", "chapter1.html", testTextContentFileRef);
             EpubNavigationItemRef expectedNavigationItem2 = CreateNavigationLink("Test label 3", "chapter1.html#section-1", testTextContentFileRef);
@@ -229,9 +229,9 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
-            EpubTextContentFileRef testTextContentFileRef1 = CreateTestHtmlFile("chapter1.html");
-            EpubTextContentFileRef testTextContentFileRef2 = CreateTestHtmlFile("chapter2.html");
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(testZipFile);
+            EpubTextContentFileRef testTextContentFileRef1 = CreateTestHtmlFile(testZipFile, "chapter1.html");
+            EpubTextContentFileRef testTextContentFileRef2 = CreateTestHtmlFile(testZipFile, "chapter2.html");
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef, testTextContentFileRef1, testTextContentFileRef2);
             EpubNavigationItemRef expectedNavigationItem1 = CreateNavigationHeader("Test header");
             EpubNavigationItemRef expectedNavigationItem2 = CreateNavigationLink("Test text 1", "chapter1.html", testTextContentFileRef1);
@@ -289,8 +289,8 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
-            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile("chapter1.html");
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(testZipFile);
+            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile(testZipFile, "chapter1.html");
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef, testTextContentFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
@@ -336,7 +336,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(testZipFile);
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new();
             List<EpubNavigationItemRef> actualNavigationItems = NavigationReader.GetNavigationItems(epubBookRef);
@@ -391,7 +391,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(testZipFile);
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
@@ -544,8 +544,8 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
-            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile("chapter1.html");
+            EpubTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile(testZipFile);
+            EpubTextContentFileRef testTextContentFileRef = CreateTestHtmlFile(testZipFile, "chapter1.html");
             epubBookRef.Content = CreateContentRef(testNavigationHtmlFileRef, testTextContentFileRef);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
@@ -566,14 +566,14 @@ namespace VersOne.Epub.Test.Unit.Readers
             EpubNavigationItemRefComparer.CompareNavigationItemRefLists(expectedNavigationItems, actualNavigationItems);
         }
 
-        private EpubTextContentFileRef CreateTestNavigationFile()
+        private EpubTextContentFileRef CreateTestNavigationFile(TestZipFile testZipFile)
         {
-            return CreateTestHtmlFile("toc.html");
+            return CreateTestHtmlFile(testZipFile, "toc.html");
         }
 
-        private EpubTextContentFileRef CreateTestHtmlFile(string htmlFileName)
+        private EpubTextContentFileRef CreateTestHtmlFile(TestZipFile testZipFile, string htmlFileName)
         {
-            return new(htmlFileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", CONTENT_DIRECTORY_PATH);
+            return new(htmlFileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
         private EpubNavigationItemRef CreateNavigationLink(string title, string htmlFileUrl, EpubTextContentFileRef htmlFileRef)

--- a/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
@@ -9,7 +9,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         [Fact(DisplayName = "Getting reading order for a minimal EPUB spine should succeed")]
         public void GetReadingOrderForMinimalSpineTest()
         {
-            EpubBookRef epubBookRef = CreateEmptyEpubBookRef();
+            EpubBookRef epubBookRef = CreateEmptyEpubBookRef(new TestZipFile());
             List<EpubTextContentFileRef> expectedReadingOrder = new();
             List<EpubTextContentFileRef> actualReadingOrder = SpineReader.GetReadingOrder(epubBookRef);
             Assert.Equal(expectedReadingOrder, actualReadingOrder);
@@ -18,7 +18,8 @@ namespace VersOne.Epub.Test.Unit.Readers
         [Fact(DisplayName = "Getting reading order for a typical EPUB spine should succeed")]
         public void GetReadingOrderForTypicalSpineTest()
         {
-            EpubBookRef epubBookRef = CreateEmptyEpubBookRef();
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEmptyEpubBookRef(testZipFile);
             epubBookRef.Schema.Package.Spine = new EpubSpine()
             {
                 Items = new List<EpubSpineItemRef>()
@@ -51,8 +52,8 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 }
             };
-            EpubTextContentFileRef expectedHtmlFileRef1 = CreateTestHtmlFileRef("chapter1.html");
-            EpubTextContentFileRef expectedHtmlFileRef2 = CreateTestHtmlFileRef("chapter2.html");
+            EpubTextContentFileRef expectedHtmlFileRef1 = CreateTestHtmlFileRef(testZipFile, "chapter1.html");
+            EpubTextContentFileRef expectedHtmlFileRef2 = CreateTestHtmlFileRef(testZipFile, "chapter2.html");
             epubBookRef.Content.Html = new Dictionary<string, EpubTextContentFileRef>()
             {
                 {
@@ -76,7 +77,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         [Fact(DisplayName = "GetReadingOrder should throw EpubPackageException if there is no manifest item with ID matching to the ID ref of a spine item")]
         public void GetReadingOrderWithMissingManifestItemTest()
         {
-            EpubBookRef epubBookRef = CreateEmptyEpubBookRef();
+            EpubBookRef epubBookRef = CreateEmptyEpubBookRef(new TestZipFile());
             epubBookRef.Schema.Package.Spine = new EpubSpine()
             {
                 Items = new List<EpubSpineItemRef>()
@@ -105,7 +106,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         [Fact(DisplayName = "GetReadingOrder should throw EpubPackageException if there is no HTML content file referenced by a manifest item")]
         public void GetReadingOrderWithMissingHtmlContentFileTest()
         {
-            EpubBookRef epubBookRef = CreateEmptyEpubBookRef();
+            EpubBookRef epubBookRef = CreateEmptyEpubBookRef(new TestZipFile());
             epubBookRef.Schema.Package.Spine = new EpubSpine()
             {
                 Items = new List<EpubSpineItemRef>()
@@ -132,9 +133,9 @@ namespace VersOne.Epub.Test.Unit.Readers
             Assert.Throws<EpubPackageException>(() => SpineReader.GetReadingOrder(epubBookRef));
         }
 
-        private EpubBookRef CreateEmptyEpubBookRef()
+        private EpubBookRef CreateEmptyEpubBookRef(TestZipFile testZipFile)
         {
-            return new(new TestZipFile())
+            return new(testZipFile)
             {
                 Schema = new EpubSchema()
                 {
@@ -174,9 +175,9 @@ namespace VersOne.Epub.Test.Unit.Readers
             };
         }
 
-        private EpubTextContentFileRef CreateTestHtmlFileRef(string fileName)
+        private EpubTextContentFileRef CreateTestHtmlFileRef(TestZipFile testZipFile, string fileName)
         {
-            return new(fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", String.Empty);
+            return new(fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", testZipFile, String.Empty);
         }
     }
 }

--- a/Source/VersOne.Epub.Test/Unit/RefEntities/EpubBookRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/RefEntities/EpubBookRefTests.cs
@@ -149,13 +149,14 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             testZipFile.AddEntry(COVER_FILE_PATH, coverFileContent);
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile, EpubVersion.EPUB_3);
             epubBookRef.Content.Cover =
-                new EpubByteContentFileRef(COVER_FILE_NAME, EpubContentLocation.LOCAL, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+                new EpubByteContentFileRef(COVER_FILE_NAME, EpubContentLocation.LOCAL, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
             return epubBookRef;
         }
 
         private EpubBookRef CreateEpubBookRefWithReadingOrder(string htmlFileName)
         {
-            EpubBookRef epubBookRef = CreateEpubBookRef(new TestZipFile(), EpubVersion.EPUB_3);
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile, EpubVersion.EPUB_3);
             epubBookRef.Schema.Package.Spine = new EpubSpine()
             {
                 Items = new List<EpubSpineItemRef>()
@@ -178,7 +179,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
                     }
                 }
             };
-            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName);
+            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(testZipFile, htmlFileName);
             epubBookRef.Content.Html = new Dictionary<string, EpubTextContentFileRef>()
             {
                 {
@@ -191,7 +192,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
 
         private EpubBookRef CreateEpubBookRefWithNavigation(string htmlFileName, string anchorText)
         {
-            EpubBookRef epubBookRef = CreateEpubBookRef(new TestZipFile(), EpubVersion.EPUB_3);
+            TestZipFile testZipFile = new();
+            EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile, EpubVersion.EPUB_3);
             epubBookRef.Schema.Epub3NavDocument = new Epub3NavDocument()
             {
                 Navs = new List<Epub3Nav>()
@@ -216,10 +218,10 @@ namespace VersOne.Epub.Test.Unit.RefEntities
                     }
                 }
             };
-            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName);
+            EpubTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(testZipFile, htmlFileName);
             epubBookRef.Content = new EpubContentRef()
             {
-                NavigationHtmlFile = CreateTestHtmlFileRef("toc.html"),
+                NavigationHtmlFile = CreateTestHtmlFileRef(testZipFile, "toc.html"),
                 Html = new Dictionary<string, EpubTextContentFileRef>()
                 {
                     {
@@ -268,9 +270,9 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             };
         }
 
-        private EpubTextContentFileRef CreateTestHtmlFileRef(string fileName)
+        private EpubTextContentFileRef CreateTestHtmlFileRef(TestZipFile testZipFile, string fileName)
         {
-            return new(fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", CONTENT_DIRECTORY_PATH);
+            return new(fileName, EpubContentLocation.LOCAL, EpubContentType.XHTML_1_1, "application/xhtml+xml", testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
         private EpubNavigationItemRef CreateTestNavigationLink(string title, string htmlFileUrl, EpubTextContentFileRef htmlFileRef)

--- a/Source/VersOne.Epub.Test/Unit/RefEntities/EpubContentFileRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/RefEntities/EpubContentFileRefTests.cs
@@ -25,7 +25,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public void LocalTextContentItemPropertiesTest()
         {
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, new TestZipFile(), CONTENT_DIRECTORY_PATH);
             Assert.Equal(LOCAL_TEXT_FILE_NAME, epubTextContentFileRef.FileName);
             Assert.Equal(TEXT_FILE_PATH, epubTextContentFileRef.FilePathInEpubArchive);
             Assert.Null(epubTextContentFileRef.Href);
@@ -35,7 +35,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public void LocalByteContentItemPropertiesTest()
         {
             EpubByteContentFileRef epubByteContentFileRef =
-                new(LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+                new(LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, new TestZipFile(), CONTENT_DIRECTORY_PATH);
             Assert.Equal(LOCAL_BYTE_FILE_NAME, epubByteContentFileRef.FileName);
             Assert.Equal(BYTE_FILE_PATH, epubByteContentFileRef.FilePathInEpubArchive);
             Assert.Null(epubByteContentFileRef.Href);
@@ -45,7 +45,7 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public void RemoteTextContentItemPropertiesTest()
         {
             EpubTextContentFileRef epubTextContentFileRef =
-                new(REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+                new(REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, new TestZipFile(), CONTENT_DIRECTORY_PATH);
             Assert.Equal(REMOTE_TEXT_CONTENT_HREF, epubTextContentFileRef.Href);
             Assert.Null(epubTextContentFileRef.FileName);
             Assert.Null(epubTextContentFileRef.FilePathInEpubArchive);
@@ -55,18 +55,32 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public void RemoteByteContentItemPropertiesTest()
         {
             EpubByteContentFileRef epubByteContentFileRef =
-                new(REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+                new(REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, new TestZipFile(), CONTENT_DIRECTORY_PATH);
             Assert.Equal(REMOTE_BYTE_CONTENT_HREF, epubByteContentFileRef.Href);
             Assert.Null(epubByteContentFileRef.FileName);
             Assert.Null(epubByteContentFileRef.FilePathInEpubArchive);
+        }
+
+        [Fact(DisplayName = "EpubTextContentFileRef constructor should throw ArgumentNullException if the supplied EPUB file is null")]
+        public void CreateEpubTextContentFileRefWithNullEpubFileTest()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new EpubTextContentFileRef(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, null, CONTENT_DIRECTORY_PATH));
+        }
+
+        [Fact(DisplayName = "EpubByteContentFileRef constructor should throw ArgumentNullException if the supplied EPUB file is null")]
+        public void CreateEpubByteContentFileRefWithNullEpubFileTest()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new EpubByteContentFileRef(LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, null, CONTENT_DIRECTORY_PATH));
         }
 
         [Fact(DisplayName = "Reading content of an existing text file synchronously should succeed")]
         public void ReadTextContentTest()
         {
             TestZipFile testZipFile = CreateTestZipFileWithTextFile();
-            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
-            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef(testZipFile);
+            string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
@@ -74,8 +88,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public async void ReadTextContentAsyncTest()
         {
             TestZipFile testZipFile = CreateTestZipFileWithTextFile();
-            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
-            string textContent = await epubTextContentFileRef.ReadContentAsync(testZipFile);
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef(testZipFile);
+            string textContent = await epubTextContentFileRef.ReadContentAsync();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
@@ -83,8 +97,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public void ReadByteContentTest()
         {
             TestZipFile testZipFile = CreateTestZipFileWithByteFile();
-            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
-            byte[] byteContent = epubByteContentFileRef.ReadContent(testZipFile);
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef(testZipFile);
+            byte[] byteContent = epubByteContentFileRef.ReadContent();
             Assert.Equal(BYTE_FILE_CONTENT, byteContent);
         }
 
@@ -92,8 +106,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         public async void ReadByteContentAsyncTest()
         {
             TestZipFile testZipFile = CreateTestZipFileWithByteFile();
-            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
-            byte[] byteContent = await epubByteContentFileRef.ReadContentAsync(testZipFile);
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef(testZipFile);
+            byte[] byteContent = await epubByteContentFileRef.ReadContentAsync();
             Assert.Equal(BYTE_FILE_CONTENT, byteContent);
         }
 
@@ -102,8 +116,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         {
             TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef =
-                new(String.Empty, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
-            Assert.Throws<EpubPackageException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
+                new(String.Empty, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
+            Assert.Throws<EpubPackageException>(() => epubTextContentFileRef.GetContentStream());
         }
 
         [Fact(DisplayName = "GetContentStream should throw EpubContentException if the file is missing in the EPUB archive")]
@@ -111,8 +125,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
         {
             TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
-            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
+            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
         }
 
         [Fact(DisplayName = "GetContentStream should throw EpubContentException if the file is larger than 2 GB")]
@@ -121,8 +135,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(TEXT_FILE_PATH, new Test4GbZipFileEntry());
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
-            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
+            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
         }
 
         [Fact(DisplayName = "EpubContentFileRef should return an empty content if the file is missing and SuppressException is true")]
@@ -132,8 +146,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             contentReaderOptions.ContentFileMissing += (sender, e) => e.SuppressException = true;
             TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
-            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(String.Empty, textContent);
         }
 
@@ -144,8 +158,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             contentReaderOptions.ContentFileMissing += (sender, e) => e.ReplacementContentStream = new MemoryStream(Encoding.UTF8.GetBytes(TEXT_FILE_CONTENT));
             TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
-            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
@@ -156,10 +170,10 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             contentReaderOptions.ContentFileMissing += (sender, e) => e.ReplacementContentStream = new MemoryStream(Encoding.UTF8.GetBytes(TEXT_FILE_CONTENT));
             TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
-            string textContent = epubTextContentFileRef.ReadContent(testZipFile);
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            string textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
-            textContent = epubTextContentFileRef.ReadContent(testZipFile);
+            textContent = epubTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, textContent);
         }
 
@@ -169,8 +183,8 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             ContentReaderOptions contentReaderOptions = new();
             TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
-            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            Assert.Throws<EpubContentException>(() => epubTextContentFileRef.GetContentStream());
         }
 
         [Fact(DisplayName = "ContentFileMissingEventArgs should contain details of the missing file")]
@@ -185,87 +199,97 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             };
             TestZipFile testZipFile = new();
             EpubTextContentFileRef epubTextContentFileRef =
-                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH, contentReaderOptions);
-            epubTextContentFileRef.ReadContent(testZipFile);
+                new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH, contentReaderOptions);
+            epubTextContentFileRef.ReadContent();
             Assert.Equal(LOCAL_TEXT_FILE_NAME, contentFileMissingEventArgs.FileName);
             Assert.Equal(TEXT_FILE_PATH, contentFileMissingEventArgs.FilePathInEpubArchive);
             Assert.Equal(TEXT_FILE_CONTENT_TYPE, contentFileMissingEventArgs.ContentType);
             Assert.Equal(TEXT_FILE_CONTENT_MIME_TYPE, contentFileMissingEventArgs.ContentMimeType);
         }
 
-        [Fact(DisplayName = "ReadContent should throw ArgumentNullException if the supplied EPUB file is null")]
-        public void ReadContentForLocalTextContentItemWithNullEpubFileTest()
-        {
-            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
-            Assert.Throws<ArgumentNullException>(() => epubTextContentFileRef.ReadContent(null));
-        }
-
-        [Fact(DisplayName = "ReadContentAsync should throw ArgumentNullException if the supplied EPUB file is null")]
-        public async void ReadContentAsyncForLocalTextContentItemWithNullEpubFileTest()
-        {
-            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
-            await Assert.ThrowsAsync<ArgumentNullException>(() => epubTextContentFileRef.ReadContentAsync(null));
-        }
-
-        [Fact(DisplayName = "ReadContent should throw ArgumentNullException if the supplied EPUB file is null")]
-        public void ReadContentForLocalByteContentItemWithNullEpubFileTest()
-        {
-            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
-            Assert.Throws<ArgumentNullException>(() => epubByteContentFileRef.ReadContent(null));
-        }
-
-        [Fact(DisplayName = "ReadContentAsync should throw ArgumentNullException if the supplied EPUB file is null")]
-        public async void ReadContentAsyncForLocalByteContentItemWithNullEpubFileTest()
-        {
-            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef();
-            await Assert.ThrowsAsync<ArgumentNullException>(() => epubByteContentFileRef.ReadContentAsync(null));
-        }
-
-        [Fact(DisplayName = "GetContentStream should throw ArgumentNullException if the supplied EPUB file is null")]
-        public void GetContentStreamForLocalContentItemWithNullEpubFileTest()
-        {
-            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef();
-            Assert.Throws<ArgumentNullException>(() => epubTextContentFileRef.GetContentStream(null));
-        }
-
         [Fact(DisplayName = "ReadContent should throw InvalidOperationException for remote text content items")]
         public void ReadContentForRemoteTextContentItemTest()
         {
             TestZipFile testZipFile = new();
-            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
-            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.ReadContent(testZipFile));
+            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef(testZipFile);
+            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.ReadContent());
         }
 
         [Fact(DisplayName = "ReadContentAsync should throw InvalidOperationException for remote text content items")]
         public async void ReadContentAsyncForRemoteTextContentItemTest()
         {
             TestZipFile testZipFile = new();
-            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
-            await Assert.ThrowsAsync<InvalidOperationException>(() => epubTextContentFileRef.ReadContentAsync(testZipFile));
+            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef(testZipFile);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => epubTextContentFileRef.ReadContentAsync());
         }
 
         [Fact(DisplayName = "ReadContent should throw InvalidOperationException for remote byte content items")]
         public void ReadContentForRemoteByteContentItemTest()
         {
             TestZipFile testZipFile = new();
-            EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef();
-            Assert.Throws<InvalidOperationException>(() => epubByteContentFileRef.ReadContent(testZipFile));
+            EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef(testZipFile);
+            Assert.Throws<InvalidOperationException>(() => epubByteContentFileRef.ReadContent());
         }
 
         [Fact(DisplayName = "ReadContentAsync should throw InvalidOperationException for remote byte content items")]
         public async void ReadContentAsyncForRemoteByteContentItemTest()
         {
             TestZipFile testZipFile = new();
-            EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef();
-            await Assert.ThrowsAsync<InvalidOperationException>(() => epubByteContentFileRef.ReadContentAsync(testZipFile));
+            EpubByteContentFileRef epubByteContentFileRef = CreateRemoteByteContentFileRef(testZipFile);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => epubByteContentFileRef.ReadContentAsync());
         }
 
         [Fact(DisplayName = "GetContentStream should throw InvalidOperationException for remote content items")]
         public void GetContentStreamForRemoteContentItemTest()
         {
             TestZipFile testZipFile = new();
-            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef();
-            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.GetContentStream(testZipFile));
+            EpubTextContentFileRef epubTextContentFileRef = CreateRemoteTextContentFileRef(testZipFile);
+            Assert.Throws<InvalidOperationException>(() => epubTextContentFileRef.GetContentStream());
+        }
+
+        [Fact(DisplayName = "ReadContent should throw ObjectDisposedException for local text content items with disposed EPUB file")]
+        public void ReadContentForLocalTextContentItemWithDisposedEpubFileTest()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.Dispose();
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef(testZipFile);
+            Assert.Throws<ObjectDisposedException>(() => epubTextContentFileRef.ReadContent());
+        }
+
+        [Fact(DisplayName = "ReadContentAsync should throw ObjectDisposedException for local text content items with disposed EPUB file")]
+        public async void ReadContentAsyncForLocalTextContentItemWithDisposedEpubFileTest()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.Dispose();
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef(testZipFile);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => epubTextContentFileRef.ReadContentAsync());
+        }
+
+        [Fact(DisplayName = "ReadContent should throw ObjectDisposedException for local byte content items with disposed EPUB file")]
+        public void ReadContentForLocalByteContentItemWithDisposedEpubFileTest()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.Dispose();
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef(testZipFile);
+            Assert.Throws<ObjectDisposedException>(() => epubByteContentFileRef.ReadContent());
+        }
+
+        [Fact(DisplayName = "ReadContentAsync should throw ObjectDisposedException for local byte content items with disposed EPUB file")]
+        public async void ReadContentAsyncForLocalByteContentItemWithDisposedEpubFileTest()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.Dispose();
+            EpubByteContentFileRef epubByteContentFileRef = CreateLocalByteContentFileRef(testZipFile);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => epubByteContentFileRef.ReadContentAsync());
+        }
+
+        [Fact(DisplayName = "GetContentStream should throw ObjectDisposedException for local content items with disposed EPUB file")]
+        public void GetContentStreamForLocalContentItemWithDisposedEpubFileTest()
+        {
+            TestZipFile testZipFile = new();
+            testZipFile.Dispose();
+            EpubTextContentFileRef epubTextContentFileRef = CreateLocalTextContentFileRef(testZipFile);
+            Assert.Throws<ObjectDisposedException>(() => epubTextContentFileRef.GetContentStream());
         }
 
         private TestZipFile CreateTestZipFileWithTextFile()
@@ -282,24 +306,24 @@ namespace VersOne.Epub.Test.Unit.RefEntities
             return testZipFile;
         }
 
-        private EpubTextContentFileRef CreateLocalTextContentFileRef()
+        private EpubTextContentFileRef CreateLocalTextContentFileRef(TestZipFile testZipFile)
         {
-            return new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            return new(LOCAL_TEXT_FILE_NAME, EpubContentLocation.LOCAL, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
-        private EpubByteContentFileRef CreateLocalByteContentFileRef()
+        private EpubByteContentFileRef CreateLocalByteContentFileRef(TestZipFile testZipFile)
         {
-            return new(LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            return new(LOCAL_BYTE_FILE_NAME, EpubContentLocation.LOCAL, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
-        private EpubTextContentFileRef CreateRemoteTextContentFileRef()
+        private EpubTextContentFileRef CreateRemoteTextContentFileRef(TestZipFile testZipFile)
         {
-            return new(REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            return new(REMOTE_TEXT_CONTENT_HREF, EpubContentLocation.REMOTE, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
-        private EpubByteContentFileRef CreateRemoteByteContentFileRef()
+        private EpubByteContentFileRef CreateRemoteByteContentFileRef(TestZipFile testZipFile)
         {
-            return new(REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            return new(REMOTE_BYTE_CONTENT_HREF, EpubContentLocation.REMOTE, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
         private EpubBookRef CreateEpubBookRef(TestZipFile testZipFile)

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubBookRefs.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubBookRefs.cs
@@ -25,7 +25,7 @@ namespace VersOne.Epub.Test.Unit.TestData
                     Cover = null
                 }
             };
-            EpubTextContentFileRef navFileRef = new(NAV_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE, CONTENT_DIRECTORY_PATH);
+            EpubTextContentFileRef navFileRef = new(NAV_FILE_NAME, EpubContentLocation.LOCAL, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE, epubFile, CONTENT_DIRECTORY_PATH);
             result.Content.Html[NAV_FILE_NAME] = navFileRef;
             result.Content.AllFiles[NAV_FILE_NAME] = navFileRef;
             result.Content.NavigationHtmlFile = navFileRef;
@@ -43,20 +43,20 @@ namespace VersOne.Epub.Test.Unit.TestData
                 Description = BOOK_DESCRIPTION,
                 Schema = TestEpubSchemas.CreateFullTestEpubSchema()
             };
-            EpubTextContentFileRef chapter1FileRef = CreateLocalTextContentFileRef(CHAPTER1_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef chapter2FileRef = CreateLocalTextContentFileRef(CHAPTER2_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef styles1FileRef = CreateLocalTextContentFileRef(STYLES1_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef styles2FileRef = CreateLocalTextContentFileRef(STYLES2_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef image1FileRef = CreateLocalByteContentFileRef(IMAGE1_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef image2FileRef = CreateLocalByteContentFileRef(IMAGE2_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef font1FileRef = CreateLocalByteContentFileRef(FONT1_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef font2FileRef = CreateLocalByteContentFileRef(FONT2_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef audioFileRef = CreateLocalByteContentFileRef(AUDIO_FILE_NAME, OTHER_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef remoteTextContentItemRef = CreateRemoteTextContentFileRef(REMOTE_TEXT_CONTENT_ITEM_HREF, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef remoteByteContentItemRef = CreateRemoteByteContentFileRef(REMOTE_BYTE_CONTENT_ITEM_HREF, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef navFileRef = CreateLocalTextContentFileRef(NAV_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-            EpubByteContentFileRef coverFileRef = CreateLocalByteContentFileRef(COVER_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-            EpubTextContentFileRef ncxFileRef = CreateLocalTextContentFileRef(NCX_FILE_NAME, NCX_CONTENT_TYPE, NCX_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef chapter1FileRef = CreateLocalTextContentFileRef(epubFile, CHAPTER1_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef chapter2FileRef = CreateLocalTextContentFileRef(epubFile, CHAPTER2_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef styles1FileRef = CreateLocalTextContentFileRef(epubFile, STYLES1_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef styles2FileRef = CreateLocalTextContentFileRef(epubFile, STYLES2_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef image1FileRef = CreateLocalByteContentFileRef(epubFile, IMAGE1_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef image2FileRef = CreateLocalByteContentFileRef(epubFile, IMAGE2_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef font1FileRef = CreateLocalByteContentFileRef(epubFile, FONT1_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef font2FileRef = CreateLocalByteContentFileRef(epubFile, FONT2_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef audioFileRef = CreateLocalByteContentFileRef(epubFile, AUDIO_FILE_NAME, OTHER_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef remoteTextContentItemRef = CreateRemoteTextContentFileRef(epubFile, REMOTE_TEXT_CONTENT_ITEM_HREF, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef remoteByteContentItemRef = CreateRemoteByteContentFileRef(epubFile, REMOTE_BYTE_CONTENT_ITEM_HREF, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef navFileRef = CreateLocalTextContentFileRef(epubFile, NAV_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
+            EpubByteContentFileRef coverFileRef = CreateLocalByteContentFileRef(epubFile, COVER_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
+            EpubTextContentFileRef ncxFileRef = CreateLocalTextContentFileRef(epubFile, NCX_FILE_NAME, NCX_CONTENT_TYPE, NCX_CONTENT_MIME_TYPE);
             result.Content = new EpubContentRef()
             {
                 Html = new Dictionary<string, EpubTextContentFileRef>()
@@ -184,24 +184,24 @@ namespace VersOne.Epub.Test.Unit.TestData
             return result;
         }
 
-        private static EpubTextContentFileRef CreateLocalTextContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
+        private static EpubTextContentFileRef CreateLocalTextContentFileRef(TestZipFile testZipFile, string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(fileName, EpubContentLocation.LOCAL, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
+            return new(fileName, EpubContentLocation.LOCAL, contentType, contentMimeType, testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
-        private static EpubByteContentFileRef CreateLocalByteContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
+        private static EpubByteContentFileRef CreateLocalByteContentFileRef(TestZipFile testZipFile, string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(fileName, EpubContentLocation.LOCAL, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
+            return new(fileName, EpubContentLocation.LOCAL, contentType, contentMimeType, testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
-        private static EpubTextContentFileRef CreateRemoteTextContentFileRef(string href, EpubContentType contentType, string contentMimeType)
+        private static EpubTextContentFileRef CreateRemoteTextContentFileRef(TestZipFile testZipFile, string href, EpubContentType contentType, string contentMimeType)
         {
-            return new(href, EpubContentLocation.REMOTE, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
+            return new(href, EpubContentLocation.REMOTE, contentType, contentMimeType, testZipFile, CONTENT_DIRECTORY_PATH);
         }
 
-        private static EpubByteContentFileRef CreateRemoteByteContentFileRef(string href, EpubContentType contentType, string contentMimeType)
+        private static EpubByteContentFileRef CreateRemoteByteContentFileRef(TestZipFile testZipFile, string href, EpubContentType contentType, string contentMimeType)
         {
-            return new(href, EpubContentLocation.REMOTE, contentType, contentMimeType, CONTENT_DIRECTORY_PATH);
+            return new(href, EpubContentLocation.REMOTE, contentType, contentMimeType, testZipFile, CONTENT_DIRECTORY_PATH);
         }
     }
 }

--- a/Source/VersOne.Epub/Environment/IZipFile.cs
+++ b/Source/VersOne.Epub/Environment/IZipFile.cs
@@ -8,6 +8,11 @@ namespace VersOne.Epub.Environment
     public interface IZipFile : IDisposable
     {
         /// <summary>
+        /// Gets a value indicating whether this file was disposed or not.
+        /// </summary>
+        bool IsDisposed { get; }
+
+        /// <summary>
         /// Retrieves a wrapper for the specified entry in the ZIP archive.
         /// </summary>
         /// <param name="entryName">A path, relative to the root of the archive, that identifies the entry to retrieve.</param>

--- a/Source/VersOne.Epub/Environment/Implementation/ZipFile.cs
+++ b/Source/VersOne.Epub/Environment/Implementation/ZipFile.cs
@@ -6,11 +6,11 @@ namespace VersOne.Epub.Environment.Implementation
     internal class ZipFile : IZipFile
     {
         private readonly ZipArchive zipArchive;
-        private bool isDisposed;
 
         public ZipFile(ZipArchive zipArchive)
         {
             this.zipArchive = zipArchive;
+            IsDisposed = false;
         }
 
         ~ZipFile()
@@ -18,8 +18,14 @@ namespace VersOne.Epub.Environment.Implementation
             Dispose(false);
         }
 
+        public bool IsDisposed { get; private set; }
+
         public IZipFileEntry GetEntry(string entryName)
         {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(ZipFile));
+            }
             ZipArchiveEntry zipArchiveEntry = zipArchive.GetEntry(entryName);
             return zipArchiveEntry != null ? new ZipFileEntry(zipArchiveEntry) : null;
         }
@@ -32,13 +38,13 @@ namespace VersOne.Epub.Environment.Implementation
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!isDisposed)
+            if (!IsDisposed)
             {
                 if (disposing)
                 {
                     zipArchive?.Dispose();
                 }
-                isDisposed = true;
+                IsDisposed = true;
             }
         }
     }

--- a/Source/VersOne.Epub/Readers/BookReader.cs
+++ b/Source/VersOne.Epub/Readers/BookReader.cs
@@ -42,7 +42,7 @@ namespace VersOne.Epub.Internal
                 result.Title = epubBookRef.Title;
                 result.AuthorList = epubBookRef.AuthorList;
                 result.Author = epubBookRef.Author;
-                result.Content = await ReadContent(epubBookRef.Content, epubBookRef.EpubFile).ConfigureAwait(false);
+                result.Content = await ReadContent(epubBookRef.Content).ConfigureAwait(false);
                 result.CoverImage = await epubBookRef.ReadCoverAsync().ConfigureAwait(false);
                 result.Description = epubBookRef.Description;
                 List<EpubTextContentFileRef> htmlContentFileRefs = await epubBookRef.GetReadingOrderAsync().ConfigureAwait(false);
@@ -53,13 +53,13 @@ namespace VersOne.Epub.Internal
             return result;
         }
 
-        private static async Task<EpubContent> ReadContent(EpubContentRef contentRef, IZipFile epubFile)
+        private static async Task<EpubContent> ReadContent(EpubContentRef contentRef)
         {
             EpubContent result = new EpubContent();
-            result.Html = await ReadTextContentFiles(contentRef.Html, epubFile).ConfigureAwait(false);
-            result.Css = await ReadTextContentFiles(contentRef.Css, epubFile).ConfigureAwait(false);
-            result.Images = await ReadByteContentFiles(contentRef.Images, epubFile).ConfigureAwait(false);
-            result.Fonts = await ReadByteContentFiles(contentRef.Fonts, epubFile).ConfigureAwait(false);
+            result.Html = await ReadTextContentFiles(contentRef.Html).ConfigureAwait(false);
+            result.Css = await ReadTextContentFiles(contentRef.Css).ConfigureAwait(false);
+            result.Images = await ReadByteContentFiles(contentRef.Images).ConfigureAwait(false);
+            result.Fonts = await ReadByteContentFiles(contentRef.Fonts).ConfigureAwait(false);
             result.AllFiles = new Dictionary<string, EpubContentFile>();
             foreach (KeyValuePair<string, EpubTextContentFile> textContentFile in result.Html.Concat(result.Css))
             {
@@ -75,11 +75,11 @@ namespace VersOne.Epub.Internal
                 {
                     if (contentFileRef.Value is EpubTextContentFileRef)
                     {
-                        result.AllFiles.Add(contentFileRef.Key, await ReadTextContentFile(contentFileRef.Value, epubFile).ConfigureAwait(false));
+                        result.AllFiles.Add(contentFileRef.Key, await ReadTextContentFile(contentFileRef.Value).ConfigureAwait(false));
                     }
                     else
                     {
-                        result.AllFiles.Add(contentFileRef.Key, await ReadByteContentFile(contentFileRef.Value, epubFile).ConfigureAwait(false));
+                        result.AllFiles.Add(contentFileRef.Key, await ReadByteContentFile(contentFileRef.Value).ConfigureAwait(false));
                     }
                 }
             }
@@ -94,27 +94,27 @@ namespace VersOne.Epub.Internal
             return result;
         }
 
-        private static async Task<Dictionary<string, EpubTextContentFile>> ReadTextContentFiles(Dictionary<string, EpubTextContentFileRef> textContentFileRefs, IZipFile epubFile)
+        private static async Task<Dictionary<string, EpubTextContentFile>> ReadTextContentFiles(Dictionary<string, EpubTextContentFileRef> textContentFileRefs)
         {
             Dictionary<string, EpubTextContentFile> result = new Dictionary<string, EpubTextContentFile>();
             foreach (KeyValuePair<string, EpubTextContentFileRef> textContentFileRef in textContentFileRefs)
             {
-                result.Add(textContentFileRef.Key, await ReadTextContentFile(textContentFileRef.Value, epubFile).ConfigureAwait(false));
+                result.Add(textContentFileRef.Key, await ReadTextContentFile(textContentFileRef.Value).ConfigureAwait(false));
             }
             return result;
         }
 
-        private static async Task<Dictionary<string, EpubByteContentFile>> ReadByteContentFiles(Dictionary<string, EpubByteContentFileRef> byteContentFileRefs, IZipFile epubFile)
+        private static async Task<Dictionary<string, EpubByteContentFile>> ReadByteContentFiles(Dictionary<string, EpubByteContentFileRef> byteContentFileRefs)
         {
             Dictionary<string, EpubByteContentFile> result = new Dictionary<string, EpubByteContentFile>();
             foreach (KeyValuePair<string, EpubByteContentFileRef> byteContentFileRef in byteContentFileRefs)
             {
-                result.Add(byteContentFileRef.Key, await ReadByteContentFile(byteContentFileRef.Value, epubFile).ConfigureAwait(false));
+                result.Add(byteContentFileRef.Key, await ReadByteContentFile(byteContentFileRef.Value).ConfigureAwait(false));
             }
             return result;
         }
 
-        private static async Task<EpubTextContentFile> ReadTextContentFile(EpubContentFileRef contentFileRef, IZipFile epubFile)
+        private static async Task<EpubTextContentFile> ReadTextContentFile(EpubContentFileRef contentFileRef)
         {
             EpubTextContentFile result = new EpubTextContentFile
             {
@@ -127,7 +127,7 @@ namespace VersOne.Epub.Internal
             };
             if (result.ContentLocation == EpubContentLocation.LOCAL)
             {
-                result.Content = await contentFileRef.ReadContentAsTextAsync(epubFile).ConfigureAwait(false);
+                result.Content = await contentFileRef.ReadContentAsTextAsync().ConfigureAwait(false);
             }
             else
             {
@@ -136,7 +136,7 @@ namespace VersOne.Epub.Internal
             return result;
         }
 
-        private static async Task<EpubByteContentFile> ReadByteContentFile(EpubContentFileRef contentFileRef, IZipFile epubFile)
+        private static async Task<EpubByteContentFile> ReadByteContentFile(EpubContentFileRef contentFileRef)
         {
             EpubByteContentFile result = new EpubByteContentFile
             {
@@ -149,7 +149,7 @@ namespace VersOne.Epub.Internal
             };
             if (result.ContentLocation == EpubContentLocation.LOCAL)
             {
-                result.Content = await contentFileRef.ReadContentAsBytesAsync(epubFile).ConfigureAwait(false);
+                result.Content = await contentFileRef.ReadContentAsBytesAsync().ConfigureAwait(false);
             }
             else
             {

--- a/Source/VersOne.Epub/Readers/ContentReader.cs
+++ b/Source/VersOne.Epub/Readers/ContentReader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using VersOne.Epub.Environment;
 using VersOne.Epub.Options;
 using VersOne.Epub.Schema;
 
@@ -22,6 +23,7 @@ namespace VersOne.Epub.Internal
                 EpubContentLocation contentLocation = href.Contains("://") ? EpubContentLocation.REMOTE : EpubContentLocation.LOCAL;
                 string contentMimeType = manifestItem.MediaType;
                 EpubContentType contentType = GetContentTypeByContentMimeType(contentMimeType);
+                IZipFile epubFile = bookRef.EpubFile;
                 string contentDirectoryPath = bookRef.Schema.ContentDirectoryPath;
                 switch (contentType)
                 {
@@ -33,7 +35,7 @@ namespace VersOne.Epub.Internal
                     case EpubContentType.DTBOOK:
                     case EpubContentType.DTBOOK_NCX:
                         EpubTextContentFileRef epubTextContentFile =
-                            new EpubTextContentFileRef(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions);
+                            new EpubTextContentFileRef(href, contentLocation, contentType, contentMimeType, epubFile, contentDirectoryPath, contentReaderOptions);
                         switch (contentType)
                         {
                             case EpubContentType.XHTML_1_1:
@@ -51,7 +53,7 @@ namespace VersOne.Epub.Internal
                         break;
                     default:
                         EpubByteContentFileRef epubByteContentFile =
-                            new EpubByteContentFileRef(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions);
+                            new EpubByteContentFileRef(href, contentLocation, contentType, contentMimeType, epubFile, contentDirectoryPath, contentReaderOptions);
                         switch (contentType)
                         {
                             case EpubContentType.IMAGE_GIF:

--- a/Source/VersOne.Epub/RefEntities/EpubBookRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubBookRef.cs
@@ -92,7 +92,7 @@ namespace VersOne.Epub
             {
                 return null;
             }
-            return await Content.Cover.ReadContentAsBytesAsync(EpubFile).ConfigureAwait(false);
+            return await Content.Cover.ReadContentAsBytesAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/VersOne.Epub/RefEntities/EpubByteContentFileRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubByteContentFileRef.cs
@@ -19,11 +19,12 @@ namespace VersOne.Epub
         /// <param name="contentLocation">Location of the content item (local or remote).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
+        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <param name="contentDirectoryPath">The content directory path which acts as a root directory for all content files within the EPUB book.</param>
         /// <param name="contentReaderOptions">Optional content reader options determining how to handle missing content files.</param>
-        public EpubByteContentFileRef(string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType, string contentDirectoryPath,
-            ContentReaderOptions contentReaderOptions = null)
-            : base(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions)
+        public EpubByteContentFileRef(string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType,
+            IZipFile epubFile, string contentDirectoryPath, ContentReaderOptions contentReaderOptions = null)
+            : base(href, contentLocation, contentType, contentMimeType, epubFile, contentDirectoryPath, contentReaderOptions)
         {
         }
 
@@ -31,22 +32,20 @@ namespace VersOne.Epub
         /// Reads the whole content of the referenced file and returns it as a byte array.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
-        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>Content of the referenced file.</returns>
-        public byte[] ReadContent(IZipFile epubFile)
+        public byte[] ReadContent()
         {
-            return ReadContentAsBytes(epubFile);
+            return ReadContentAsBytes();
         }
 
         /// <summary>
         /// Asynchronously reads the whole content of the referenced file and returns it as a byte array.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
-        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>A task that represents the asynchronous read operation. The value of the TResult parameter contains the content of the referenced file.</returns>
-        public Task<byte[]> ReadContentAsync(IZipFile epubFile)
+        public Task<byte[]> ReadContentAsync()
         {
-            return ReadContentAsBytesAsync(epubFile);
+            return ReadContentAsBytesAsync();
         }
     }
 }

--- a/Source/VersOne.Epub/RefEntities/EpubTextContentFileRef.cs
+++ b/Source/VersOne.Epub/RefEntities/EpubTextContentFileRef.cs
@@ -19,11 +19,12 @@ namespace VersOne.Epub
         /// <param name="contentLocation">Location of the content item (local or remote).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
+        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <param name="contentDirectoryPath">The content directory path which acts as a root directory for all content files within the EPUB book.</param>
         /// <param name="contentReaderOptions">Optional content reader options determining how to handle missing content files.</param>
-        public EpubTextContentFileRef(string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType, string contentDirectoryPath,
-            ContentReaderOptions contentReaderOptions = null)
-            : base(href, contentLocation, contentType, contentMimeType, contentDirectoryPath, contentReaderOptions)
+        public EpubTextContentFileRef(string href, EpubContentLocation contentLocation, EpubContentType contentType, string contentMimeType,
+            IZipFile epubFile, string contentDirectoryPath, ContentReaderOptions contentReaderOptions = null)
+            : base(href, contentLocation, contentType, contentMimeType, epubFile, contentDirectoryPath, contentReaderOptions)
         {
         }
 
@@ -31,22 +32,20 @@ namespace VersOne.Epub
         /// Reads the whole content of the referenced file and returns it as a string.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
-        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>Content of the referenced file.</returns>
-        public string ReadContent(IZipFile epubFile)
+        public string ReadContent()
         {
-            return ReadContentAsText(epubFile);
+            return ReadContentAsText();
         }
 
         /// <summary>
         /// Asynchronously reads the whole content of the referenced file and returns it as a string.
         /// Throws <see cref="InvalidOperationException" /> if <see cref="EpubContentFileRef.ContentLocation" /> is <see cref="EpubContentLocation.REMOTE" />.
         /// </summary>
-        /// <param name="epubFile">The reference to the EPUB file.</param>
         /// <returns>A task that represents the asynchronous read operation. The value of the TResult parameter contains the content of the referenced file.</returns>
-        public Task<string> ReadContentAsync(IZipFile epubFile)
+        public Task<string> ReadContentAsync()
         {
-            return ReadContentAsTextAsync(epubFile);
+            return ReadContentAsTextAsync();
         }
     }
 }


### PR DESCRIPTION
# Decouple EpubContentFileRef from EpubBookRef, part 2

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #66

## Description

This is a follow-up for the pull request [#67](https://github.com/vers-one/EpubReader/pull/67) to move the `IZipFile epubFile` argument from the `ReadXX` / `GetContentStream` methods to the `EpubContentFileRef` constructor.

## Testing steps

All unit tests should pass.