### PR TITLE
Migrate tests and console demo app to .NET 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,13 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core
+    - name: Install .NET
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Restore dependencies
       run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration /p:RestorePackagesConfig=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.302
+        dotnet-version: 7
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -25,10 +25,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Install .NET
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.302
+        dotnet-version: 7
 
     - name: Restore dependencies
       run: dotnet restore .\Source\VersOne.Epub\VersOne.Epub.csproj

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -16,10 +16,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET 6
-      uses: actions/setup-dotnet@v1
+    - name: Install .NET
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.302
+        dotnet-version: 7
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -22,7 +22,7 @@ jobs:
         dotnet-version: 7
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Restore dependencies
       run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration /p:RestorePackagesConfig=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         dotnet-version: 7
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Restore dependencies
       run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration /p:RestorePackagesConfig=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET 6
-      uses: actions/setup-dotnet@v1
+    - name: Install .NET
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.302
+        dotnet-version: 7
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Install .NET
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.x'
-        include-prerelease: true
+        dotnet-version: 7
 
     - name: Build test project and its dependencies
       run: dotnet build Source\VersOne.Epub.Test -c $env:Configuration

--- a/Source/EpubReader.sln
+++ b/Source/EpubReader.sln
@@ -35,7 +35,9 @@ Global
 		{A6ED4735-3D37-4E44-BEE4-218C6BBAC1BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6ED4735-3D37-4E44-BEE4-218C6BBAC1BD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2FCDA010-24D2-43E4-B58C-07E88434A966}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FCDA010-24D2-43E4-B58C-07E88434A966}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FCDA010-24D2-43E4-B58C-07E88434A966}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FCDA010-24D2-43E4-B58C-07E88434A966}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
+++ b/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
         <Authors>vers</Authors>
         <Copyright>vers, 2015-2022</Copyright>


### PR DESCRIPTION
# Migrate tests and console demo app to .NET 7

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #70

## Description

This pull request:
1. Changes the target framework for *VersOne.Epub.ConsoleDemo* project from .NET 6 to .NET 7.
2. Updates all GitHub actions to use .NET 7 instead of .NET 6 or .NET 7 preview.

## Testing steps

Build and test actions should pass.