### PR TITLE
NavigationReader fix: get content files via absolute file paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7
+          dotnet-version: 7.0.203
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1.3
       - name: Restore dependencies

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7
+          dotnet-version: 7.0.203
       - name: Restore dependencies
         run: dotnet restore .\Source\VersOne.Epub\VersOne.Epub.csproj
       - name: Install DocFX

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7
+          dotnet-version: 7.0.203
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1.3
       - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7
+          dotnet-version: 7.0.203
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1.3
       - name: Restore dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7
+          dotnet-version: 7.0.203
       - name: Build test project and its dependencies
         run: dotnet build Source\VersOne.Epub.Test -c $env:Configuration
       - name: Run unit tests

--- a/Source/VersOne.Epub.Test/Comparers/CollectionComparer.cs
+++ b/Source/VersOne.Epub.Test/Comparers/CollectionComparer.cs
@@ -11,7 +11,7 @@
             }
         }
 
-        public static void CompareDictionaries<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, Action<TValue, TValue> elementValueComprarer)
+        public static void CompareDictionaries<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, Action<TValue, TValue> elementValueComparer)
         {
             Assert.Equal(expected.Count, actual.Count);
             foreach (KeyValuePair<TKey, TValue> expectedKeyValuePair in expected)
@@ -20,7 +20,7 @@
                 TValue expectedValue = expectedKeyValuePair.Value;
                 if (actual.TryGetValue(expectedKey, out TValue? actualValue))
                 {
-                    elementValueComprarer(expectedValue, actualValue);
+                    elementValueComparer(expectedValue, actualValue);
                 }
                 else
                 {

--- a/Source/VersOne.Epub.Test/Comparers/EpubContentComparer.cs
+++ b/Source/VersOne.Epub.Test/Comparers/EpubContentComparer.cs
@@ -84,8 +84,8 @@
             where TLocalContentFile : EpubLocalContentFile
             where TRemoteContentFile : EpubRemoteContentFile
         {
-            CollectionComparer.CompareDictionaries(expected.Local, actual.Local, localContentFileComprarer);
-            CollectionComparer.CompareDictionaries(expected.Remote, actual.Remote, remoteContentFileComparer);
+            CollectionComparer.CompareCollections(expected.Local, actual.Local, localContentFileComprarer);
+            CollectionComparer.CompareCollections(expected.Remote, actual.Remote, remoteContentFileComparer);
         }
 
         private static void CompareLocalEpubContentFilesWithContent(EpubLocalContentFile? expected, EpubLocalContentFile? actual)

--- a/Source/VersOne.Epub.Test/Comparers/EpubContentRefComparer.cs
+++ b/Source/VersOne.Epub.Test/Comparers/EpubContentRefComparer.cs
@@ -40,8 +40,8 @@
             where TLocalContentFileRef : EpubLocalContentFileRef
             where TRemoteContentFileRef : EpubRemoteContentFileRef
         {
-            CollectionComparer.CompareDictionaries(expected.Local, actual.Local, CompareEpubLocalContentFileRefs);
-            CollectionComparer.CompareDictionaries(expected.Remote, actual.Remote, CompareEpubRemoteContentFileRefs);
+            CollectionComparer.CompareCollections(expected.Local, actual.Local, CompareEpubLocalContentFileRefs);
+            CollectionComparer.CompareCollections(expected.Remote, actual.Remote, CompareEpubRemoteContentFileRefs);
         }
 
         private static void CompareEpubContentFileRefs(EpubContentFileRef? expected, EpubContentFileRef? actual)

--- a/Source/VersOne.Epub.Test/Comparers/EpubNavigationItemComparer.cs
+++ b/Source/VersOne.Epub.Test/Comparers/EpubNavigationItemComparer.cs
@@ -24,7 +24,7 @@
             else
             {
                 Assert.NotNull(actual);
-                Assert.Equal(expected.ContentFileName, actual.ContentFileName);
+                Assert.Equal(expected.ContentFileUrl, actual.ContentFileUrl);
                 Assert.Equal(expected.ContentFilePath, actual.ContentFilePath);
                 Assert.Equal(expected.Anchor, actual.Anchor);
             }

--- a/Source/VersOne.Epub.Test/Integration/CustomSerialization/CustomTypes.cs
+++ b/Source/VersOne.Epub.Test/Integration/CustomSerialization/CustomTypes.cs
@@ -515,7 +515,8 @@ namespace VersOne.Epub.Test.Integration.CustomSerialization
                 ignoredProperties: new()
                 {
                     nameof(EpubRemoteByteContentFile.ContentFileType),
-                    nameof(EpubRemoteByteContentFile.ContentLocation)
+                    nameof(EpubRemoteByteContentFile.ContentLocation),
+                    nameof(EpubRemoteByteContentFile.Url)
                 }
             );
             yield return CreateType<EpubRemoteTextContentFile>
@@ -524,7 +525,8 @@ namespace VersOne.Epub.Test.Integration.CustomSerialization
                 ignoredProperties: new()
                 {
                     nameof(EpubRemoteTextContentFile.ContentFileType),
-                    nameof(EpubRemoteTextContentFile.ContentLocation)
+                    nameof(EpubRemoteTextContentFile.ContentLocation),
+                    nameof(EpubRemoteTextContentFile.Url)
                 }
             );
             yield return CreateType<EpubReaderOptions>

--- a/Source/VersOne.Epub.Test/Integration/CustomSerialization/CustomTypes.cs
+++ b/Source/VersOne.Epub.Test/Integration/CustomSerialization/CustomTypes.cs
@@ -471,24 +471,24 @@ namespace VersOne.Epub.Test.Integration.CustomSerialization
             (
                 optionalProperties: new()
                 {
-                    { nameof(EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>.Local), PropertyDefaultValue.EMPTY_DICTIONARY },
-                    { nameof(EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>.Remote), PropertyDefaultValue.EMPTY_DICTIONARY }
+                    { nameof(EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>.Local), PropertyDefaultValue.EMPTY_ARRAY },
+                    { nameof(EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>.Remote), PropertyDefaultValue.EMPTY_ARRAY }
                 }
             );
             yield return CreateType<EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>>
             (
                 optionalProperties: new()
                 {
-                    { nameof(EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>.Local), PropertyDefaultValue.EMPTY_DICTIONARY },
-                    { nameof(EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>.Remote), PropertyDefaultValue.EMPTY_DICTIONARY }
+                    { nameof(EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>.Local), PropertyDefaultValue.EMPTY_ARRAY },
+                    { nameof(EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>.Remote), PropertyDefaultValue.EMPTY_ARRAY }
                 }
             );
             yield return CreateType<EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>>
             (
                 optionalProperties: new()
                 {
-                    { nameof(EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>.Local), PropertyDefaultValue.EMPTY_DICTIONARY },
-                    { nameof(EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>.Remote), PropertyDefaultValue.EMPTY_DICTIONARY }
+                    { nameof(EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>.Local), PropertyDefaultValue.EMPTY_ARRAY },
+                    { nameof(EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>.Remote), PropertyDefaultValue.EMPTY_ARRAY }
                 }
             );
             yield return CreateType<EpubLocalByteContentFile>

--- a/Source/VersOne.Epub.Test/Integration/JsonUtils/Deserializers/ListDeserializer.cs
+++ b/Source/VersOne.Epub.Test/Integration/JsonUtils/Deserializers/ListDeserializer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.ObjectModel;
 using System.Text.Json;
 
 namespace VersOne.Epub.Test.Integration.JsonUtils.Deserializers
@@ -6,24 +7,33 @@ namespace VersOne.Epub.Test.Integration.JsonUtils.Deserializers
     internal class ListDeserializer : TypeDeserializer
     {
         private readonly Type listType;
+        private readonly bool isReadOnlyCollection;
+        private readonly Type listItemType;
         private readonly Lazy<TypeDeserializer> listItemTypeDeserializer;
 
         public ListDeserializer(Type listType, TypeDeserializerCollection typeDeserializerCollection)
         {
+            if (!listType.IsGenericType)
+            {
+                throw new ArgumentException($"{listType.Name} is not a generic List<T> type.");
+            }
             this.listType = listType;
-            Type listItemType = listType.IsGenericType ? listType.GetGenericArguments().First() : throw new ArgumentException($"{listType.Name} is not a generic List<T> type.");
+            isReadOnlyCollection = listType.GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>);
+            listItemType = listType.GetGenericArguments().First();
             listItemTypeDeserializer = new Lazy<TypeDeserializer>(() => typeDeserializerCollection.GetDeserializer(listItemType));
         }
 
         public override object? Deserialize(JsonElement jsonElement, JsonSerializationContext jsonSerializationContext)
         {
             Assert.Equal(JsonValueKind.Array, jsonElement.ValueKind);
-            IList? result = Activator.CreateInstance(listType, new object[] { jsonElement.GetArrayLength() }) as IList;
-            Assert.NotNull(result);
+            IList? list = Activator.CreateInstance(isReadOnlyCollection ? typeof(List<>).MakeGenericType(listItemType) : listType,
+                new object[] { jsonElement.GetArrayLength() }) as IList;
+            Assert.NotNull(list);
             foreach (JsonElement serializedListItem in jsonElement.EnumerateArray())
             {
-                result.Add(listItemTypeDeserializer.Value.Deserialize(serializedListItem, jsonSerializationContext));
+                list.Add(listItemTypeDeserializer.Value.Deserialize(serializedListItem, jsonSerializationContext));
             }
+            object? result = isReadOnlyCollection ? Activator.CreateInstance(listType, new object[] { list }) : list;
             return result;
         }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/BugFixes/53/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/BugFixes/53/testcases.json
@@ -85,11 +85,11 @@
       },
       "Content": {
         "AllFiles": {
-          "Local": {
-            "toc.ncx": {
+          "Local": [
+            {
               "$ref": 1
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/BugFixes/55/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/BugFixes/55/testcases.json
@@ -79,11 +79,11 @@
       },
       "Content": {
         "AllFiles": {
-          "Local": {
-            "toc.ncx": {
+          "Local": [
+            {
               "$ref": 1
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/BugFixes/57/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/BugFixes/57/testcases.json
@@ -63,11 +63,11 @@
       },
       "Content": {
         "AllFiles": {
-          "Local": {
-            "toc.ncx": {
+          "Local": [
+            {
               "$ref": 1
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Features/RemoteContent/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Features/RemoteContent/testcases.json
@@ -52,7 +52,6 @@
         "$id": 6,
         "$type": "EpubRemoteTextContentFile",
         "$content": null,
-        "Url": "https://os.vers.one/EpubReader/toc.html",
         "Key": "https://os.vers.one/EpubReader/toc.html",
         "ContentType": "XHTML_1_1",
         "ContentMimeType": "application/xhtml+xml"
@@ -61,7 +60,6 @@
         "$id": 7,
         "$type": "EpubRemoteTextContentFile",
         "$content": null,
-        "Url": "https://os.vers.one/EpubReader/styles/docfx.css",
         "Key": "https://os.vers.one/EpubReader/styles/docfx.css",
         "ContentType": "CSS",
         "ContentMimeType": "text/css"
@@ -70,7 +68,6 @@
         "$id": 8,
         "$type": "EpubRemoteByteContentFile",
         "$content": null,
-        "Url": "https://os.vers.one/EpubReader/images/logo.svg",
         "Key": "https://os.vers.one/EpubReader/images/logo.svg",
         "ContentType": "IMAGE_SVG",
         "ContentMimeType": "image/svg+xml"
@@ -79,7 +76,6 @@
         "$id": 9,
         "$type": "EpubRemoteByteContentFile",
         "$content": null,
-        "Url": "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf",
         "Key": "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf",
         "ContentType": "FONT_TRUETYPE",
         "ContentMimeType": "application/x-font-truetype"
@@ -205,88 +201,88 @@
           "$ref": 2
         },
         "Html": {
-          "Local": {
-            "chapter.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "toc.html": {
+            {
               "$ref": 2
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/toc.html": {
+          ],
+          "Remote": [
+            {
               "$ref": 6
             }
-          }
+          ]
         },
         "Css": {
-          "Local": {
-            "styles.css": {
+          "Local": [
+            {
               "$ref": 3
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/styles/docfx.css": {
+          ],
+          "Remote": [
+            {
               "$ref": 7
             }
-          }
+          ]
         },
         "Images": {
-          "Local": {
-            "cover.jpg": {
+          "Local": [
+            {
               "$ref": 4
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/images/logo.svg": {
+          ],
+          "Remote": [
+            {
               "$ref": 8
             }
-          }
+          ]
         },
         "Fonts": {
-          "Local": {
-            "font.ttf": {
+          "Local": [
+            {
               "$ref": 5
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf": {
+          ],
+          "Remote": [
+            {
               "$ref": 9
             }
-          }
+          ]
         },
         "AllFiles": {
-          "Local": {
-            "chapter.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "toc.html": {
+            {
               "$ref": 2
             },
-            "styles.css": {
+            {
               "$ref": 3
             },
-            "cover.jpg": {
+            {
               "$ref": 4
             },
-            "font.ttf": {
+            {
               "$ref": 5
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/toc.html": {
+          ],
+          "Remote": [
+            {
               "$ref": 6
             },
-            "https://os.vers.one/EpubReader/styles/docfx.css": {
+            {
               "$ref": 7
             },
-            "https://os.vers.one/EpubReader/images/logo.svg": {
+            {
               "$ref": 8
             },
-            "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf": {
+            {
               "$ref": 9
             }
-          }
+          ]
         }
       }
     }
@@ -349,7 +345,6 @@
         "$id": 15,
         "$type": "EpubRemoteTextContentFile",
         "$content": "https://os.vers.one/EpubReader/toc.html",
-        "Url": "https://os.vers.one/EpubReader/toc.html",
         "Key": "https://os.vers.one/EpubReader/toc.html",
         "ContentType": "XHTML_1_1",
         "ContentMimeType": "application/xhtml+xml"
@@ -358,7 +353,6 @@
         "$id": 16,
         "$type": "EpubRemoteTextContentFile",
         "$content": "https://os.vers.one/EpubReader/styles/docfx.css",
-        "Url": "https://os.vers.one/EpubReader/styles/docfx.css",
         "Key": "https://os.vers.one/EpubReader/styles/docfx.css",
         "ContentType": "CSS",
         "ContentMimeType": "text/css"
@@ -367,7 +361,6 @@
         "$id": 17,
         "$type": "EpubRemoteByteContentFile",
         "$content": "https://os.vers.one/EpubReader/images/logo.svg",
-        "Url": "https://os.vers.one/EpubReader/images/logo.svg",
         "Key": "https://os.vers.one/EpubReader/images/logo.svg",
         "ContentType": "IMAGE_SVG",
         "ContentMimeType": "image/svg+xml"
@@ -376,7 +369,6 @@
         "$id": 18,
         "$type": "EpubRemoteByteContentFile",
         "$content": "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf",
-        "Url": "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf",
         "Key": "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf",
         "ContentType": "FONT_TRUETYPE",
         "ContentMimeType": "application/x-font-truetype"
@@ -502,88 +494,88 @@
           "$ref": 11
         },
         "Html": {
-          "Local": {
-            "chapter.html": {
+          "Local": [
+            {
               "$ref": 10
             },
-            "toc.html": {
+            {
               "$ref": 11
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/toc.html": {
+          ],
+          "Remote": [
+            {
               "$ref": 15
             }
-          }
+          ]
         },
         "Css": {
-          "Local": {
-            "styles.css": {
+          "Local": [
+            {
               "$ref": 12
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/styles/docfx.css": {
+          ],
+          "Remote": [
+            {
               "$ref": 16
             }
-          }
+          ]
         },
         "Images": {
-          "Local": {
-            "cover.jpg": {
+          "Local": [
+            {
               "$ref": 13
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/images/logo.svg": {
+          ],
+          "Remote": [
+            {
               "$ref": 17
             }
-          }
+          ]
         },
         "Fonts": {
-          "Local": {
-            "font.ttf": {
+          "Local": [
+            {
               "$ref": 14
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf": {
+          ],
+          "Remote": [
+            {
               "$ref": 18
             }
-          }
+          ]
         },
         "AllFiles": {
-          "Local": {
-            "chapter.html": {
+          "Local": [
+            {
               "$ref": 10
             },
-            "toc.html": {
+            {
               "$ref": 11
             },
-            "styles.css": {
+            {
               "$ref": 12
             },
-            "cover.jpg": {
+            {
               "$ref": 13
             },
-            "font.ttf": {
+            {
               "$ref": 14
             }
-          },
-          "Remote": {
-            "https://os.vers.one/EpubReader/toc.html": {
+          ],
+          "Remote": [
+            {
               "$ref": 15
             },
-            "https://os.vers.one/EpubReader/styles/docfx.css": {
+            {
               "$ref": 16
             },
-            "https://os.vers.one/EpubReader/images/logo.svg": {
+            {
               "$ref": 17
             },
-            "https://os.vers.one/EpubReader/fonts/glyphicons-halflings-regular.ttf": {
+            {
               "$ref": 18
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/InvalidManifestItems/EPUB2/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/InvalidManifestItems/EPUB2/testcases.json
@@ -90,21 +90,21 @@
       },
       "Content": {
         "Html": {
-          "Local": {
-            "chapter1.html": {
+          "Local": [
+            {
               "$ref": 1
             }
-          }
+          ]
         },
         "AllFiles": {
-          "Local": {
-            "chapter1.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "toc.ncx": {
+            {
               "$ref": 2
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/InvalidManifestItems/EPUB3/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/InvalidManifestItems/EPUB3/testcases.json
@@ -107,24 +107,24 @@
           "$ref": 2
         },
         "Html": {
-          "Local": {
-            "chapter1.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "toc.html": {
+            {
               "$ref": 2
             }
-          }
+          ]
         },
         "AllFiles": {
-          "Local": {
-            "chapter1.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "toc.html": {
+            {
               "$ref": 2
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/MissingContentForNavigationPoint/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/MissingContentForNavigationPoint/testcases.json
@@ -48,7 +48,7 @@
           "Type": "LINK",
           "Title": "Chapter 1",
           "Link": {
-            "ContentFileName": "chapter1.html",
+            "ContentFileUrl": "chapter1.html",
             "ContentFilePath": "Content/chapter1.html",
             "Anchor": null
           },

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/MissingContentForNavigationPoint/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Malformed/MissingContentForNavigationPoint/testcases.json
@@ -117,21 +117,21 @@
       },
       "Content": {
         "Html": {
-          "Local": {
-            "chapter1.html": {
+          "Local": [
+            {
               "$ref": 1
             }
-          }
+          ]
         },
         "AllFiles": {
-          "Local": {
-            "chapter1.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "toc.ncx": {
+            {
               "$ref": 2
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB2/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB2/testcases.json
@@ -159,7 +159,7 @@
           "Type": "LINK",
           "Title": "Chapter 1",
           "Link": {
-            "ContentFileName": "chapter1.html",
+            "ContentFileUrl": "chapter1.html",
             "ContentFilePath": "Content/chapter1.html",
             "Anchor": null
           },
@@ -171,7 +171,7 @@
               "Type": "LINK",
               "Title": "Chapter 1.1",
               "Link": {
-                "ContentFileName": "chapter1.html",
+                "ContentFileUrl": "chapter1.html",
                 "ContentFilePath": "Content/chapter1.html",
                 "Anchor": "section-1"
               },
@@ -183,7 +183,7 @@
               "Type": "LINK",
               "Title": "Chapter 1.2",
               "Link": {
-                "ContentFileName": "chapter1.html",
+                "ContentFileUrl": "chapter1.html",
                 "ContentFilePath": "Content/chapter1.html",
                 "Anchor": "section-2"
               },
@@ -197,7 +197,7 @@
           "Type": "LINK",
           "Title": "Chapter 2",
           "Link": {
-            "ContentFileName": "chapter2.html",
+            "ContentFileUrl": "chapter2.html",
             "ContentFilePath": "Content/chapter2.html",
             "Anchor": null
           },
@@ -209,7 +209,7 @@
           "Type": "LINK",
           "Title": "Chapter 3",
           "Link": {
-            "ContentFileName": "chapter3.html",
+            "ContentFileUrl": "chapter3.html",
             "ContentFilePath": "Content/chapter3.html",
             "Anchor": null
           },

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB2/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB2/testcases.json
@@ -698,103 +698,103 @@
           "$ref": 7
         },
         "Html": {
-          "Local": {
-            "front.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "cover.html": {
+            {
               "$ref": 2
             },
-            "chapter1.html": {
+            {
               "$ref": 3
             },
-            "chapter2.html": {
+            {
               "$ref": 4
             },
-            "chapter3.html": {
+            {
               "$ref": 5
             }
-          }
+          ]
         },
         "Css": {
-          "Local": {
-            "styles.css": {
+          "Local": [
+            {
               "$ref": 6
             }
-          }
+          ]
         },
         "Images": {
-          "Local": {
-            "cover.jpg": {
+          "Local": [
+            {
               "$ref": 7
             },
-            "image.jpg": {
+            {
               "$ref": 8
             }
-          }
+          ]
         },
         "Fonts": {
-          "Local": {
-            "font.ttf": {
+          "Local": [
+            {
               "$ref": 9
             }
-          }
+          ]
         },
         "Audio": {
-          "Local": {
-            "chapter1-audio.mp3": {
+          "Local": [
+            {
               "$ref": 10
             },
-            "title.mp3": {
+            {
               "$ref": 11
             }
-          }
+          ]
         },
         "AllFiles": {
-          "Local": {
-            "front.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "cover.html": {
+            {
               "$ref": 2
             },
-            "chapter1.html": {
+            {
               "$ref": 3
             },
-            "chapter2.html": {
+            {
               "$ref": 4
             },
-            "chapter3.html": {
+            {
               "$ref": 5
             },
-            "styles.css": {
+            {
               "$ref": 6
             },
-            "cover.jpg": {
+            {
               "$ref": 7
             },
-            "image.jpg": {
+            {
               "$ref": 8
             },
-            "font.ttf": {
+            {
               "$ref": 9
             },
-            "chapter1-audio.mp3": {
+            {
               "$ref": 10
             },
-            "title.mp3": {
+            {
               "$ref": 11
             },
-            "chapter2.xml": {
+            {
               "$ref": 12
             },
-            "chapter3.xml": {
+            {
               "$ref": 13
             },
-            "toc.ncx": {
+            {
               "$ref": 14
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB3/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB3/testcases.json
@@ -947,115 +947,115 @@
           "$ref": 6
         },
         "Html": {
-          "Local": {
-            "front.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "cover.html": {
+            {
               "$ref": 2
             },
-            "chapter1.html": {
+            {
               "$ref": 3
             },
-            "chapter2.html": {
+            {
               "$ref": 4
             },
-            "chapter3.html": {
+            {
               "$ref": 5
             },
-            "toc.html": {
+            {
               "$ref": 6
             }
-          }
+          ]
         },
         "Css": {
-          "Local": {
-            "styles.css": {
+          "Local": [
+            {
               "$ref": 7
             }
-          }
+          ]
         },
         "Images": {
-          "Local": {
-            "cover.jpg": {
+          "Local": [
+            {
               "$ref": 8
             },
-            "image.jpg": {
+            {
               "$ref": 9
             }
-          }
+          ]
         },
         "Fonts": {
-          "Local": {
-            "font.ttf": {
+          "Local": [
+            {
               "$ref": 10
             }
-          }
+          ]
         },
         "Audio": {
-          "Local": {
-            "chapter1-audio.mp3": {
+          "Local": [
+            {
               "$ref": 11
             },
-            "title.mp3": {
+            {
               "$ref": 12
             }
-          }
+          ]
         },
         "AllFiles": {
-          "Local": {
-            "front.html": {
+          "Local": [
+            {
               "$ref": 1
             },
-            "cover.html": {
+            {
               "$ref": 2
             },
-            "chapter1.html": {
+            {
               "$ref": 3
             },
-            "chapter2.html": {
+            {
               "$ref": 4
             },
-            "chapter3.html": {
+            {
               "$ref": 5
             },
-            "toc.html": {
+            {
               "$ref": 6
             },
-            "styles.css": {
+            {
               "$ref": 7
             },
-            "cover.jpg": {
+            {
               "$ref": 8
             },
-            "image.jpg": {
+            {
               "$ref": 9
             },
-            "font.ttf": {
+            {
               "$ref": 10
             },
-            "chapter1-audio.mp3": {
+            {
               "$ref": 11
             },
-            "title.mp3": {
+            {
               "$ref": 12
             },
-            "chapter1.smil": {
+            {
               "$ref": 13
             },
-            "chapter2.xml": {
+            {
               "$ref": 14
             },
-            "chapter3.xml": {
+            {
               "$ref": 15
             },
-            "book.atom": {
+            {
               "$ref": 16
             },
-            "toc.ncx": {
+            {
               "$ref": 17
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB3/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Typical/EPUB3/testcases.json
@@ -197,7 +197,7 @@
                   "Type": "LINK",
                   "Title": "Chapter 1",
                   "Link": {
-                    "ContentFileName": "chapter1.html",
+                    "ContentFileUrl": "chapter1.html",
                     "ContentFilePath": "Content/chapter1.html",
                     "Anchor": null
                   },
@@ -215,7 +215,7 @@
                   "Type": "LINK",
                   "Title": "Chapter 2",
                   "Link": {
-                    "ContentFileName": "chapter2.html",
+                    "ContentFileUrl": "chapter2.html",
                     "ContentFilePath": "Content/chapter2.html",
                     "Anchor": null
                   },
@@ -227,7 +227,7 @@
                   "Type": "LINK",
                   "Title": "Chapter 3",
                   "Link": {
-                    "ContentFileName": "chapter3.html",
+                    "ContentFileUrl": "chapter3.html",
                     "ContentFilePath": "Content/chapter3.html",
                     "Anchor": null
                   },

--- a/Source/VersOne.Epub.Test/Integration/TestCases/Workarounds/Xml11/testcases.json
+++ b/Source/VersOne.Epub.Test/Integration/TestCases/Workarounds/Xml11/testcases.json
@@ -75,11 +75,11 @@
       },
       "Content": {
         "AllFiles": {
-          "Local": {
-            "toc.ncx": {
+          "Local": [
+            {
               "$ref": 1
             }
-          }
+          ]
         }
       }
     }

--- a/Source/VersOne.Epub.Test/Integration/Types/TestCase.cs
+++ b/Source/VersOne.Epub.Test/Integration/Types/TestCase.cs
@@ -27,11 +27,11 @@ namespace VersOne.Epub.Test.Integration.Types
                 return null;
             }
             List<EpubContentFile> result = new(epubBook.Content.AllFiles.Local.Count + epubBook.Content.AllFiles.Remote.Count);
-            foreach (EpubContentFile epubContentFile in epubBook.Content.AllFiles.Local.Values)
+            foreach (EpubContentFile epubContentFile in epubBook.Content.AllFiles.Local)
             {
                 result.Add(epubContentFile);
             }
-            foreach (EpubContentFile epubContentFile in epubBook.Content.AllFiles.Remote.Values)
+            foreach (EpubContentFile epubContentFile in epubBook.Content.AllFiles.Remote)
             {
                 result.Add(epubContentFile);
             }

--- a/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefMetadataTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefMetadataTests.cs
@@ -1,4 +1,4 @@
-﻿namespace VersOne.Epub.Test.Unit.Content
+﻿namespace VersOne.Epub.Test.Unit.Content.Base
 {
     public class EpubContentFileRefMetadataTests
     {

--- a/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefTests.cs
@@ -1,6 +1,6 @@
 ﻿using VersOne.Epub.Test.Unit.Mocks;
 
-namespace VersOne.Epub.Test.Unit.Content
+namespace VersOne.Epub.Test.Unit.Content.Base
 {
     public class EpubContentFileRefTests
     {

--- a/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileTests.cs
@@ -1,4 +1,4 @@
-﻿namespace VersOne.Epub.Test.Unit.Content
+﻿namespace VersOne.Epub.Test.Unit.Content.Base
 {
     public class EpubContentFileTests
     {

--- a/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionRefTests.cs
@@ -1,0 +1,566 @@
+﻿using System.Collections.ObjectModel;
+using VersOne.Epub.Test.Comparers;
+using VersOne.Epub.Test.Unit.Mocks;
+using VersOne.Epub.Test.Unit.TestData;
+using static VersOne.Epub.Test.Unit.TestData.TestEpubData;
+
+namespace VersOne.Epub.Test.Unit.Content.Collections
+{
+    public class EpubContentCollectionRefTests
+    {
+        private static ReadOnlyCollection<EpubLocalTextContentFileRef> Local
+        {
+            get
+            {
+                List<EpubLocalTextContentFileRef> list = new()
+                {
+                    TestEpubContentRef.Chapter1FileRef,
+                    TestEpubContentRef.Chapter2FileRef
+                };
+                return list.AsReadOnly();
+            }
+        }
+
+        private static ReadOnlyCollection<EpubRemoteTextContentFileRef> Remote
+        {
+            get
+            {
+                List<EpubRemoteTextContentFileRef> list = new()
+                {
+                    TestEpubContentRef.RemoteHtmlContentFileRef,
+                    TestEpubContentRef.RemoteCssContentFileRef
+                };
+                return list.AsReadOnly();
+            }
+        }
+
+        private static IEpubContentLoader ContentLoader => new TestEpubContentLoader();
+
+        [Fact(DisplayName = "Constructing a EpubContentCollectionRef instance with default parameters should succeed")]
+        public void ConstructorWithNonNullParametersTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new();
+            Assert.NotNull(epubContentCollectionRef.Local);
+            Assert.Empty(epubContentCollectionRef.Local);
+            Assert.NotNull(epubContentCollectionRef.Remote);
+            Assert.Empty(epubContentCollectionRef.Remote);
+        }
+
+        [Fact(DisplayName = "Constructing a EpubContentCollectionRef instance with null local parameter should succeed")]
+        public void ConstructorWithNullLocalParameterTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(null, Remote);
+            Assert.NotNull(epubContentCollectionRef.Local);
+            Assert.Empty(epubContentCollectionRef.Local);
+            CompareRemoteTextRefReadOnlyCollections(Remote, epubContentCollectionRef.Remote);
+        }
+
+        [Fact(DisplayName = "Constructing a EpubContentCollectionRef instance with null remote parameter should succeed")]
+        public void ConstructorWithNullRemoteParameterTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, null);
+            CompareLocalTextRefReadOnlyCollections(Local, epubContentCollectionRef.Local);
+            Assert.NotNull(epubContentCollectionRef.Remote);
+            Assert.Empty(epubContentCollectionRef.Remote);
+        }
+
+        [Fact(DisplayName = "Constructor should throw EpubPackageException if local parameter contains content files with duplicate keys")]
+        public void ConstructorWithLocalDuplicateKeysTest()
+        {
+            string duplicateKey = CHAPTER1_FILE_NAME;
+            ReadOnlyCollection<EpubLocalTextContentFileRef> localWithDuplicateKeys = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: duplicateKey,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: CHAPTER1_FILE_PATH,
+                        epubContentLoader: ContentLoader
+                    ),
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: duplicateKey,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: CHAPTER2_FILE_PATH,
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            Assert.Throws<EpubPackageException>(() => new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(localWithDuplicateKeys, Remote));
+        }
+
+        [Fact(DisplayName = "Constructor should throw EpubPackageException if local parameter contains content files with duplicate file paths")]
+        public void ConstructorWithLocalDuplicateFilePathsTest()
+        {
+            string duplicateFilePath = CHAPTER1_FILE_PATH;
+            ReadOnlyCollection<EpubLocalTextContentFileRef> localWithDuplicateFilePaths = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: CHAPTER1_FILE_NAME,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: duplicateFilePath,
+                        epubContentLoader: ContentLoader
+                    ),
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: CHAPTER2_FILE_NAME,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: duplicateFilePath,
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            Assert.Throws<EpubPackageException>(() => new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(localWithDuplicateFilePaths, Remote));
+        }
+
+        [Fact(DisplayName = "Constructor should throw EpubPackageException if remote parameter contains content files with duplicate URLs")]
+        public void ConstructorWithRemoteDuplicateUrlsTest()
+        {
+            string duplicateKey = REMOTE_HTML_CONTENT_FILE_HREF;
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remoteWithDuplicateKeys = new
+            (
+                new List<EpubRemoteTextContentFileRef>()
+                {
+                    new EpubRemoteTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: duplicateKey,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        epubContentLoader: ContentLoader
+                    ),
+                    new EpubRemoteTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: duplicateKey,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            Assert.Throws<EpubPackageException>(() => new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(Local, remoteWithDuplicateKeys));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileRefWithKey should return true if the local file reference with the given key exists and false otherwise")]
+        public void ContainsLocalFileWithKeyWithNonNullKeyTest()
+        {
+            string existingKey = CHAPTER1_FILE_NAME;
+            string nonExistingKey = CHAPTER2_FILE_NAME;
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: existingKey,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: CHAPTER1_FILE_PATH,
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            Assert.True(epubContentCollectionRef.ContainsLocalFileRefWithKey(existingKey));
+            Assert.False(epubContentCollectionRef.ContainsLocalFileRefWithKey(nonExistingKey));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileRefWithKey should throw ArgumentNullException if key argument is null")]
+        public void ContainsLocalFileWithKeyWithNullKeyTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.ContainsLocalFileRefWithKey(null!));
+        }
+
+        [Fact(DisplayName = "GetLocalFileRefByKey should return the local file reference with the given key if it exists")]
+        public void GetLocalFileByKeyWithExistingKeyTest()
+        {
+            string existingKey = CHAPTER1_FILE_NAME;
+            EpubLocalTextContentFileRef expectedFileRef = new
+            (
+                metadata: new EpubContentFileRefMetadata
+                (
+                    key: existingKey,
+                    contentType: HTML_CONTENT_TYPE,
+                    contentMimeType: HTML_CONTENT_MIME_TYPE
+                ),
+                filePath: CHAPTER1_FILE_PATH,
+                epubContentLoader: ContentLoader
+            );
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    expectedFileRef
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            EpubLocalTextContentFileRef actualFileRef = epubContentCollectionRef.GetLocalFileRefByKey(existingKey);
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(expectedFileRef, actualFileRef);
+        }
+
+        [Fact(DisplayName = "GetLocalFileRefByKey should throw EpubContentCollectionRefException if the local file reference with the given key doesn't exist")]
+        public void GetLocalFileByKeyWithNonExistingKeyTest()
+        {
+            string nonExistingKey = CHAPTER2_FILE_NAME;
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: CHAPTER1_FILE_NAME,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: CHAPTER1_FILE_PATH,
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            Assert.Throws<EpubContentCollectionRefException>(() => epubContentCollectionRef.GetLocalFileRefByKey(nonExistingKey));
+        }
+
+        [Fact(DisplayName = "GetLocalFileRefByKey should throw ArgumentNullException if key argument is null")]
+        public void GetLocalFileByKeyWithNullKeyTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.GetLocalFileRefByKey(null!));
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileRefByKey should return true with the local file reference with the given key if it exists and false with null reference otherwise")]
+        public void TryGetLocalFileByKeyWithNonNullKeyTest()
+        {
+            string existingKey = CHAPTER1_FILE_NAME;
+            string nonExistingKey = CHAPTER2_FILE_NAME;
+            EpubLocalTextContentFileRef expectedFileRef = new
+            (
+                metadata: new EpubContentFileRefMetadata
+                (
+                    key: existingKey,
+                    contentType: HTML_CONTENT_TYPE,
+                    contentMimeType: HTML_CONTENT_MIME_TYPE
+                ),
+                filePath: CHAPTER1_FILE_PATH,
+                epubContentLoader: ContentLoader
+            );
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    expectedFileRef
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            Assert.True(epubContentCollectionRef.TryGetLocalFileRefByKey(existingKey, out EpubLocalTextContentFileRef actualFileRefForExistingKey));
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(expectedFileRef, actualFileRefForExistingKey);
+            Assert.False(epubContentCollectionRef.TryGetLocalFileRefByKey(nonExistingKey, out EpubLocalTextContentFileRef actualFileRefForNonExistingKey));
+            Assert.Null(actualFileRefForNonExistingKey);
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileRefByKey should throw ArgumentNullException if key argument is null")]
+        public void TryGetLocalFileByKeyWithNullKeyTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.TryGetLocalFileRefByKey(null!, out _));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileRefWithFilePath should return true if the local file reference with the given file path exists and false otherwise")]
+        public void ContainsLocalFileWithFilePathWithNonNullFilePathTest()
+        {
+            string existingFilePath = CHAPTER1_FILE_PATH;
+            string nonExistingFilePath = CHAPTER2_FILE_PATH;
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: CHAPTER1_FILE_NAME,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: existingFilePath,
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            Assert.True(epubContentCollectionRef.ContainsLocalFileRefWithFilePath(existingFilePath));
+            Assert.False(epubContentCollectionRef.ContainsLocalFileRefWithFilePath(nonExistingFilePath));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileRefWithFilePath should throw ArgumentNullException if filePath argument is null")]
+        public void ContainsLocalFileWithFilePathWithNullFilePathTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.ContainsLocalFileRefWithFilePath(null!));
+        }
+
+        [Fact(DisplayName = "GetLocalFileRefByFilePath should return the local file reference with the given file path if it exists")]
+        public void GetLocalFileByFilePathWithExistingFilePathTest()
+        {
+            string existingFilePath = CHAPTER1_FILE_PATH;
+            EpubLocalTextContentFileRef expectedFileRef = new
+            (
+                metadata: new EpubContentFileRefMetadata
+                (
+                    key: CHAPTER1_FILE_NAME,
+                    contentType: HTML_CONTENT_TYPE,
+                    contentMimeType: HTML_CONTENT_MIME_TYPE
+                ),
+                filePath: existingFilePath,
+                epubContentLoader: ContentLoader
+            );
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    expectedFileRef
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            EpubLocalTextContentFileRef actualFileRef = epubContentCollectionRef.GetLocalFileRefByFilePath(existingFilePath);
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(expectedFileRef, actualFileRef);
+        }
+
+        [Fact(DisplayName = "GetLocalFileRefByFilePath should throw EpubContentCollectionRefException if the local file reference with the given file path doesn't exist")]
+        public void GetLocalFileByFilePathWithNonExistingFilePathTest()
+        {
+            string nonExistingFilePath = CHAPTER2_FILE_PATH;
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    new EpubLocalTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: CHAPTER1_FILE_NAME,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        filePath: CHAPTER1_FILE_PATH,
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            Assert.Throws<EpubContentCollectionRefException>(() => epubContentCollectionRef.GetLocalFileRefByFilePath(nonExistingFilePath));
+        }
+
+        [Fact(DisplayName = "GetLocalFileRefByFilePath should throw ArgumentNullException if filePath argument is null")]
+        public void GetLocalFileByFilePathWithNullFilePathTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.GetLocalFileRefByFilePath(null!));
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileRefByFilePath should return true with the local file reference with the given file path if it exists and false with null reference otherwise")]
+        public void TryGetLocalFileByFilePathWithNonNullFilePathTest()
+        {
+            string existingFilePath = CHAPTER1_FILE_PATH;
+            string nonExistingFilePath = CHAPTER2_FILE_PATH;
+            EpubLocalTextContentFileRef expectedFileRef = new
+            (
+                metadata: new EpubContentFileRefMetadata
+                (
+                    key: CHAPTER1_FILE_NAME,
+                    contentType: HTML_CONTENT_TYPE,
+                    contentMimeType: HTML_CONTENT_MIME_TYPE
+                ),
+                filePath: existingFilePath,
+                epubContentLoader: ContentLoader
+            );
+            ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
+            (
+                new List<EpubLocalTextContentFileRef>()
+                {
+                    expectedFileRef
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(local, Remote);
+            Assert.True(epubContentCollectionRef.TryGetLocalFileRefByFilePath(existingFilePath, out EpubLocalTextContentFileRef actualFileRefForExistingFilePath));
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(expectedFileRef, actualFileRefForExistingFilePath);
+            Assert.False(epubContentCollectionRef.TryGetLocalFileRefByFilePath(nonExistingFilePath, out EpubLocalTextContentFileRef actualFileRefForNonExistingFilePath));
+            Assert.Null(actualFileRefForNonExistingFilePath);
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileRefByFilePath should throw ArgumentNullException if filePath argument is null")]
+        public void TryGetLocalFileByFilePathWithNullFilePathTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.TryGetLocalFileRefByFilePath(null!, out _));
+        }
+
+        [Fact(DisplayName = "ContainsRemoteFileRefWithUrl should return true if the remote file reference with the given URL exists and false otherwise")]
+        public void ContainsRemoteFileWithUrlWithNonNullUrlTest()
+        {
+            string existingUrl = REMOTE_HTML_CONTENT_FILE_HREF;
+            string nonExistingUrl = REMOTE_CSS_CONTENT_FILE_HREF;
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remote = new
+            (
+                new List<EpubRemoteTextContentFileRef>()
+                {
+                    new EpubRemoteTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: existingUrl,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, remote);
+            Assert.True(epubContentCollectionRef.ContainsRemoteFileRefWithUrl(existingUrl));
+            Assert.False(epubContentCollectionRef.ContainsRemoteFileRefWithUrl(nonExistingUrl));
+        }
+
+        [Fact(DisplayName = "ContainsRemoteFileRefWithUrl should throw ArgumentNullException if url argument is null")]
+        public void ContainsRemoteFileWithUrlWithNullUrlTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.ContainsRemoteFileRefWithUrl(null!));
+        }
+
+        [Fact(DisplayName = "GetRemoteFileRefByUrl should return the remote file reference with the given URL if it exists")]
+        public void GetRemoteFileByUrlWithExistingUrlTest()
+        {
+            string existingUrl = REMOTE_HTML_CONTENT_FILE_HREF;
+            EpubRemoteTextContentFileRef expectedFileRef = new
+            (
+                metadata: new EpubContentFileRefMetadata
+                (
+                    key: existingUrl,
+                    contentType: HTML_CONTENT_TYPE,
+                    contentMimeType: HTML_CONTENT_MIME_TYPE
+                ),
+                epubContentLoader: ContentLoader
+            );
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remote = new
+            (
+                new List<EpubRemoteTextContentFileRef>()
+                {
+                    expectedFileRef
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, remote);
+            EpubRemoteTextContentFileRef actualFileRef = epubContentCollectionRef.GetRemoteFileRefByUrl(existingUrl);
+            EpubContentRefComparer.CompareEpubRemoteContentFileRefs(expectedFileRef, actualFileRef);
+        }
+
+        [Fact(DisplayName = "GetRemoteFileRefByUrl should throw EpubContentCollectionRefException if the remote file reference with the given URL doesn't exist")]
+        public void GetRemoteFileByUrlWithNonExistingUrlTest()
+        {
+            string nonExistingUrl = REMOTE_CSS_CONTENT_FILE_HREF;
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remote = new
+            (
+                new List<EpubRemoteTextContentFileRef>()
+                {
+                    new EpubRemoteTextContentFileRef
+                    (
+                        metadata: new EpubContentFileRefMetadata
+                        (
+                            key: REMOTE_HTML_CONTENT_FILE_HREF,
+                            contentType: HTML_CONTENT_TYPE,
+                            contentMimeType: HTML_CONTENT_MIME_TYPE
+                        ),
+                        epubContentLoader: ContentLoader
+                    )
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, remote);
+            Assert.Throws<EpubContentCollectionRefException>(() => epubContentCollectionRef.GetRemoteFileRefByUrl(nonExistingUrl));
+        }
+
+        [Fact(DisplayName = "GetRemoteFileRefByUrl should throw ArgumentNullException if url argument is null")]
+        public void GetRemoteFileByUrlWithNullUrlTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.GetRemoteFileRefByUrl(null!));
+        }
+
+        [Fact(DisplayName = "TryGetRemoteFileRefByUrl should return true with the remote file reference with the given URL if it exists and false with null reference otherwise")]
+        public void TryGetRemoteFileByUrlWithNonNullUrlTest()
+        {
+            string existingUrl = REMOTE_HTML_CONTENT_FILE_HREF;
+            string nonExistingUrl = REMOTE_CSS_CONTENT_FILE_HREF;
+            EpubRemoteTextContentFileRef expectedFileRef = new
+            (
+                metadata: new EpubContentFileRefMetadata
+                (
+                    key: existingUrl,
+                    contentType: HTML_CONTENT_TYPE,
+                    contentMimeType: HTML_CONTENT_MIME_TYPE
+                ),
+                epubContentLoader: ContentLoader
+            );
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remote = new
+            (
+                new List<EpubRemoteTextContentFileRef>()
+                {
+                    expectedFileRef
+                }
+            );
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, remote);
+            Assert.True(epubContentCollectionRef.TryGetRemoteFileRefByUrl(existingUrl, out EpubRemoteTextContentFileRef actualFileRefForExistingUrl));
+            EpubContentRefComparer.CompareEpubRemoteContentFileRefs(expectedFileRef, actualFileRefForExistingUrl);
+            Assert.False(epubContentCollectionRef.TryGetRemoteFileRefByUrl(nonExistingUrl, out EpubRemoteTextContentFileRef actualFileRefForNonExistingUrl));
+            Assert.Null(actualFileRefForNonExistingUrl);
+        }
+
+        [Fact(DisplayName = "TryGetRemoteFileRefByUrl should throw ArgumentNullException if url argument is null")]
+        public void TryGetRemoteFileByUrlWithNullUrlTest()
+        {
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollectionRef.TryGetRemoteFileRefByUrl(null!, out _));
+        }
+
+        private static void CompareLocalTextRefReadOnlyCollections(ReadOnlyCollection<EpubLocalTextContentFileRef> expected, ReadOnlyCollection<EpubLocalTextContentFileRef> actual)
+        {
+            CollectionComparer.CompareCollections(expected, actual, EpubContentRefComparer.CompareEpubLocalContentFileRefs);
+        }
+
+        private static void CompareRemoteTextRefReadOnlyCollections(ReadOnlyCollection<EpubRemoteTextContentFileRef> expected, ReadOnlyCollection<EpubRemoteTextContentFileRef> actual)
+        {
+            CollectionComparer.CompareCollections(expected, actual, EpubContentRefComparer.CompareEpubRemoteContentFileRefs);
+        }
+    }
+}

--- a/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionTests.cs
@@ -1,0 +1,509 @@
+﻿using System.Collections.ObjectModel;
+using VersOne.Epub.Test.Comparers;
+using VersOne.Epub.Test.Unit.TestData;
+using static VersOne.Epub.Test.Unit.TestData.TestEpubData;
+
+namespace VersOne.Epub.Test.Unit.Content.Collections
+{
+    public class EpubContentCollectionTests
+    {
+        private static ReadOnlyCollection<EpubLocalTextContentFile> Local
+        {
+            get
+            {
+                List<EpubLocalTextContentFile> list = new()
+                {
+                    TestEpubContent.Chapter1File,
+                    TestEpubContent.Chapter2File
+                };
+                return list.AsReadOnly();
+            }
+        }
+
+        private static ReadOnlyCollection<EpubRemoteTextContentFile> Remote
+        {
+            get
+            {
+                List<EpubRemoteTextContentFile> list = new()
+                {
+                    TestEpubContent.RemoteHtmlContentFile,
+                    TestEpubContent.RemoteCssContentFile
+                };
+                return list.AsReadOnly();
+            }
+        }
+
+        [Fact(DisplayName = "Constructing a EpubContentCollection instance with default parameters should succeed")]
+        public void ConstructorWithNonNullParametersTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new();
+            Assert.NotNull(epubContentCollection.Local);
+            Assert.Empty(epubContentCollection.Local);
+            Assert.NotNull(epubContentCollection.Remote);
+            Assert.Empty(epubContentCollection.Remote);
+        }
+
+        [Fact(DisplayName = "Constructing a EpubContentCollection instance with null local parameter should succeed")]
+        public void ConstructorWithNullLocalParameterTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(null, Remote);
+            Assert.NotNull(epubContentCollection.Local);
+            Assert.Empty(epubContentCollection.Local);
+            CompareRemoteTextReadOnlyCollections(Remote, epubContentCollection.Remote);
+        }
+
+        [Fact(DisplayName = "Constructing a EpubContentCollection instance with null remote parameter should succeed")]
+        public void ConstructorWithNullRemoteParameterTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, null);
+            CompareLocalTextReadOnlyCollections(Local, epubContentCollection.Local);
+            Assert.NotNull(epubContentCollection.Remote);
+            Assert.Empty(epubContentCollection.Remote);
+        }
+
+        [Fact(DisplayName = "Constructor should throw EpubPackageException if local parameter contains content files with duplicate keys")]
+        public void ConstructorWithLocalDuplicateKeysTest()
+        {
+            string duplicateKey = CHAPTER1_FILE_NAME;
+            ReadOnlyCollection<EpubLocalTextContentFile> localWithDuplicateKeys = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    new EpubLocalTextContentFile
+                    (
+                        key: duplicateKey,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: CHAPTER1_FILE_PATH,
+                        content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+                    ),
+                    new EpubLocalTextContentFile
+                    (
+                        key: duplicateKey,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: CHAPTER2_FILE_PATH,
+                        content: TestEpubFiles.CHAPTER2_FILE_CONTENT
+                    )
+                }
+            );
+            Assert.Throws<EpubPackageException>(() => new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>(localWithDuplicateKeys, Remote));
+        }
+
+        [Fact(DisplayName = "Constructor should throw EpubPackageException if local parameter contains content files with duplicate file paths")]
+        public void ConstructorWithLocalDuplicateFilePathsTest()
+        {
+            string duplicateFilePath = CHAPTER1_FILE_PATH;
+            ReadOnlyCollection<EpubLocalTextContentFile> localWithDuplicateFilePaths = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    new EpubLocalTextContentFile
+                    (
+                        key: CHAPTER1_FILE_NAME,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: duplicateFilePath,
+                        content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+                    ),
+                    new EpubLocalTextContentFile
+                    (
+                        key: CHAPTER2_FILE_NAME,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: duplicateFilePath,
+                        content: TestEpubFiles.CHAPTER2_FILE_CONTENT
+                    )
+                }
+            );
+            Assert.Throws<EpubPackageException>(() => new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>(localWithDuplicateFilePaths, Remote));
+        }
+
+        [Fact(DisplayName = "Constructor should throw EpubPackageException if remote parameter contains content files with duplicate URLs")]
+        public void ConstructorWithRemoteDuplicateUrlsTest()
+        {
+            string duplicateKey = REMOTE_HTML_CONTENT_FILE_HREF;
+            ReadOnlyCollection<EpubRemoteTextContentFile> remoteWithDuplicateKeys = new
+            (
+                new List<EpubRemoteTextContentFile>()
+                {
+                    new EpubRemoteTextContentFile
+                    (
+                        key: duplicateKey,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        content: TestEpubFiles.REMOTE_HTML_FILE_CONTENT
+                    ),
+                    new EpubRemoteTextContentFile
+                    (
+                        key: duplicateKey,
+                        contentType: CSS_CONTENT_TYPE,
+                        contentMimeType: CSS_CONTENT_MIME_TYPE,
+                        content: TestEpubFiles.REMOTE_CSS_FILE_CONTENT
+                    )
+                }
+            );
+            Assert.Throws<EpubPackageException>(() => new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>(Local, remoteWithDuplicateKeys));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileWithKey should return true if the local file with the given key exists and false otherwise")]
+        public void ContainsLocalFileWithKeyWithNonNullKeyTest()
+        {
+            string existingKey = CHAPTER1_FILE_NAME;
+            string nonExistingKey = CHAPTER2_FILE_NAME;
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    new EpubLocalTextContentFile
+                    (
+                        key: existingKey,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: CHAPTER1_FILE_PATH,
+                        content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+                    )
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            Assert.True(epubContentCollection.ContainsLocalFileWithKey(existingKey));
+            Assert.False(epubContentCollection.ContainsLocalFileWithKey(nonExistingKey));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileWithKey should throw ArgumentNullException if key argument is null")]
+        public void ContainsLocalFileWithKeyWithNullKeyTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.ContainsLocalFileWithKey(null!));
+        }
+
+        [Fact(DisplayName = "GetLocalFileByKey should return the local file with the given key if it exists")]
+        public void GetLocalFileByKeyWithExistingKeyTest()
+        {
+            string existingKey = CHAPTER1_FILE_NAME;
+            EpubLocalTextContentFile expectedFile = new
+            (
+                key: existingKey,
+                contentType: HTML_CONTENT_TYPE,
+                contentMimeType: HTML_CONTENT_MIME_TYPE,
+                filePath: CHAPTER1_FILE_PATH,
+                content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+            );
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    expectedFile
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            EpubLocalTextContentFile actualFile = epubContentCollection.GetLocalFileByKey(existingKey);
+            EpubContentComparer.CompareEpubLocalTextContentFiles(expectedFile, actualFile);
+        }
+
+        [Fact(DisplayName = "GetLocalFileByKey should throw EpubContentCollectionException if the local file with the given key doesn't exist")]
+        public void GetLocalFileByKeyWithNonExistingKeyTest()
+        {
+            string nonExistingKey = CHAPTER2_FILE_NAME;
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    new EpubLocalTextContentFile
+                    (
+                        key: CHAPTER1_FILE_NAME,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: CHAPTER1_FILE_PATH,
+                        content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+                    )
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            Assert.Throws<EpubContentCollectionException>(() => epubContentCollection.GetLocalFileByKey(nonExistingKey));
+        }
+
+        [Fact(DisplayName = "GetLocalFileByKey should throw ArgumentNullException if key argument is null")]
+        public void GetLocalFileByKeyWithNullKeyTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.GetLocalFileByKey(null!));
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileByKey should return true with the local file with the given key if it exists and false with null reference otherwise")]
+        public void TryGetLocalFileByKeyWithNonNullKeyTest()
+        {
+            string existingKey = CHAPTER1_FILE_NAME;
+            string nonExistingKey = CHAPTER2_FILE_NAME;
+            EpubLocalTextContentFile expectedFile = new
+            (
+                key: existingKey,
+                contentType: HTML_CONTENT_TYPE,
+                contentMimeType: HTML_CONTENT_MIME_TYPE,
+                filePath: CHAPTER1_FILE_PATH,
+                content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+            );
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    expectedFile
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            Assert.True(epubContentCollection.TryGetLocalFileByKey(existingKey, out EpubLocalTextContentFile actualFileForExistingKey));
+            EpubContentComparer.CompareEpubLocalTextContentFiles(expectedFile, actualFileForExistingKey);
+            Assert.False(epubContentCollection.TryGetLocalFileByKey(nonExistingKey, out EpubLocalTextContentFile actualFileForNonExistingKey));
+            Assert.Null(actualFileForNonExistingKey);
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileByKey should throw ArgumentNullException if key argument is null")]
+        public void TryGetLocalFileByKeyWithNullKeyTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.TryGetLocalFileByKey(null!, out _));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileWithFilePath should return true if the local file with the given file path exists and false otherwise")]
+        public void ContainsLocalFileWithFilePathWithNonNullFilePathTest()
+        {
+            string existingFilePath = CHAPTER1_FILE_PATH;
+            string nonExistingFilePath = CHAPTER2_FILE_PATH;
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    new EpubLocalTextContentFile
+                    (
+                        key: CHAPTER1_FILE_NAME,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: existingFilePath,
+                        content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+                    )
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            Assert.True(epubContentCollection.ContainsLocalFileWithFilePath(existingFilePath));
+            Assert.False(epubContentCollection.ContainsLocalFileWithFilePath(nonExistingFilePath));
+        }
+
+        [Fact(DisplayName = "ContainsLocalFileWithFilePath should throw ArgumentNullException if filePath argument is null")]
+        public void ContainsLocalFileWithFilePathWithNullFilePathTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.ContainsLocalFileWithFilePath(null!));
+        }
+
+        [Fact(DisplayName = "GetLocalFileByFilePath should return the local file with the given file path if it exists")]
+        public void GetLocalFileByFilePathWithExistingFilePathTest()
+        {
+            string existingFilePath = CHAPTER1_FILE_PATH;
+            EpubLocalTextContentFile expectedFile = new
+            (
+                key: CHAPTER1_FILE_NAME,
+                contentType: HTML_CONTENT_TYPE,
+                contentMimeType: HTML_CONTENT_MIME_TYPE,
+                filePath: existingFilePath,
+                content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+            );
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    expectedFile
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            EpubLocalTextContentFile actualFile = epubContentCollection.GetLocalFileByFilePath(existingFilePath);
+            EpubContentComparer.CompareEpubLocalTextContentFiles(expectedFile, actualFile);
+        }
+
+        [Fact(DisplayName = "GetLocalFileByFilePath should throw EpubContentCollectionException if the local file with the given file path doesn't exist")]
+        public void GetLocalFileByFilePathWithNonExistingFilePathTest()
+        {
+            string nonExistingFilePath = CHAPTER2_FILE_PATH;
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    new EpubLocalTextContentFile
+                    (
+                        key: CHAPTER1_FILE_NAME,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        filePath: CHAPTER1_FILE_PATH,
+                        content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+                    )
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            Assert.Throws<EpubContentCollectionException>(() => epubContentCollection.GetLocalFileByFilePath(nonExistingFilePath));
+        }
+
+        [Fact(DisplayName = "GetLocalFileByFilePath should throw ArgumentNullException if filePath argument is null")]
+        public void GetLocalFileByFilePathWithNullFilePathTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.GetLocalFileByFilePath(null!));
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileByFilePath should return true with the local file with the given file path if it exists and false with null reference otherwise")]
+        public void TryGetLocalFileByFilePathWithNonNullFilePathTest()
+        {
+            string existingFilePath = CHAPTER1_FILE_PATH;
+            string nonExistingFilePath = CHAPTER2_FILE_PATH;
+            EpubLocalTextContentFile expectedFile = new
+            (
+                key: CHAPTER1_FILE_NAME,
+                contentType: HTML_CONTENT_TYPE,
+                contentMimeType: HTML_CONTENT_MIME_TYPE,
+                filePath: existingFilePath,
+                content: TestEpubFiles.CHAPTER1_FILE_CONTENT
+            );
+            ReadOnlyCollection<EpubLocalTextContentFile> local = new
+            (
+                new List<EpubLocalTextContentFile>()
+                {
+                    expectedFile
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(local, Remote);
+            Assert.True(epubContentCollection.TryGetLocalFileByFilePath(existingFilePath, out EpubLocalTextContentFile actualFileForExistingFilePath));
+            EpubContentComparer.CompareEpubLocalTextContentFiles(expectedFile, actualFileForExistingFilePath);
+            Assert.False(epubContentCollection.TryGetLocalFileByFilePath(nonExistingFilePath, out EpubLocalTextContentFile actualFileForNonExistingFilePath));
+            Assert.Null(actualFileForNonExistingFilePath);
+        }
+
+        [Fact(DisplayName = "TryGetLocalFileByFilePath should throw ArgumentNullException if filePath argument is null")]
+        public void TryGetLocalFileByFilePathWithNullFilePathTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.TryGetLocalFileByFilePath(null!, out _));
+        }
+
+        [Fact(DisplayName = "ContainsRemoteFileWithUrl should return true if the remote file with the given URL exists and false otherwise")]
+        public void ContainsRemoteFileWithUrlWithNonNullUrlTest()
+        {
+            string existingUrl = REMOTE_HTML_CONTENT_FILE_HREF;
+            string nonExistingUrl = REMOTE_CSS_CONTENT_FILE_HREF;
+            ReadOnlyCollection<EpubRemoteTextContentFile> remote = new
+            (
+                new List<EpubRemoteTextContentFile>()
+                {
+                    new EpubRemoteTextContentFile
+                    (
+                        key: existingUrl,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        content: TestEpubFiles.REMOTE_HTML_FILE_CONTENT
+                    )
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, remote);
+            Assert.True(epubContentCollection.ContainsRemoteFileWithUrl(existingUrl));
+            Assert.False(epubContentCollection.ContainsRemoteFileWithUrl(nonExistingUrl));
+        }
+
+        [Fact(DisplayName = "ContainsRemoteFileWithUrl should throw ArgumentNullException if url argument is null")]
+        public void ContainsRemoteFileWithUrlWithNullUrlTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.ContainsRemoteFileWithUrl(null!));
+        }
+
+        [Fact(DisplayName = "GetRemoteFileByUrl should return the remote file with the given URL if it exists")]
+        public void GetRemoteFileByUrlWithExistingUrlTest()
+        {
+            string existingUrl = REMOTE_HTML_CONTENT_FILE_HREF;
+            EpubRemoteTextContentFile expectedFile = new
+            (
+                key: existingUrl,
+                contentType: HTML_CONTENT_TYPE,
+                contentMimeType: HTML_CONTENT_MIME_TYPE,
+                content: TestEpubFiles.REMOTE_HTML_FILE_CONTENT
+            );
+            ReadOnlyCollection<EpubRemoteTextContentFile> remote = new
+            (
+                new List<EpubRemoteTextContentFile>()
+                {
+                    expectedFile
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, remote);
+            EpubRemoteTextContentFile actualFile = epubContentCollection.GetRemoteFileByUrl(existingUrl);
+            EpubContentComparer.CompareEpubRemoteTextContentFiles(expectedFile, actualFile);
+        }
+
+        [Fact(DisplayName = "GetRemoteFileByUrl should throw EpubContentCollectionException if the remote file with the given URL doesn't exist")]
+        public void GetRemoteFileByUrlWithNonExistingUrlTest()
+        {
+            string nonExistingUrl = REMOTE_CSS_CONTENT_FILE_HREF;
+            ReadOnlyCollection<EpubRemoteTextContentFile> remote = new
+            (
+                new List<EpubRemoteTextContentFile>()
+                {
+                    new EpubRemoteTextContentFile
+                    (
+                        key: REMOTE_HTML_CONTENT_FILE_HREF,
+                        contentType: HTML_CONTENT_TYPE,
+                        contentMimeType: HTML_CONTENT_MIME_TYPE,
+                        content: TestEpubFiles.REMOTE_HTML_FILE_CONTENT
+                    )
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, remote);
+            Assert.Throws<EpubContentCollectionException>(() => epubContentCollection.GetRemoteFileByUrl(nonExistingUrl));
+        }
+
+        [Fact(DisplayName = "GetRemoteFileByUrl should throw ArgumentNullException if url argument is null")]
+        public void GetRemoteFileByUrlWithNullUrlTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.GetRemoteFileByUrl(null!));
+        }
+
+        [Fact(DisplayName = "TryGetRemoteFileByUrl should return true with the remote file with the given URL if it exists and false with null reference otherwise")]
+        public void TryGetRemoteFileByUrlWithNonNullUrlTest()
+        {
+            string existingUrl = REMOTE_HTML_CONTENT_FILE_HREF;
+            string nonExistingUrl = REMOTE_CSS_CONTENT_FILE_HREF;
+            EpubRemoteTextContentFile expectedFile = new
+            (
+                key: existingUrl,
+                contentType: HTML_CONTENT_TYPE,
+                contentMimeType: HTML_CONTENT_MIME_TYPE,
+                content: TestEpubFiles.REMOTE_HTML_FILE_CONTENT
+            );
+            ReadOnlyCollection<EpubRemoteTextContentFile> remote = new
+            (
+                new List<EpubRemoteTextContentFile>()
+                {
+                    expectedFile
+                }
+            );
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, remote);
+            Assert.True(epubContentCollection.TryGetRemoteFileByUrl(existingUrl, out EpubRemoteTextContentFile actualFileForExistingUrl));
+            EpubContentComparer.CompareEpubRemoteTextContentFiles(expectedFile, actualFileForExistingUrl);
+            Assert.False(epubContentCollection.TryGetRemoteFileByUrl(nonExistingUrl, out EpubRemoteTextContentFile actualFileForNonExistingUrl));
+            Assert.Null(actualFileForNonExistingUrl);
+        }
+
+        [Fact(DisplayName = "TryGetRemoteFileByUrl should throw ArgumentNullException if url argument is null")]
+        public void TryGetRemoteFileByUrlWithNullUrlTest()
+        {
+            EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile> epubContentCollection = new(Local, Remote);
+            Assert.Throws<ArgumentNullException>(() => epubContentCollection.TryGetRemoteFileByUrl(null!, out _));
+        }
+
+        private static void CompareLocalTextReadOnlyCollections(ReadOnlyCollection<EpubLocalTextContentFile> expected, ReadOnlyCollection<EpubLocalTextContentFile> actual)
+        {
+            CollectionComparer.CompareCollections(expected, actual, EpubContentComparer.CompareEpubLocalTextContentFiles);
+        }
+
+        private static void CompareRemoteTextReadOnlyCollections(ReadOnlyCollection<EpubRemoteTextContentFile> expected, ReadOnlyCollection<EpubRemoteTextContentFile> actual)
+        {
+            CollectionComparer.CompareCollections(expected, actual, EpubContentComparer.CompareEpubRemoteTextContentFiles);
+        }
+    }
+}

--- a/Source/VersOne.Epub.Test/Unit/Content/EpubContentFileTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/EpubContentFileTests.cs
@@ -46,7 +46,7 @@
         [Fact(DisplayName = "Constructing a EpubRemoteTextContentFile instance with non-null parameters should succeed")]
         public void RemoteTextContentFileConstructorTest()
         {
-            EpubRemoteTextContentFile epubRemoteTextContentFile = new(REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT);
+            EpubRemoteTextContentFile epubRemoteTextContentFile = new(REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, TEXT_FILE_CONTENT);
             Assert.Equal(REMOTE_TEXT_FILE_HREF, epubRemoteTextContentFile.Key);
             Assert.Equal(TEXT_FILE_CONTENT_TYPE, epubRemoteTextContentFile.ContentType);
             Assert.Equal(TEXT_FILE_CONTENT_MIME_TYPE, epubRemoteTextContentFile.ContentMimeType);
@@ -59,7 +59,7 @@
         [Fact(DisplayName = "Constructing a EpubRemoteByteContentFile instance with non-null parameters should succeed")]
         public void RemoteByteContentFileConstructorTest()
         {
-            EpubRemoteByteContentFile epubRemoteByteContentFile = new(REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT);
+            EpubRemoteByteContentFile epubRemoteByteContentFile = new(REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, BYTE_FILE_CONTENT);
             Assert.Equal(REMOTE_BYTE_FILE_HREF, epubRemoteByteContentFile.Key);
             Assert.Equal(BYTE_FILE_CONTENT_TYPE, epubRemoteByteContentFile.ContentType);
             Assert.Equal(BYTE_FILE_CONTENT_MIME_TYPE, epubRemoteByteContentFile.ContentMimeType);
@@ -87,14 +87,14 @@
         public void RemoteTextContentFileConstructorWithNullKeyTest()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new EpubRemoteTextContentFile(null!, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT));
+                new EpubRemoteTextContentFile(null!, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, TEXT_FILE_CONTENT));
         }
 
         [Fact(DisplayName = "EpubRemoteByteContentFile constructor should throw ArgumentNullException if key parameter is null")]
         public void RemoteByteContentFileConstructorWithNullKeyTest()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new EpubRemoteByteContentFile(null!, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT));
+                new EpubRemoteByteContentFile(null!, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, BYTE_FILE_CONTENT));
         }
 
         [Fact(DisplayName = "EpubLocalTextContentFile constructor should throw ArgumentNullException if contentMimeType parameter is null")]
@@ -115,14 +115,14 @@
         public void RemoteTextContentFileConstructorWithNullContentMimeTypeTest()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new EpubRemoteTextContentFile(REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT_TYPE, null!, REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT));
+                new EpubRemoteTextContentFile(REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT_TYPE, null!, TEXT_FILE_CONTENT));
         }
 
         [Fact(DisplayName = "EpubRemoteByteContentFile constructor should throw ArgumentNullException if contentMimeType parameter is null")]
         public void RemoteByteContentFileConstructorWithNullContentMimeTypeTest()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new EpubRemoteByteContentFile(REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT_TYPE, null!, REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT));
+                new EpubRemoteByteContentFile(REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT_TYPE, null!, BYTE_FILE_CONTENT));
         }
 
         [Fact(DisplayName = "EpubLocalTextContentFile constructor should throw ArgumentNullException if filePath parameter is null")]
@@ -137,20 +137,6 @@
         {
             Assert.Throws<ArgumentNullException>(() =>
                 new EpubLocalByteContentFile(LOCAL_BYTE_FILE_NAME, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, null!, BYTE_FILE_CONTENT));
-        }
-
-        [Fact(DisplayName = "EpubRemoteTextContentFile constructor should throw ArgumentNullException if url parameter is null")]
-        public void RemoteTextContentFileConstructorWithNullUrlTest()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                new EpubRemoteTextContentFile(REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, null!, TEXT_FILE_CONTENT));
-        }
-
-        [Fact(DisplayName = "EpubRemoteByteContentFile constructor should throw ArgumentNullException if url parameter is null")]
-        public void RemoteByteContentFileConstructorWithNullUrlTest()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                new EpubRemoteByteContentFile(REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, null!, BYTE_FILE_CONTENT));
         }
 
         [Fact(DisplayName = "EpubLocalTextContentFile constructor should throw ArgumentNullException if content parameter is null")]
@@ -170,7 +156,7 @@
         [Fact(DisplayName = "Constructing a EpubRemoteTextContentFile instance with null content parameter should succeed")]
         public void RemoteTextContentFileConstructorWithNullContentTest()
         {
-            EpubRemoteTextContentFile epubRemoteTextContentFile = new(REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, REMOTE_TEXT_FILE_HREF, null);
+            EpubRemoteTextContentFile epubRemoteTextContentFile = new(REMOTE_TEXT_FILE_HREF, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE, null);
             Assert.Equal(REMOTE_TEXT_FILE_HREF, epubRemoteTextContentFile.Key);
             Assert.Equal(TEXT_FILE_CONTENT_TYPE, epubRemoteTextContentFile.ContentType);
             Assert.Equal(TEXT_FILE_CONTENT_MIME_TYPE, epubRemoteTextContentFile.ContentMimeType);
@@ -183,7 +169,7 @@
         [Fact(DisplayName = "Constructing a EpubRemoteByteContentFile instance with null content parameter should succeed")]
         public void RemoteByteContentFileConstructorWithNullContentTest()
         {
-            EpubRemoteByteContentFile epubRemoteByteContentFile = new(REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, REMOTE_BYTE_FILE_HREF, null);
+            EpubRemoteByteContentFile epubRemoteByteContentFile = new(REMOTE_BYTE_FILE_HREF, BYTE_FILE_CONTENT_TYPE, BYTE_FILE_CONTENT_MIME_TYPE, null);
             Assert.Equal(REMOTE_BYTE_FILE_HREF, epubRemoteByteContentFile.Key);
             Assert.Equal(BYTE_FILE_CONTENT_TYPE, epubRemoteByteContentFile.ContentType);
             Assert.Equal(BYTE_FILE_CONTENT_MIME_TYPE, epubRemoteByteContentFile.ContentMimeType);

--- a/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubLocalContentLoaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubLocalContentLoaderTests.cs
@@ -3,7 +3,7 @@ using VersOne.Epub.Internal;
 using VersOne.Epub.Options;
 using VersOne.Epub.Test.Unit.Mocks;
 
-namespace VersOne.Epub.Test.Unit.Content
+namespace VersOne.Epub.Test.Unit.Content.Loaders
 {
     public class EpubLocalContentLoaderTests
     {

--- a/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubRemoteContentLoaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubRemoteContentLoaderTests.cs
@@ -3,7 +3,7 @@ using VersOne.Epub.Internal;
 using VersOne.Epub.Options;
 using VersOne.Epub.Test.Unit.Mocks;
 
-namespace VersOne.Epub.Test.Unit.Content
+namespace VersOne.Epub.Test.Unit.Content.Loaders
 {
     public class EpubRemoteContentLoaderTests
     {

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
@@ -159,7 +159,7 @@ namespace VersOne.Epub.Test.Unit.Entities
             EpubBookRef epubBookRef = CreateEpubBookRefWithReadingOrder(HTML_FILE_NAME, HTML_FILE_PATH);
             List<EpubLocalTextContentFileRef> expectedReadingOrder = new()
             {
-                epubBookRef.Content.Html.Local[HTML_FILE_NAME]
+                epubBookRef.Content.Html.GetLocalFileRefByKey(HTML_FILE_NAME)
             };
             List<EpubLocalTextContentFileRef> actualReadingOrder = epubBookRef.GetReadingOrder();
             Assert.Equal(expectedReadingOrder, actualReadingOrder);
@@ -171,7 +171,7 @@ namespace VersOne.Epub.Test.Unit.Entities
             EpubBookRef epubBookRef = CreateEpubBookRefWithReadingOrder(HTML_FILE_NAME, HTML_FILE_PATH);
             List<EpubLocalTextContentFileRef> expectedReadingOrder = new()
             {
-                epubBookRef.Content.Html.Local[HTML_FILE_NAME]
+                epubBookRef.Content.Html.GetLocalFileRefByKey(HTML_FILE_NAME)
             };
             List<EpubLocalTextContentFileRef> actualReadingOrder = await epubBookRef.GetReadingOrderAsync();
             Assert.Equal(expectedReadingOrder, actualReadingOrder);
@@ -183,7 +183,7 @@ namespace VersOne.Epub.Test.Unit.Entities
             EpubBookRef epubBookRef = CreateEpubBookRefWithNavigation(HTML_FILE_NAME, HTML_FILE_PATH, TEST_ANCHOR_TEXT);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
-                CreateTestNavigationLink(TEST_ANCHOR_TEXT, HTML_FILE_NAME, epubBookRef.Content.Html.Local[HTML_FILE_NAME])
+                CreateTestNavigationLink(TEST_ANCHOR_TEXT, HTML_FILE_NAME, epubBookRef.Content.Html.GetLocalFileRefByKey(HTML_FILE_NAME))
             };
             List<EpubNavigationItemRef>? actualNavigationItems = epubBookRef.GetNavigation();
             EpubNavigationItemRefComparer.CompareNavigationItemRefLists(expectedNavigationItems, actualNavigationItems);
@@ -195,7 +195,7 @@ namespace VersOne.Epub.Test.Unit.Entities
             EpubBookRef epubBookRef = CreateEpubBookRefWithNavigation(HTML_FILE_NAME, HTML_FILE_PATH, TEST_ANCHOR_TEXT);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
             {
-                CreateTestNavigationLink(TEST_ANCHOR_TEXT, HTML_FILE_NAME, epubBookRef.Content.Html.Local[HTML_FILE_NAME])
+                CreateTestNavigationLink(TEST_ANCHOR_TEXT, HTML_FILE_NAME, epubBookRef.Content.Html.GetLocalFileRefByKey(HTML_FILE_NAME))
             };
             List<EpubNavigationItemRef>? actualNavigationItems = await epubBookRef.GetNavigationAsync();
             EpubNavigationItemRefComparer.CompareNavigationItemRefLists(expectedNavigationItems, actualNavigationItems);
@@ -263,6 +263,10 @@ namespace VersOne.Epub.Test.Unit.Entities
         private static EpubBookRef CreateEpubBookRefWithReadingOrder(string htmlFileName, string htmlFilePath)
         {
             EpubLocalTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName, htmlFilePath);
+            List<EpubLocalTextContentFileRef> htmlLocal = new()
+            {
+                htmlFileRef
+            };
             return CreateEpubBookRef
             (
                 epubFile: new TestZipFile(),
@@ -291,16 +295,7 @@ namespace VersOne.Epub.Test.Unit.Entities
                 ),
                 content: new EpubContentRef
                 (
-                    html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                    (
-                        local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                        {
-                            {
-                                htmlFileName,
-                                htmlFileRef
-                            }
-                        }
-                    )
+                    html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(htmlLocal.AsReadOnly())
                 )
             );
         }
@@ -309,6 +304,10 @@ namespace VersOne.Epub.Test.Unit.Entities
         {
             EpubLocalTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName, htmlFilePath);
             EpubLocalTextContentFileRef navigationFileRef = CreateTestHtmlFileRef("toc.html", $"{CONTENT_DIRECTORY_PATH}/toc.html");
+            List<EpubLocalTextContentFileRef> htmlLocal = new()
+            {
+                htmlFileRef
+            };
             return CreateEpubBookRef
             (
                 epubFile: new TestZipFile(),
@@ -341,16 +340,7 @@ namespace VersOne.Epub.Test.Unit.Entities
                 content: new EpubContentRef
                 (
                     navigationHtmlFile: navigationFileRef,
-                    html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                    (
-                        local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                        {
-                            {
-                                htmlFileName,
-                                htmlFileRef
-                            }
-                        }
-                    )
+                    html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(htmlLocal.AsReadOnly())
                 )
             );
         }

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemLinkTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemLinkTests.cs
@@ -2,61 +2,75 @@
 {
     public class EpubNavigationItemLinkTests
     {
-        private const string CONTENT_FILE_URL = "../content/chapter1.html#section1";
+        private const string CONTENT_FILE_URL_WITH_ANCHOR = "../content/chapter1.html#section1";
+        private const string CONTENT_FILE_URL_WITHOUT_ANCHOR = "../content/chapter1.html";
+        private const string REMOTE_FILE_URL = "https://example.com/books/123/chapter1.html";
         private const string BASE_DIRECTORY_PATH = "OPS/toc";
-        private const string CONTENT_FILE_NAME = "../content/chapter1.html";
+        private const string CONTENT_FILE_URL = "../content/chapter1.html";
         private const string CONTENT_FILE_PATH = "OPS/content/chapter1.html";
         private const string ANCHOR = "section1";
 
-        [Fact(DisplayName = "Constructing a EpubNavigationItemLink instance with non-null contentFileName, contentFilePath, and anchor parameters should succeed")]
+        [Fact(DisplayName = "Constructing a EpubNavigationItemLink instance with non-null contentFileUrlWithoutAnchor, contentFilePath, and anchor parameters should succeed")]
         public void ExplicitConstructorWithNonNullParametersTest()
         {
-            EpubNavigationItemLink epubNavigationItemLink = new(CONTENT_FILE_NAME, CONTENT_FILE_PATH, ANCHOR);
-            Assert.Equal(CONTENT_FILE_NAME, epubNavigationItemLink.ContentFileName);
+            EpubNavigationItemLink epubNavigationItemLink = new(CONTENT_FILE_URL_WITHOUT_ANCHOR, CONTENT_FILE_PATH, ANCHOR);
+            Assert.Equal(CONTENT_FILE_URL, epubNavigationItemLink.ContentFileUrl);
             Assert.Equal(CONTENT_FILE_PATH, epubNavigationItemLink.ContentFilePath);
             Assert.Equal(ANCHOR, epubNavigationItemLink.Anchor);
         }
 
-        [Fact(DisplayName = "Constructor should throw ArgumentNullException if contentFileName parameter is null")]
-        public void ExplicitConstructorWithNullContentFileNameTest()
+        [Fact(DisplayName = "Constructor should throw ArgumentNullException if contentFileUrlWithoutAnchor parameter is null")]
+        public void ExplicitConstructorWithNullContentFileUrlWithoutAnchorTest()
         {
             Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(null!, CONTENT_FILE_PATH, ANCHOR));
+        }
+
+        [Fact(DisplayName = "Constructor should throw ArgumentException if contentFileUrlWithoutAnchor parameter is a remote URL")]
+        public void ExplicitConstructorWithRemoteContentFileUrlWithoutAnchorTest()
+        {
+            Assert.Throws<ArgumentException>(() => new EpubNavigationItemLink(REMOTE_FILE_URL, CONTENT_FILE_PATH, ANCHOR));
         }
 
         [Fact(DisplayName = "Constructor should throw ArgumentNullException if contentFilePath parameter is null")]
         public void ExplicitConstructorWithNullContentFilePathTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(CONTENT_FILE_NAME, null!, ANCHOR));
+            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(CONTENT_FILE_URL_WITHOUT_ANCHOR, null!, ANCHOR));
         }
 
         [Fact(DisplayName = "Constructing a EpubNavigationItemLink instance with null anchor parameter should succeed")]
         public void ExplicitConstructorWithNullAnchorTest()
         {
-            EpubNavigationItemLink epubNavigationItemLink = new(CONTENT_FILE_NAME, CONTENT_FILE_PATH, null);
-            Assert.Equal(CONTENT_FILE_NAME, epubNavigationItemLink.ContentFileName);
+            EpubNavigationItemLink epubNavigationItemLink = new(CONTENT_FILE_URL_WITHOUT_ANCHOR, CONTENT_FILE_PATH, null);
+            Assert.Equal(CONTENT_FILE_URL, epubNavigationItemLink.ContentFileUrl);
             Assert.Equal(CONTENT_FILE_PATH, epubNavigationItemLink.ContentFilePath);
             Assert.Null(epubNavigationItemLink.Anchor);
         }
 
-        [Fact(DisplayName = "Constructing a EpubNavigationItemLink instance with non-null contentFileUrl and baseDirectoryPath parameters should succeed")]
+        [Fact(DisplayName = "Constructing a EpubNavigationItemLink instance with non-null contentFileUrlWithAnchor and baseDirectoryPath parameters should succeed")]
         public void UrlConstructorWithNonNullParametersTest()
         {
-            EpubNavigationItemLink epubNavigationItemLink = new(CONTENT_FILE_URL, BASE_DIRECTORY_PATH);
-            Assert.Equal(CONTENT_FILE_NAME, epubNavigationItemLink.ContentFileName);
+            EpubNavigationItemLink epubNavigationItemLink = new(CONTENT_FILE_URL_WITH_ANCHOR, BASE_DIRECTORY_PATH);
+            Assert.Equal(CONTENT_FILE_URL, epubNavigationItemLink.ContentFileUrl);
             Assert.Equal(CONTENT_FILE_PATH, epubNavigationItemLink.ContentFilePath);
             Assert.Equal(ANCHOR, epubNavigationItemLink.Anchor);
         }
 
-        [Fact(DisplayName = "Constructor should throw ArgumentNullException if contentFileUrl parameter is null")]
-        public void UrlConstructorWithNullContentFileUrlTest()
+        [Fact(DisplayName = "Constructor should throw ArgumentNullException if contentFileUrlWithAnchor parameter is null")]
+        public void UrlConstructorWithNullContentFileUrlWithAnchorTest()
         {
             Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(null!, BASE_DIRECTORY_PATH));
+        }
+
+        [Fact(DisplayName = "Constructor should throw ArgumentException if contentFileUrlWithAnchor parameter is a remote URL")]
+        public void UrlConstructorWithRemoteContentFileUrlWithAnchorTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(REMOTE_FILE_URL, BASE_DIRECTORY_PATH));
         }
 
         [Fact(DisplayName = "Constructor should throw ArgumentNullException if baseDirectoryPath parameter is null")]
         public void UrlConstructorWithNullBaseDirectoryPathTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(CONTENT_FILE_URL, null!));
+            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(CONTENT_FILE_URL_WITH_ANCHOR, null!));
         }
     }
 }

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemLinkTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemLinkTests.cs
@@ -10,7 +10,7 @@
         private const string CONTENT_FILE_PATH = "OPS/content/chapter1.html";
         private const string ANCHOR = "section1";
 
-        [Fact(DisplayName = "Constructing a EpubNavigationItemLink instance with non-null contentFileUrlWithoutAnchor, contentFilePath, and anchor parameters should succeed")]
+        [Fact(DisplayName = "Constructing a EpubNavigationItemLink instance with non-null contentFileUrl, contentFilePath, and anchor parameters should succeed")]
         public void ExplicitConstructorWithNonNullParametersTest()
         {
             EpubNavigationItemLink epubNavigationItemLink = new(CONTENT_FILE_URL_WITHOUT_ANCHOR, CONTENT_FILE_PATH, ANCHOR);
@@ -19,13 +19,13 @@
             Assert.Equal(ANCHOR, epubNavigationItemLink.Anchor);
         }
 
-        [Fact(DisplayName = "Constructor should throw ArgumentNullException if contentFileUrlWithoutAnchor parameter is null")]
+        [Fact(DisplayName = "Constructor should throw ArgumentNullException if contentFileUrl parameter is null")]
         public void ExplicitConstructorWithNullContentFileUrlWithoutAnchorTest()
         {
             Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(null!, CONTENT_FILE_PATH, ANCHOR));
         }
 
-        [Fact(DisplayName = "Constructor should throw ArgumentException if contentFileUrlWithoutAnchor parameter is a remote URL")]
+        [Fact(DisplayName = "Constructor should throw ArgumentException if contentFileUrl parameter is a remote URL")]
         public void ExplicitConstructorWithRemoteContentFileUrlWithoutAnchorTest()
         {
             Assert.Throws<ArgumentException>(() => new EpubNavigationItemLink(REMOTE_FILE_URL, CONTENT_FILE_PATH, ANCHOR));
@@ -64,7 +64,7 @@
         [Fact(DisplayName = "Constructor should throw ArgumentException if contentFileUrlWithAnchor parameter is a remote URL")]
         public void UrlConstructorWithRemoteContentFileUrlWithAnchorTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemLink(REMOTE_FILE_URL, BASE_DIRECTORY_PATH));
+            Assert.Throws<ArgumentException>(() => new EpubNavigationItemLink(REMOTE_FILE_URL, BASE_DIRECTORY_PATH));
         }
 
         [Fact(DisplayName = "Constructor should throw ArgumentNullException if baseDirectoryPath parameter is null")]

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemRefTests.cs
@@ -11,7 +11,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         private static EpubNavigationItemLink Link =>
             new
             (
-                contentFileUrl: "../content/chapter1.html#section1",
+                contentFileUrlWithAnchor: "../content/chapter1.html#section1",
                 baseDirectoryPath: "OPS/toc"
             );
 

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemTests.cs
@@ -11,7 +11,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         private static EpubNavigationItemLink Link =>
             new
             (
-                contentFileUrl: "../content/chapter1.html#section1",
+                contentFileUrlWithAnchor: "../content/chapter1.html#section1",
                 baseDirectoryPath: "OPS/toc"
             );
 

--- a/Source/VersOne.Epub.Test/Unit/Exceptions/EpubContentCollectionExceptionTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Exceptions/EpubContentCollectionExceptionTests.cs
@@ -1,0 +1,30 @@
+﻿namespace VersOne.Epub.Test.Unit.Exceptions
+{
+    public class EpubContentCollectionExceptionTests
+    {
+        private const string TEST_MESSAGE = "test message";
+
+        [Fact(DisplayName = "Creating EpubContentCollectionException without arguments should succeed")]
+        public void CreateWithNoArgumentsTest()
+        {
+            _ = new EpubContentCollectionException();
+        }
+
+        [Fact(DisplayName = "Creating EpubContentCollectionException with message should succeed")]
+        public void CreateWithMessageTest()
+        {
+            EpubContentCollectionException epubContentCollectionException = new(TEST_MESSAGE);
+            Assert.Equal(TEST_MESSAGE, epubContentCollectionException.Message);
+        }
+
+        [Fact(DisplayName = "Creating EpubContentCollectionException with message and inner exception should succeed")]
+        public void CreateWithMessageAndInnerExceptionTest()
+        {
+            Exception innerException = new();
+            EpubContentCollectionException epubContentCollectionException = new(TEST_MESSAGE, innerException);
+            Assert.Equal(TEST_MESSAGE, epubContentCollectionException.Message);
+            Assert.Equal(innerException, epubContentCollectionException.InnerException);
+        }
+
+    }
+}

--- a/Source/VersOne.Epub.Test/Unit/Exceptions/EpubContentCollectionRefExceptionTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Exceptions/EpubContentCollectionRefExceptionTests.cs
@@ -1,0 +1,30 @@
+﻿namespace VersOne.Epub.Test.Unit.Exceptions
+{
+    public class EpubContentCollectionRefExceptionTests
+    {
+        private const string TEST_MESSAGE = "test message";
+
+        [Fact(DisplayName = "Creating EpubContentCollectionRefException without arguments should succeed")]
+        public void CreateWithNoArgumentsTest()
+        {
+            _ = new EpubContentCollectionRefException();
+        }
+
+        [Fact(DisplayName = "Creating EpubContentCollectionRefException with message should succeed")]
+        public void CreateWithMessageTest()
+        {
+            EpubContentCollectionRefException epubContentCollectionRefException = new(TEST_MESSAGE);
+            Assert.Equal(TEST_MESSAGE, epubContentCollectionRefException.Message);
+        }
+
+        [Fact(DisplayName = "Creating EpubContentCollectionRefException with message and inner exception should succeed")]
+        public void CreateWithMessageAndInnerExceptionTest()
+        {
+            Exception innerException = new();
+            EpubContentCollectionRefException epubContentCollectionRefException = new(TEST_MESSAGE, innerException);
+            Assert.Equal(TEST_MESSAGE, epubContentCollectionRefException.Message);
+            Assert.Equal(innerException, epubContentCollectionRefException.InnerException);
+        }
+
+    }
+}

--- a/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
@@ -346,15 +346,17 @@ namespace VersOne.Epub.Test.Unit.Readers
         private static EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> CreateImageContentRefs(
             EpubLocalByteContentFileRef? localImageFileRef = null, EpubRemoteByteContentFileRef? remoteImageFileRef = null)
         {
-            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> result = new();
+            List<EpubLocalByteContentFileRef> local = new();
+            List<EpubRemoteByteContentFileRef> remote = new();
             if (localImageFileRef != null)
             {
-                result.Local[localImageFileRef.Key] = localImageFileRef;
+                local.Add(localImageFileRef);
             }
             if (remoteImageFileRef != null)
             {
-                result.Remote[remoteImageFileRef.Key] = remoteImageFileRef;
+                remote.Add(remoteImageFileRef);
             }
+            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> result = new(local.AsReadOnly(), remote.AsReadOnly());
             return result;
         }
     }

--- a/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
@@ -336,336 +336,120 @@ namespace VersOne.Epub.Test.Unit.Readers
             EpubRemoteByteContentFileRef expectedRemoteJpgFileRef = CreateRemoteByteFileRef("https://example.com/books/123/image.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
             EpubRemoteByteContentFileRef expectedRemoteTtfFileRef = CreateRemoteByteFileRef("https://example.com/books/123/font.ttf", EpubContentType.FONT_TRUETYPE, "font/truetype");
             EpubRemoteByteContentFileRef expectedRemoteMp3FileRef = CreateRemoteByteFileRef("https://example.com/books/123/audio.mp3", EpubContentType.AUDIO_MP3, "audio/mpeg");
+            List<EpubLocalTextContentFileRef> expectedHtmlLocal = new()
+            {
+                expectedHtmlFileRef,
+                expectedTocFileRef
+            };
+            List<EpubRemoteTextContentFileRef> expectedHtmlRemote = new()
+            {
+                expectedRemoteHtmlFileRef
+            };
+            List<EpubLocalTextContentFileRef> expectedCssLocal = new()
+            {
+                expectedCssFileRef
+            };
+            List<EpubRemoteTextContentFileRef> expectedCssRemote = new()
+            {
+                expectedRemoteCssFileRef
+            };
+            List<EpubLocalByteContentFileRef> expectedImagesLocal = new()
+            {
+                expectedGifFileRef,
+                expectedJpgFileRef,
+                expectedPngFileRef,
+                expectedSvgFileRef,
+                expectedWebpFileRef,
+                expectedCoverFileRef
+            };
+            List<EpubRemoteByteContentFileRef> expectedImagesRemote = new()
+            {
+                expectedRemoteJpgFileRef
+            };
+            List<EpubLocalByteContentFileRef> expectedFontsLocal = new()
+            {
+                expectedTtf1FileRef,
+                expectedTtf2FileRef,
+                expectedTtf3FileRef,
+                expectedOtf1FileRef,
+                expectedOtf2FileRef,
+                expectedOtf3FileRef,
+                expectedSfnt1FileRef,
+                expectedSfnt2FileRef,
+                expectedWoff11FileRef,
+                expectedWoff12FileRef,
+                expectedWoff2FileRef
+            };
+            List<EpubRemoteByteContentFileRef> expectedFontsRemote = new()
+            {
+                expectedRemoteTtfFileRef
+            };
+            List<EpubLocalByteContentFileRef> expectedAudioLocal = new()
+            {
+                expectedMp3FileRef,
+                expectedMp4FileRef,
+                expectedOgg1FileRef,
+                expectedOgg2FileRef
+            };
+            List<EpubRemoteByteContentFileRef> expectedAudioRemote = new()
+            {
+                expectedRemoteMp3FileRef
+            };
+            List<EpubLocalContentFileRef> expectedAllFilesLocal = new()
+            {
+                expectedHtmlFileRef,
+                expectedDtbFileRef,
+                expectedNcxFileRef,
+                expectedOebFileRef,
+                expectedXmlFileRef,
+                expectedCssFileRef,
+                expectedOebCssFileRef,
+                expectedJs1FileRef,
+                expectedJs2FileRef,
+                expectedJs3FileRef,
+                expectedGifFileRef,
+                expectedJpgFileRef,
+                expectedPngFileRef,
+                expectedSvgFileRef,
+                expectedWebpFileRef,
+                expectedTtf1FileRef,
+                expectedTtf2FileRef,
+                expectedTtf3FileRef,
+                expectedOtf1FileRef,
+                expectedOtf2FileRef,
+                expectedOtf3FileRef,
+                expectedSfnt1FileRef,
+                expectedSfnt2FileRef,
+                expectedWoff11FileRef,
+                expectedWoff12FileRef,
+                expectedWoff2FileRef,
+                expectedSmilFileRef,
+                expectedMp3FileRef,
+                expectedMp4FileRef,
+                expectedOgg1FileRef,
+                expectedOgg2FileRef,
+                expectedVideoFileRef,
+                expectedCoverFileRef,
+                expectedTocFileRef
+            };
+            List<EpubRemoteContentFileRef> expectedAllFilesRemote = new()
+            {
+                expectedRemoteHtmlFileRef,
+                expectedRemoteCssFileRef,
+                expectedRemoteJpgFileRef,
+                expectedRemoteTtfFileRef,
+                expectedRemoteMp3FileRef
+            };
             EpubContentRef expectedContentMap = new
             (
                 cover: expectedCoverFileRef,
                 navigationHtmlFile: expectedTocFileRef,
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                    {
-                        {
-                            "text.html",
-                            expectedHtmlFileRef
-                        },
-                        {
-                            "toc.html",
-                            expectedTocFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/test.html",
-                            expectedRemoteHtmlFileRef
-                        }
-                    }
-                ),
-                css: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                    {
-                        {
-                            "styles.css",
-                            expectedCssFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/test.css",
-                            expectedRemoteCssFileRef
-                        }
-                    }
-                ),
-                images: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFileRef>()
-                    {
-                        {
-                            "image.gif",
-                            expectedGifFileRef
-                        },
-                        {
-                            "image.jpg",
-                            expectedJpgFileRef
-                        },
-                        {
-                            "image.png",
-                            expectedPngFileRef
-                        },
-                        {
-                            "image.svg",
-                            expectedSvgFileRef
-                        },
-                        {
-                            "image.webp",
-                            expectedWebpFileRef
-                        },
-                        {
-                            "cover.jpg",
-                            expectedCoverFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/image.jpg",
-                            expectedRemoteJpgFileRef
-                        }
-                    }
-                ),
-                fonts: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFileRef>()
-                    {
-                        {
-                            "font1.ttf",
-                            expectedTtf1FileRef
-                        },
-                        {
-                            "font2.ttf",
-                            expectedTtf2FileRef
-                        },
-                        {
-                            "font3.ttf",
-                            expectedTtf3FileRef
-                        },
-                        {
-                            "font1.otf",
-                            expectedOtf1FileRef
-                        },
-                        {
-                            "font2.otf",
-                            expectedOtf2FileRef
-                        },
-                        {
-                            "font3.otf",
-                            expectedOtf3FileRef
-                        },
-                        {
-                            "font.aat",
-                            expectedSfnt1FileRef
-                        },
-                        {
-                            "font.sil",
-                            expectedSfnt2FileRef
-                        },
-                        {
-                            "font1.woff",
-                            expectedWoff11FileRef
-                        },
-                        {
-                            "font2.woff",
-                            expectedWoff12FileRef
-                        },
-                        {
-                            "font.woff2",
-                            expectedWoff2FileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/font.ttf",
-                            expectedRemoteTtfFileRef
-                        }
-                    }
-                ),
-                audio: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFileRef>()
-                    {
-                        {
-                            "audio.mp3",
-                            expectedMp3FileRef
-                        },
-                        {
-                            "audio.mp4",
-                            expectedMp4FileRef
-                        },
-                        {
-                            "audio1.opus",
-                            expectedOgg1FileRef
-                        },
-                        {
-                            "audio2.opus",
-                            expectedOgg2FileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/audio.mp3",
-                            expectedRemoteMp3FileRef
-                        }
-                    }
-                ),
-                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalContentFileRef>()
-                    {
-                        {
-                            "text.html",
-                            expectedHtmlFileRef
-                        },
-                        {
-                            "doc.dtb",
-                            expectedDtbFileRef
-                        },
-                        {
-                            "toc.ncx",
-                            expectedNcxFileRef
-                        },
-                        {
-                            "oeb.html",
-                            expectedOebFileRef
-                        },
-                        {
-                            "file.xml",
-                            expectedXmlFileRef
-                        },
-                        {
-                            "styles.css",
-                            expectedCssFileRef
-                        },
-                        {
-                            "oeb.css",
-                            expectedOebCssFileRef
-                        },
-                        {
-                            "script1.js",
-                            expectedJs1FileRef
-                        },
-                        {
-                            "script2.js",
-                            expectedJs2FileRef
-                        },
-                        {
-                            "script3.js",
-                            expectedJs3FileRef
-                        },
-                        {
-                            "image.gif",
-                            expectedGifFileRef
-                        },
-                        {
-                            "image.jpg",
-                            expectedJpgFileRef
-                        },
-                        {
-                            "image.png",
-                            expectedPngFileRef
-                        },
-                        {
-                            "image.svg",
-                            expectedSvgFileRef
-                        },
-                        {
-                            "image.webp",
-                            expectedWebpFileRef
-                        },
-                        {
-                            "font1.ttf",
-                            expectedTtf1FileRef
-                        },
-                        {
-                            "font2.ttf",
-                            expectedTtf2FileRef
-                        },
-                        {
-                            "font3.ttf",
-                            expectedTtf3FileRef
-                        },
-                        {
-                            "font1.otf",
-                            expectedOtf1FileRef
-                        },
-                        {
-                            "font2.otf",
-                            expectedOtf2FileRef
-                        },
-                        {
-                            "font3.otf",
-                            expectedOtf3FileRef
-                        },
-                        {
-                            "font.aat",
-                            expectedSfnt1FileRef
-                        },
-                        {
-                            "font.sil",
-                            expectedSfnt2FileRef
-                        },
-                        {
-                            "font1.woff",
-                            expectedWoff11FileRef
-                        },
-                        {
-                            "font2.woff",
-                            expectedWoff12FileRef
-                        },
-                        {
-                            "font.woff2",
-                            expectedWoff2FileRef
-                        },
-                        {
-                            "narration.smil",
-                            expectedSmilFileRef
-                        },
-                        {
-                            "audio.mp3",
-                            expectedMp3FileRef
-                        },
-                        {
-                            "audio.mp4",
-                            expectedMp4FileRef
-                        },
-                        {
-                            "audio1.opus",
-                            expectedOgg1FileRef
-                        },
-                        {
-                            "audio2.opus",
-                            expectedOgg2FileRef
-                        },
-                        {
-                            "video.mp4",
-                            expectedVideoFileRef
-                        },
-                        {
-                            "cover.jpg",
-                            expectedCoverFileRef
-                        },
-                        {
-                            "toc.html",
-                            expectedTocFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/test.html",
-                            expectedRemoteHtmlFileRef
-                        },
-                        {
-                            "https://example.com/books/123/test.css",
-                            expectedRemoteCssFileRef
-                        },
-                        {
-                            "https://example.com/books/123/image.jpg",
-                            expectedRemoteJpgFileRef
-                        },
-                        {
-                            "https://example.com/books/123/font.ttf",
-                            expectedRemoteTtfFileRef
-                        },
-                        {
-                            "https://example.com/books/123/audio.mp3",
-                            expectedRemoteMp3FileRef
-                        }
-                    }
-                )
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(expectedHtmlLocal.AsReadOnly(), expectedHtmlRemote.AsReadOnly()),
+                css: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(expectedCssLocal.AsReadOnly(), expectedCssRemote.AsReadOnly()),
+                images: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(expectedImagesLocal.AsReadOnly(), expectedImagesRemote.AsReadOnly()),
+                fonts: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(expectedFontsLocal.AsReadOnly(), expectedFontsRemote.AsReadOnly()),
+                audio: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(expectedAudioLocal.AsReadOnly(), expectedAudioRemote.AsReadOnly()),
+                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>(expectedAllFilesLocal.AsReadOnly(), expectedAllFilesRemote.AsReadOnly())
             );
             ContentReader contentReader = new(environmentDependencies);
             EpubContentRef actualContentMap = contentReader.ParseContentMap(epubSchema, new TestZipFile());
@@ -698,42 +482,24 @@ namespace VersOne.Epub.Test.Unit.Readers
             );
             EpubRemoteTextContentFileRef expectedFileRef1 = CreateRemoteTextFileRef("https://example.com/books/123/test.html", EpubContentType.XHTML_1_1, "application/xhtml+xml");
             EpubRemoteTextContentFileRef expectedFileRef2 = CreateRemoteTextFileRef("https://example.com/books/123/test.css", EpubContentType.CSS, "text/css");
+            List<EpubRemoteTextContentFileRef> expectedHtmlRemote = new()
+            {
+                expectedFileRef1
+            };
+            List<EpubRemoteTextContentFileRef> expectedCssRemote = new()
+            {
+                expectedFileRef2
+            };
+            List<EpubRemoteContentFileRef> expectedAllFilesRemote = new()
+            {
+                expectedFileRef1,
+                expectedFileRef2
+            };
             EpubContentRef expectedContentMap = new
             (
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/test.html",
-                            expectedFileRef1
-                        }
-                    }
-                ),
-                css: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/test.css",
-                            expectedFileRef2
-                        }
-                    }
-                ),
-                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>
-                (
-                    remote: new Dictionary<string, EpubRemoteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/test.html",
-                            expectedFileRef1
-                        },
-                        {
-                            "https://example.com/books/123/test.css",
-                            expectedFileRef2
-                        }
-                    }
-                )
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(null, expectedHtmlRemote.AsReadOnly()),
+                css: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(null, expectedCssRemote.AsReadOnly()),
+                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>(null, expectedAllFilesRemote.AsReadOnly())
             );
             ContentReader contentReader = new(environmentDependencies);
             EpubContentRef actualContentMap = contentReader.ParseContentMap(epubSchema, new TestZipFile());
@@ -766,42 +532,24 @@ namespace VersOne.Epub.Test.Unit.Readers
             );
             EpubRemoteByteContentFileRef expectedFileRef1 = CreateRemoteByteFileRef("https://example.com/books/123/image.jpg", EpubContentType.IMAGE_JPEG, "image/jpeg");
             EpubRemoteByteContentFileRef expectedFileRef2 = CreateRemoteByteFileRef("https://example.com/books/123/font.ttf", EpubContentType.FONT_TRUETYPE, "font/truetype");
+            List<EpubRemoteByteContentFileRef> expectedImagesRemote = new()
+            {
+                expectedFileRef1
+            };
+            List<EpubRemoteByteContentFileRef> expectedFontsRemote = new()
+            {
+                expectedFileRef2
+            };
+            List<EpubRemoteContentFileRef> expectedAllFilesRemote = new()
+            {
+                expectedFileRef1,
+                expectedFileRef2
+            };
             EpubContentRef expectedContentMap = new
             (
-                images: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/image.jpg",
-                            expectedFileRef1
-                        }
-                    }
-                ),
-                fonts: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/font.ttf",
-                            expectedFileRef2
-                        }
-                    }
-                ),
-                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>
-                (
-                    remote: new Dictionary<string, EpubRemoteContentFileRef>()
-                    {
-                        {
-                            "https://example.com/books/123/image.jpg",
-                            expectedFileRef1
-                        },
-                        {
-                            "https://example.com/books/123/font.ttf",
-                            expectedFileRef2
-                        }
-                    }
-                )
+                images: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(null, expectedImagesRemote.AsReadOnly()),
+                fonts: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(null, expectedFontsRemote.AsReadOnly()),
+                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>(null, expectedAllFilesRemote.AsReadOnly())
             );
             ContentReader contentReader = new(environmentDependencies);
             EpubContentRef actualContentMap = contentReader.ParseContentMap(epubSchema, new TestZipFile());

--- a/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
@@ -133,7 +133,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "GetNavigationItems should throw a Epub2NcxException if an NCX navigation point has no navigation labels")]
-        public void GetNavigationItemsForEpub2WithoutNavigationLabelsFile()
+        public void GetNavigationItemsForEpub2WithoutNavigationLabelsTest()
         {
             EpubSchema epubSchema = new
             (
@@ -173,8 +173,56 @@ namespace VersOne.Epub.Test.Unit.Readers
             Assert.Throws<Epub2NcxException>(() => NavigationReader.GetNavigationItems(epubSchema, epubContentRef));
         }
 
+        [Fact(DisplayName = "GetNavigationItems should throw a Epub2NcxException if an NCX navigation point points to a remote resource")]
+        public void GetNavigationItemsForEpub2WithRemoteNavigationPointSourceTest()
+        {
+            string remoteFileHref = "https://example.com/books/123/chapter1.html";
+            EpubSchema epubSchema = new
+            (
+                package: CreateEmptyPackage(EpubVersion.EPUB_2),
+                epub2Ncx: new Epub2Ncx
+                (
+                    filePath: NCX_FILE_PATH,
+                    head: new Epub2NcxHead(),
+                    docTitle: null,
+                    docAuthors: null,
+                    navMap: new Epub2NcxNavigationMap
+                    (
+                        items: new List<Epub2NcxNavigationPoint>()
+                        {
+                            new Epub2NcxNavigationPoint
+                            (
+                                id: String.Empty,
+                                @class: null,
+                                playOrder: null,
+                                navigationLabels: new List<Epub2NcxNavigationLabel>()
+                                {
+                                    new Epub2NcxNavigationLabel
+                                    (
+                                        text: "Test label"
+                                    )
+                                },
+                                content: new Epub2NcxContent
+                                (
+                                    source: remoteFileHref
+                                ),
+                                childNavigationPoints: null
+                            )
+                        }
+                    ),
+                    pageList: null,
+                    navLists: null
+                ),
+                epub3NavDocument: null,
+                mediaOverlays: null,
+                contentDirectoryPath: CONTENT_DIRECTORY_PATH
+            );
+            EpubContentRef epubContentRef = new();
+            Assert.Throws<Epub2NcxException>(() => NavigationReader.GetNavigationItems(epubSchema, epubContentRef));
+        }
+
         [Fact(DisplayName = "GetNavigationItems should throw a Epub2NcxException if the file referenced by an NCX navigation point is missing in the EpubContentRef")]
-        public void GetNavigationItemsForEpub2WithMissingContentFile()
+        public void GetNavigationItemsForEpub2WithMissingContentFileTest()
         {
             EpubSchema epubSchema = new
             (
@@ -608,7 +656,7 @@ namespace VersOne.Epub.Test.Unit.Readers
             EpubNavigationItemRefComparer.CompareNavigationItemRefLists(expectedNavigationItems, actualNavigationItems);
         }
 
-        [Fact(DisplayName = "GetNavigationItems should throw a Epub3NavException if the file referenced by a EPUB 3 navigational Li item is missing in the EpubContentRef")]
+        [Fact(DisplayName = "GetNavigationItems should throw a Epub3NavException if the file referenced by a EPUB 3 navigation Li item is missing in the EpubContentRef")]
         public void GetNavigationItemsForEpub3WithMissingContentFile()
         {
             EpubSchema epubSchema = new
@@ -649,7 +697,7 @@ namespace VersOne.Epub.Test.Unit.Readers
             Assert.Throws<Epub3NavException>(() => NavigationReader.GetNavigationItems(epubSchema, epubContentRef));
         }
 
-        [Fact(DisplayName = "GetNavigationItems should throw EpubPackageException if the content file referenced by a navigation item is a remote resource")]
+        [Fact(DisplayName = "GetNavigationItems should throw Epub3NavException if a EPUB 3 navigation anchor points to a remote resource")]
         public void GetNavigationItemsWithRemoteContentFileTest()
         {
             string remoteFileHref = "https://example.com/books/123/chapter1.html";
@@ -686,22 +734,16 @@ namespace VersOne.Epub.Test.Unit.Readers
                 contentDirectoryPath: CONTENT_DIRECTORY_PATH
             );
             EpubLocalTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
-            EpubContentFileRefMetadata testTextContentFileRefMetadata = new(remoteFileHref, EpubContentType.XHTML_1_1, "application/xhtml+xml");
-            EpubRemoteTextContentFileRef testTextContentFileRef = new(testTextContentFileRefMetadata, new TestEpubContentLoader());
             List<EpubLocalTextContentFileRef> htmlLocal = new()
             {
                 testNavigationHtmlFileRef
             };
-            List<EpubRemoteTextContentFileRef> htmlRemote = new()
-            {
-                testTextContentFileRef
-            };
             EpubContentRef epubContentRef = new
             (
                 navigationHtmlFile: testNavigationHtmlFileRef,
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(htmlLocal.AsReadOnly(), htmlRemote.AsReadOnly())
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(htmlLocal.AsReadOnly())
             );
-            Assert.Throws<EpubPackageException>(() => NavigationReader.GetNavigationItems(epubSchema, epubContentRef));
+            Assert.Throws<Epub3NavException>(() => NavigationReader.GetNavigationItems(epubSchema, epubContentRef));
         }
 
         private static EpubLocalTextContentFileRef CreateTestNavigationFile()

--- a/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
@@ -688,26 +688,18 @@ namespace VersOne.Epub.Test.Unit.Readers
             EpubLocalTextContentFileRef testNavigationHtmlFileRef = CreateTestNavigationFile();
             EpubContentFileRefMetadata testTextContentFileRefMetadata = new(remoteFileHref, EpubContentType.XHTML_1_1, "application/xhtml+xml");
             EpubRemoteTextContentFileRef testTextContentFileRef = new(testTextContentFileRefMetadata, new TestEpubContentLoader());
+            List<EpubLocalTextContentFileRef> htmlLocal = new()
+            {
+                testNavigationHtmlFileRef
+            };
+            List<EpubRemoteTextContentFileRef> htmlRemote = new()
+            {
+                testTextContentFileRef
+            };
             EpubContentRef epubContentRef = new
             (
                 navigationHtmlFile: testNavigationHtmlFileRef,
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                    {
-                        {
-                            testNavigationHtmlFileRef.Key,
-                            testNavigationHtmlFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            testTextContentFileRef.Key,
-                            testTextContentFileRef
-                        }
-                    }
-                )
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(htmlLocal.AsReadOnly(), htmlRemote.AsReadOnly())
             );
             Assert.Throws<EpubPackageException>(() => NavigationReader.GetNavigationItems(epubSchema, epubContentRef));
         }
@@ -762,19 +754,20 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private static EpubContentRef CreateContentRef(EpubLocalTextContentFileRef? navigationHtmlFile, params EpubLocalTextContentFileRef[] htmlFiles)
         {
-            EpubContentRef result = new
-            (
-                navigationHtmlFile: navigationHtmlFile,
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>()
-            );
+            List<EpubLocalTextContentFileRef> local = new();
             if (navigationHtmlFile != null)
             {
-                result.Html.Local[navigationHtmlFile.Key] = navigationHtmlFile;
+                local.Add(navigationHtmlFile);
             }
             foreach (EpubLocalTextContentFileRef htmlFile in htmlFiles)
             {
-                result.Html.Local[htmlFile.Key] = htmlFile;
+                local.Add(htmlFile);
             }
+            EpubContentRef result = new
+            (
+                navigationHtmlFile: navigationHtmlFile,
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(local.AsReadOnly())
+            );
             return result;
         }
     }

--- a/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
@@ -187,6 +187,32 @@ namespace VersOne.Epub.Test.Unit.Readers
             </package>
             """;
 
+        private const string OPF_FILE_WITH_DUPLICATING_MANIFEST_ITEM_IDS = $"""
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+              <metadata />
+              <manifest>
+                <item id="unique" href="chapter1.html" media-type="application/xhtml+xml" />
+                <item id="duplicate" href="chapter2.html" media-type="application/xhtml+xml" />
+                <item id="duplicate" href="chapter3.html" media-type="application/xhtml+xml" />
+              </manifest>
+              <spine />
+            </package>
+            """;
+
+        private const string OPF_FILE_WITH_DUPLICATING_MANIFEST_ITEM_HREFS = $"""
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+              <metadata />
+              <manifest>
+                <item id="item-1" href="unique.html" media-type="application/xhtml+xml" />
+                <item id="item-2" href="duplicate.html" media-type="application/xhtml+xml" />
+                <item id="item-3" href="duplicate.html" media-type="application/xhtml+xml" />
+              </manifest>
+              <spine />
+            </package>
+            """;
+
         private const string EPUB2_OPF_FILE_WITHOUT_SPINE_TOC = $"""
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
@@ -751,6 +777,18 @@ namespace VersOne.Epub.Test.Unit.Readers
         public async void ReadPackageWithoutManifestItemMediaTypeWithSkippingInvalidManifestItemsTest()
         {
             await TestSuccessfulReadOperationWithSkippingInvalidManifestItems(OPF_FILE_WITHOUT_MEDIA_TYPE_IN_MANIFEST_ITEM, MinimalEpub3Package);
+        }
+
+        [Fact(DisplayName = "Trying to read OPF package with duplicating 'id' attributes in manifest item XML nodes should fail with EpubPackageException")]
+        public async void ReadPackageWithDuplicatingManifestItemIdsTest()
+        {
+            await TestFailingReadOperationWithNullPackageReaderOptions(OPF_FILE_WITH_DUPLICATING_MANIFEST_ITEM_IDS);
+        }
+
+        [Fact(DisplayName = "Trying to read OPF package with duplicating 'href' attributes in manifest item XML nodes should fail with EpubPackageException")]
+        public async void ReadPackageWithDuplicatingManifestItemHrefsTest()
+        {
+            await TestFailingReadOperationWithNullPackageReaderOptions(OPF_FILE_WITH_DUPLICATING_MANIFEST_ITEM_HREFS);
         }
 
         [Fact(DisplayName = "Trying to read EPUB 2 OPF package without 'toc' attribute in the spine XML node should fail with EpubPackageException")]

--- a/Source/VersOne.Epub.Test/Unit/Readers/SmilClockParserTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SmilClockParserTests.cs
@@ -1,4 +1,4 @@
-﻿using VersOne.Epub.Readers;
+﻿using VersOne.Epub.Internal;
 using VersOne.Epub.Test.Comparers;
 
 namespace VersOne.Epub.Test.Unit.Readers

--- a/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
@@ -56,22 +56,14 @@ namespace VersOne.Epub.Test.Unit.Readers
             );
             EpubLocalTextContentFileRef expectedHtmlFileRef1 = CreateTestHtmlFileRef("chapter1.html");
             EpubLocalTextContentFileRef expectedHtmlFileRef2 = CreateTestHtmlFileRef("chapter2.html");
+            List<EpubLocalTextContentFileRef> expectedHtmlLocal = new()
+            {
+                expectedHtmlFileRef1,
+                expectedHtmlFileRef2
+            };
             EpubContentRef epubContentRef = new
             (
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                    {
-                        {
-                            "chapter1.html",
-                            expectedHtmlFileRef1
-                        },
-                        {
-                            "chapter2.html",
-                            expectedHtmlFileRef2
-                        }
-                    }
-                )
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(expectedHtmlLocal.AsReadOnly())
             );
             List<EpubLocalTextContentFileRef> expectedReadingOrder = new()
             {
@@ -175,27 +167,22 @@ namespace VersOne.Epub.Test.Unit.Readers
                     }
                 )
             );
+            List<EpubRemoteTextContentFileRef> htmlRemote = new()
+            {
+                new EpubRemoteTextContentFileRef
+                (
+                    metadata: new EpubContentFileRefMetadata
+                    (
+                        key: remoteFileHref,
+                        contentType: EpubContentType.XHTML_1_1,
+                        contentMimeType: "application/xhtml+xml"
+                    ),
+                    epubContentLoader: new TestEpubContentLoader()
+                )
+            };
             EpubContentRef epubContentRef = new
             (
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            remoteFileHref,
-                            new EpubRemoteTextContentFileRef
-                            (
-                                metadata: new EpubContentFileRefMetadata
-                                (
-                                    key: remoteFileHref,
-                                    contentType: EpubContentType.XHTML_1_1,
-                                    contentMimeType: "application/xhtml+xml"
-                                ),
-                                epubContentLoader: new TestEpubContentLoader()
-                            )
-                        }
-                    }
-                )
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(null, htmlRemote.AsReadOnly())
             );
             Assert.Throws<EpubPackageException>(() => SpineReader.GetReadingOrder(epubSchema, epubContentRef));
         }

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContent.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContent.cs
@@ -6,249 +6,113 @@ namespace VersOne.Epub.Test.Unit.TestData
     {
         public static EpubContent CreateMinimalTestEpubContentWithNavigation()
         {
+            List<EpubLocalTextContentFile> htmlLocal = new()
+            {
+                MinimalNavFile
+            };
+            List<EpubLocalContentFile> allFilesLocal = new()
+            {
+                MinimalNavFile
+            };
             return new EpubContent
             (
                 cover: null,
                 navigationHtmlFile: MinimalNavFile,
-                html: new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFile>()
-                    {
-                        {
-                            NAV_FILE_NAME,
-                            MinimalNavFile
-                        }
-                    }
-                ),
+                html: new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>(htmlLocal.AsReadOnly()),
                 css: new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>(),
                 images: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>(),
                 fonts: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>(),
                 audio: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>(),
-                allFiles: new EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalContentFile>()
-                    {
-                        {
-                            NAV_FILE_NAME,
-                            MinimalNavFile
-                        }
-                    }
-                )
+                allFiles: new EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>(allFilesLocal.AsReadOnly())
             );
         }
 
         public static EpubContent CreateFullTestEpubContent(bool populateRemoteFilesContents)
         {
+            List<EpubLocalTextContentFile> htmlLocal = new()
+            {
+                Chapter1File,
+                Chapter2File,
+                FullNavFile
+            };
+            List<EpubRemoteTextContentFile> htmlRemote = new()
+            {
+                populateRemoteFilesContents ? RemoteHtmlContentFile : RemoteHtmlContentFileWithNoContent
+            };
+            List<EpubLocalTextContentFile> cssLocal = new()
+            {
+                Styles1File,
+                Styles2File
+            };
+            List<EpubRemoteTextContentFile> cssRemote = new()
+            {
+                populateRemoteFilesContents ? RemoteCssContentFile : RemoteCssContentFileWithNoContent
+            };
+            List<EpubLocalByteContentFile> imagesLocal = new()
+            {
+                Image1File,
+                Image2File,
+                CoverFile
+            };
+            List<EpubRemoteByteContentFile> imagesRemote = new()
+            {
+                populateRemoteFilesContents ? RemoteImageContentFile : RemoteImageContentFileWithNoContent
+            };
+            List<EpubLocalByteContentFile> fontsLocal = new()
+            {
+                Font1File,
+                Font2File
+            };
+            List<EpubRemoteByteContentFile> fontsRemote = new()
+            {
+                populateRemoteFilesContents ? RemoteFontContentFile : RemoteFontContentFileWithNoContent
+            };
+            List<EpubLocalByteContentFile> audioLocal = new()
+            {
+                Audio1File,
+                Audio2File
+            };
+            List<EpubRemoteByteContentFile> audioRemote = new()
+            {
+                populateRemoteFilesContents ? RemoteAudioContentFile : RemoteAudioContentFileWithNoContent
+            };
+            List<EpubLocalContentFile> allFilesLocal = new()
+            {
+                Chapter1File,
+                Chapter2File,
+                Styles1File,
+                Styles2File,
+                Image1File,
+                Image2File,
+                Font1File,
+                Font2File,
+                Audio1File,
+                Audio2File,
+                VideoFile,
+                FullNavFile,
+                CoverFile,
+                NcxFile
+            };
+            List<EpubRemoteContentFile> allFilesRemote = new()
+            {
+                populateRemoteFilesContents ? RemoteHtmlContentFile : RemoteHtmlContentFileWithNoContent,
+                populateRemoteFilesContents? RemoteCssContentFile : RemoteCssContentFileWithNoContent,
+                populateRemoteFilesContents? RemoteImageContentFile : RemoteImageContentFileWithNoContent,
+                populateRemoteFilesContents? RemoteFontContentFile : RemoteFontContentFileWithNoContent,
+                populateRemoteFilesContents? RemoteXmlContentFile : RemoteXmlContentFileWithNoContent,
+                populateRemoteFilesContents? RemoteAudioContentFile : RemoteAudioContentFileWithNoContent,
+                populateRemoteFilesContents? RemoteVideoContentFile : RemoteVideoContentFileWithNoContent
+            };
             return new
             (
                 cover: CoverFile,
                 navigationHtmlFile: FullNavFile,
-                html: new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFile>()
-                    {
-                        {
-                            CHAPTER1_FILE_NAME,
-                            Chapter1File
-                        },
-                        {
-                            CHAPTER2_FILE_NAME,
-                            Chapter2File
-                        },
-                        {
-                            NAV_FILE_NAME,
-                            FullNavFile
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteTextContentFile>()
-                    {
-                        {
-                            REMOTE_HTML_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteHtmlContentFile : RemoteHtmlContentFileWithNoContent
-                        }
-                    }
-                ),
-                css: new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFile>()
-                    {
-                        {
-                            STYLES1_FILE_NAME,
-                            Styles1File
-                        },
-                        {
-                            STYLES2_FILE_NAME,
-                            Styles2File
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteTextContentFile>()
-                    {
-                        {
-                            REMOTE_CSS_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteCssContentFile : RemoteCssContentFileWithNoContent
-                        }
-                    }
-                ),
-                images: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFile>()
-                    {
-                        {
-                            IMAGE1_FILE_NAME,
-                            Image1File
-                        },
-                        {
-                            IMAGE2_FILE_NAME,
-                            Image2File
-                        },
-                        {
-                            COVER_FILE_NAME,
-                            CoverFile
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFile>()
-                    {
-                        {
-                            REMOTE_IMAGE_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteImageContentFile : RemoteImageContentFileWithNoContent
-                        }
-                    }
-                ),
-                fonts: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFile>()
-                    {
-                        {
-                            FONT1_FILE_NAME,
-                            Font1File
-                        },
-                        {
-                            FONT2_FILE_NAME,
-                            Font2File
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFile>()
-                    {
-                        {
-                            REMOTE_FONT_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteFontContentFile : RemoteFontContentFileWithNoContent
-                        }
-                    }
-                ),
-                audio: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFile>()
-                    {
-                        {
-                            AUDIO1_FILE_NAME,
-                            Audio1File
-                        },
-                        {
-                            AUDIO2_FILE_NAME,
-                            Audio2File
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFile>()
-                    {
-                        {
-                            REMOTE_AUDIO_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteAudioContentFile : RemoteAudioContentFileWithNoContent
-                        }
-                    }
-                ),
-                allFiles: new EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>
-                (
-                    local: new Dictionary<string, EpubLocalContentFile>()
-                    {
-                        {
-                            CHAPTER1_FILE_NAME,
-                            Chapter1File
-                        },
-                        {
-                            CHAPTER2_FILE_NAME,
-                            Chapter2File
-                        },
-                        {
-                            STYLES1_FILE_NAME,
-                            Styles1File
-                        },
-                        {
-                            STYLES2_FILE_NAME,
-                            Styles2File
-                        },
-                        {
-                            IMAGE1_FILE_NAME,
-                            Image1File
-                        },
-                        {
-                            IMAGE2_FILE_NAME,
-                            Image2File
-                        },
-                        {
-                            FONT1_FILE_NAME,
-                            Font1File
-                        },
-                        {
-                            FONT2_FILE_NAME,
-                            Font2File
-                        },
-                        {
-                            AUDIO1_FILE_NAME,
-                            Audio1File
-                        },
-                        {
-                            AUDIO2_FILE_NAME,
-                            Audio2File
-                        },
-                        {
-                            VIDEO_FILE_NAME,
-                            VideoFile
-                        },
-                        {
-                            NAV_FILE_NAME,
-                            FullNavFile
-                        },
-                        {
-                            COVER_FILE_NAME,
-                            CoverFile
-                        },
-                        {
-                            NCX_FILE_NAME,
-                            NcxFile
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteContentFile>()
-                    {
-                        {
-                            REMOTE_HTML_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteHtmlContentFile : RemoteHtmlContentFileWithNoContent
-                        },
-                        {
-                            REMOTE_CSS_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteCssContentFile : RemoteCssContentFileWithNoContent
-                        },
-                        {
-                            REMOTE_IMAGE_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteImageContentFile : RemoteImageContentFileWithNoContent
-                        },
-                        {
-                            REMOTE_FONT_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteFontContentFile : RemoteFontContentFileWithNoContent
-                        },
-                        {
-                            REMOTE_XML_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteXmlContentFile : RemoteXmlContentFileWithNoContent
-                        },
-                        {
-                            REMOTE_AUDIO_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteAudioContentFile : RemoteAudioContentFileWithNoContent
-                        },
-                        {
-                            REMOTE_VIDEO_CONTENT_FILE_HREF,
-                            populateRemoteFilesContents ? RemoteVideoContentFile : RemoteVideoContentFileWithNoContent
-                        }
-                    }
-                )
+                html: new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>(htmlLocal.AsReadOnly(), htmlRemote.AsReadOnly()),
+                css: new EpubContentCollection<EpubLocalTextContentFile, EpubRemoteTextContentFile>(cssLocal.AsReadOnly(), cssRemote.AsReadOnly()),
+                images: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>(imagesLocal.AsReadOnly(), imagesRemote.AsReadOnly()),
+                fonts: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>(fontsLocal.AsReadOnly(), fontsRemote.AsReadOnly()),
+                audio: new EpubContentCollection<EpubLocalByteContentFile, EpubRemoteByteContentFile>(audioLocal.AsReadOnly(), audioRemote.AsReadOnly()),
+                allFiles: new EpubContentCollection<EpubLocalContentFile, EpubRemoteContentFile>(allFilesLocal.AsReadOnly(), allFilesRemote.AsReadOnly())
             );
         }
 
@@ -368,7 +232,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_HTML_CONTENT_FILE_HREF,
                 contentType: HTML_CONTENT_TYPE,
                 contentMimeType: HTML_CONTENT_MIME_TYPE,
-                url: REMOTE_HTML_CONTENT_FILE_HREF,
                 content: TestEpubFiles.REMOTE_HTML_FILE_CONTENT
             );
 
@@ -378,7 +241,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_HTML_CONTENT_FILE_HREF,
                 contentType: HTML_CONTENT_TYPE,
                 contentMimeType: HTML_CONTENT_MIME_TYPE,
-                url: REMOTE_HTML_CONTENT_FILE_HREF,
                 content: null
             );
 
@@ -388,7 +250,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_CSS_CONTENT_FILE_HREF,
                 contentType: CSS_CONTENT_TYPE,
                 contentMimeType: CSS_CONTENT_MIME_TYPE,
-                url: REMOTE_CSS_CONTENT_FILE_HREF,
                 content: TestEpubFiles.REMOTE_CSS_FILE_CONTENT
             );
 
@@ -398,7 +259,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_CSS_CONTENT_FILE_HREF,
                 contentType: CSS_CONTENT_TYPE,
                 contentMimeType: CSS_CONTENT_MIME_TYPE,
-                url: REMOTE_CSS_CONTENT_FILE_HREF,
                 content: null
             );
 
@@ -408,7 +268,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_IMAGE_CONTENT_FILE_HREF,
                 contentType: IMAGE_CONTENT_TYPE,
                 contentMimeType: IMAGE_CONTENT_MIME_TYPE,
-                url: REMOTE_IMAGE_CONTENT_FILE_HREF,
                 content: TestEpubFiles.REMOTE_IMAGE_FILE_CONTENT
             );
 
@@ -418,7 +277,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_IMAGE_CONTENT_FILE_HREF,
                 contentType: IMAGE_CONTENT_TYPE,
                 contentMimeType: IMAGE_CONTENT_MIME_TYPE,
-                url: REMOTE_IMAGE_CONTENT_FILE_HREF,
                 content: null
             );
 
@@ -428,7 +286,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_FONT_CONTENT_FILE_HREF,
                 contentType: FONT_CONTENT_TYPE,
                 contentMimeType: FONT_CONTENT_MIME_TYPE,
-                url: REMOTE_FONT_CONTENT_FILE_HREF,
                 content: TestEpubFiles.REMOTE_FONT_FILE_CONTENT
             );
 
@@ -438,7 +295,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_FONT_CONTENT_FILE_HREF,
                 contentType: FONT_CONTENT_TYPE,
                 contentMimeType: FONT_CONTENT_MIME_TYPE,
-                url: REMOTE_FONT_CONTENT_FILE_HREF,
                 content: null
             );
 
@@ -448,7 +304,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_XML_CONTENT_FILE_HREF,
                 contentType: XML_CONTENT_TYPE,
                 contentMimeType: XML_CONTENT_MIME_TYPE,
-                url: REMOTE_XML_CONTENT_FILE_HREF,
                 content: TestEpubFiles.REMOTE_XML_FILE_CONTENT
             );
 
@@ -458,7 +313,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_XML_CONTENT_FILE_HREF,
                 contentType: XML_CONTENT_TYPE,
                 contentMimeType: XML_CONTENT_MIME_TYPE,
-                url: REMOTE_XML_CONTENT_FILE_HREF,
                 content: null
             );
 
@@ -468,7 +322,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_AUDIO_CONTENT_FILE_HREF,
                 contentType: AUDIO_CONTENT_TYPE,
                 contentMimeType: AUDIO_MPEG_CONTENT_MIME_TYPE,
-                url: REMOTE_AUDIO_CONTENT_FILE_HREF,
                 content: TestEpubFiles.REMOTE_AUDIO_FILE_CONTENT
             );
 
@@ -478,7 +331,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_AUDIO_CONTENT_FILE_HREF,
                 contentType: AUDIO_CONTENT_TYPE,
                 contentMimeType: AUDIO_MPEG_CONTENT_MIME_TYPE,
-                url: REMOTE_AUDIO_CONTENT_FILE_HREF,
                 content: null
             );
 
@@ -488,7 +340,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_VIDEO_CONTENT_FILE_HREF,
                 contentType: OTHER_CONTENT_TYPE,
                 contentMimeType: VIDEO_MP4_CONTENT_MIME_TYPE,
-                url: REMOTE_VIDEO_CONTENT_FILE_HREF,
                 content: TestEpubFiles.REMOTE_VIDEO_FILE_CONTENT
             );
 
@@ -498,7 +349,6 @@ namespace VersOne.Epub.Test.Unit.TestData
                 key: REMOTE_VIDEO_CONTENT_FILE_HREF,
                 contentType: OTHER_CONTENT_TYPE,
                 contentMimeType: VIDEO_MP4_CONTENT_MIME_TYPE,
-                url: REMOTE_VIDEO_CONTENT_FILE_HREF,
                 content: null
             );
 

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContent.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContent.cs
@@ -80,17 +80,17 @@ namespace VersOne.Epub.Test.Unit.TestData
             {
                 Chapter1File,
                 Chapter2File,
+                FullNavFile,
                 Styles1File,
                 Styles2File,
                 Image1File,
                 Image2File,
+                CoverFile,
                 Font1File,
                 Font2File,
                 Audio1File,
                 Audio2File,
                 VideoFile,
-                FullNavFile,
-                CoverFile,
                 NcxFile
             };
             List<EpubRemoteContentFile> allFilesRemote = new()
@@ -99,8 +99,8 @@ namespace VersOne.Epub.Test.Unit.TestData
                 populateRemoteFilesContents? RemoteCssContentFile : RemoteCssContentFileWithNoContent,
                 populateRemoteFilesContents? RemoteImageContentFile : RemoteImageContentFileWithNoContent,
                 populateRemoteFilesContents? RemoteFontContentFile : RemoteFontContentFileWithNoContent,
-                populateRemoteFilesContents? RemoteXmlContentFile : RemoteXmlContentFileWithNoContent,
                 populateRemoteFilesContents? RemoteAudioContentFile : RemoteAudioContentFileWithNoContent,
+                populateRemoteFilesContents? RemoteXmlContentFile : RemoteXmlContentFileWithNoContent,
                 populateRemoteFilesContents? RemoteVideoContentFile : RemoteVideoContentFileWithNoContent
             };
             return new

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContentRef.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContentRef.cs
@@ -7,249 +7,113 @@ namespace VersOne.Epub.Test.Unit.TestData
     {
         public static EpubContentRef CreateMinimalTestEpubContentRefWithNavigation()
         {
+            List<EpubLocalTextContentFileRef> htmlLocal = new()
+            {
+                NavFileRef
+            };
+            List<EpubLocalContentFileRef> allFilesLocal = new()
+            {
+                NavFileRef
+            };
             return new
             (
                 cover: null,
                 navigationHtmlFile: NavFileRef,
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                    {
-                        {
-                            NAV_FILE_NAME,
-                            NavFileRef
-                        }
-                    }
-                ),
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(htmlLocal.AsReadOnly()),
                 css: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(),
                 images: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(),
                 fonts: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(),
                 audio: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(),
-                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalContentFileRef>()
-                    {
-                        {
-                            NAV_FILE_NAME,
-                            NavFileRef
-                        }
-                    }
-                )
+                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>(allFilesLocal.AsReadOnly())
             );
         }
 
         public static EpubContentRef CreateFullTestEpubContentRef()
         {
+            List<EpubLocalTextContentFileRef> htmlLocal = new()
+            {
+                Chapter1FileRef,
+                Chapter2FileRef,
+                NavFileRef
+            };
+            List<EpubRemoteTextContentFileRef> htmlRemote = new()
+            {
+                RemoteHtmlContentFileRef
+            };
+            List<EpubLocalTextContentFileRef> cssLocal = new()
+            {
+                Styles1FileRef,
+                Styles2FileRef
+            };
+            List<EpubRemoteTextContentFileRef> cssRemote = new()
+            {
+                RemoteCssContentFileRef
+            };
+            List<EpubLocalByteContentFileRef> imagesLocal = new()
+            {
+                Image1FileRef,
+                Image2FileRef,
+                CoverFileRef
+            };
+            List<EpubRemoteByteContentFileRef> imagesRemote = new()
+            {
+                RemoteImageContentFileRef
+            };
+            List<EpubLocalByteContentFileRef> fontsLocal = new()
+            {
+                Font1FileRef,
+                Font2FileRef
+            };
+            List<EpubRemoteByteContentFileRef> fontsRemote = new()
+            {
+                RemoteFontContentFileRef
+            };
+            List<EpubLocalByteContentFileRef> audioLocal = new()
+            {
+                Audio1FileRef,
+                Audio2FileRef
+            };
+            List<EpubRemoteByteContentFileRef> audioRemote = new()
+            {
+                RemoteAudioContentFileRef
+            };
+            List<EpubLocalContentFileRef> allFilesLocal = new()
+            {
+                Chapter1FileRef,
+                Chapter2FileRef,
+                Styles1FileRef,
+                Styles2FileRef,
+                Image1FileRef,
+                Image2FileRef,
+                Font1FileRef,
+                Font2FileRef,
+                Audio1FileRef,
+                Audio2FileRef,
+                VideoFileRef,
+                NavFileRef,
+                CoverFileRef,
+                NcxFileRef
+            };
+            List<EpubRemoteContentFileRef> allFilesRemote = new()
+            {
+                RemoteHtmlContentFileRef,
+                RemoteCssContentFileRef,
+                RemoteImageContentFileRef,
+                RemoteFontContentFileRef,
+                RemoteXmlContentFileRef,
+                RemoteAudioContentFileRef,
+                RemoteVideoContentFileRef
+            };
             return new EpubContentRef
             (
                 cover: CoverFileRef,
                 navigationHtmlFile: NavFileRef,
-                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                    {
-                        {
-                            CHAPTER1_FILE_NAME,
-                            Chapter1FileRef
-                        },
-                        {
-                            CHAPTER2_FILE_NAME,
-                            Chapter2FileRef
-                        },
-                        {
-                            NAV_FILE_NAME,
-                            NavFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            REMOTE_HTML_CONTENT_FILE_HREF,
-                            RemoteHtmlContentFileRef
-                        }
-                    }
-                ),
-                css: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalTextContentFileRef>()
-                    {
-                        {
-                            STYLES1_FILE_NAME,
-                            Styles1FileRef
-                        },
-                        {
-                            STYLES2_FILE_NAME,
-                            Styles2FileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteTextContentFileRef>()
-                    {
-                        {
-                            REMOTE_CSS_CONTENT_FILE_HREF,
-                            RemoteCssContentFileRef
-                        }
-                    }
-                ),
-                images: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFileRef>()
-                    {
-                        {
-                            IMAGE1_FILE_NAME,
-                            Image1FileRef
-                        },
-                        {
-                            IMAGE2_FILE_NAME,
-                            Image2FileRef
-                        },
-                        {
-                            COVER_FILE_NAME,
-                            CoverFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            REMOTE_IMAGE_CONTENT_FILE_HREF,
-                            RemoteImageContentFileRef
-                        }
-                    }
-                ),
-                fonts: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFileRef>()
-                    {
-                        {
-                            FONT1_FILE_NAME,
-                            Font1FileRef
-                        },
-                        {
-                            FONT2_FILE_NAME,
-                            Font2FileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            REMOTE_FONT_CONTENT_FILE_HREF,
-                            RemoteFontContentFileRef
-                        }
-                    }
-                ),
-                audio: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalByteContentFileRef>()
-                    {
-                        {
-                            AUDIO1_FILE_NAME,
-                            Audio1FileRef
-                        },
-                        {
-                            AUDIO2_FILE_NAME,
-                            Audio2FileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteByteContentFileRef>()
-                    {
-                        {
-                            REMOTE_AUDIO_CONTENT_FILE_HREF,
-                            RemoteAudioContentFileRef
-                        }
-                    }
-                ),
-                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>
-                (
-                    local: new Dictionary<string, EpubLocalContentFileRef>()
-                    {
-                        {
-                            CHAPTER1_FILE_NAME,
-                            Chapter1FileRef
-                        },
-                        {
-                            CHAPTER2_FILE_NAME,
-                            Chapter2FileRef
-                        },
-                        {
-                            STYLES1_FILE_NAME,
-                            Styles1FileRef
-                        },
-                        {
-                            STYLES2_FILE_NAME,
-                            Styles2FileRef
-                        },
-                        {
-                            IMAGE1_FILE_NAME,
-                            Image1FileRef
-                        },
-                        {
-                            IMAGE2_FILE_NAME,
-                            Image2FileRef
-                        },
-                        {
-                            FONT1_FILE_NAME,
-                            Font1FileRef
-                        },
-                        {
-                            FONT2_FILE_NAME,
-                            Font2FileRef
-                        },
-                        {
-                            AUDIO1_FILE_NAME,
-                            Audio1FileRef
-                        },
-                        {
-                            AUDIO2_FILE_NAME,
-                            Audio2FileRef
-                        },
-                        {
-                            VIDEO_FILE_NAME,
-                            VideoFileRef
-                        },
-                        {
-                            NAV_FILE_NAME,
-                            NavFileRef
-                        },
-                        {
-                            COVER_FILE_NAME,
-                            CoverFileRef
-                        },
-                        {
-                            NCX_FILE_NAME,
-                            NcxFileRef
-                        }
-                    },
-                    remote: new Dictionary<string, EpubRemoteContentFileRef>()
-                    {
-                        {
-                            REMOTE_HTML_CONTENT_FILE_HREF,
-                            RemoteHtmlContentFileRef
-                        },
-                        {
-                            REMOTE_CSS_CONTENT_FILE_HREF,
-                            RemoteCssContentFileRef
-                        },
-                        {
-                            REMOTE_IMAGE_CONTENT_FILE_HREF,
-                            RemoteImageContentFileRef
-                        },
-                        {
-                            REMOTE_FONT_CONTENT_FILE_HREF,
-                            RemoteFontContentFileRef
-                        },
-                        {
-                            REMOTE_XML_CONTENT_FILE_HREF,
-                            RemoteXmlContentFileRef
-                        },
-                        {
-                            REMOTE_AUDIO_CONTENT_FILE_HREF,
-                            RemoteAudioContentFileRef
-                        },
-                        {
-                            REMOTE_VIDEO_CONTENT_FILE_HREF,
-                            RemoteVideoContentFileRef
-                        }
-                    }
-                )
+                html: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(htmlLocal.AsReadOnly(), htmlRemote.AsReadOnly()),
+                css: new EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef>(cssLocal.AsReadOnly(), cssRemote.AsReadOnly()),
+                images: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(imagesLocal.AsReadOnly(), imagesRemote.AsReadOnly()),
+                fonts: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(fontsLocal.AsReadOnly(), fontsRemote.AsReadOnly()),
+                audio: new EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef>(audioLocal.AsReadOnly(), audioRemote.AsReadOnly()),
+                allFiles: new EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef>(allFilesLocal.AsReadOnly(), allFilesRemote.AsReadOnly())
             );
         }
 

--- a/Source/VersOne.Epub.Test/Unit/Utils/ContentPathUtilsTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Utils/ContentPathUtilsTests.cs
@@ -4,6 +4,22 @@ namespace VersOne.Epub.Test.Unit.Utils
 {
     public class ContentPathUtilsTests
     {
+        [Theory(DisplayName = "Testing if the specified path is a local path should succeed")]
+        [InlineData("Directory/File.html", true)]
+        [InlineData("", true)]
+        [InlineData("https://example.com/books/123/chapter1.html", false)]
+        public void IsLocalPathWithNonNullPathTest(string path, bool expectedResult)
+        {
+            bool actualResult = ContentPathUtils.IsLocalPath(path);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact(DisplayName = "IsLocalPath should throw ArgumentNullException if path parameter is null")]
+        public void IsLocalPathWithNullPathTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => ContentPathUtils.IsLocalPath(null!));
+        }
+
         [Theory(DisplayName = "Getting the directory path for a valid file path should succeed")]
         [InlineData("Directory/File.html", "Directory")]
         [InlineData("Directory/Subdirectory/File.html", "Directory/Subdirectory")]

--- a/Source/VersOne.Epub.Test/Unit/Utils/ContentPathUtilsTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Utils/ContentPathUtilsTests.cs
@@ -2,7 +2,7 @@
 
 namespace VersOne.Epub.Test.Unit.Utils
 {
-    public class ZipPathUtilsTests
+    public class ContentPathUtilsTests
     {
         [Theory(DisplayName = "Getting the directory path for a valid file path should succeed")]
         [InlineData("Directory/File.html", "Directory")]
@@ -14,7 +14,7 @@ namespace VersOne.Epub.Test.Unit.Utils
         [InlineData("../File.html", "..")]
         public void GetDirectoryPathTest(string filePath, string expectedDirectoryPath)
         {
-            string actualDirectoryPath = ZipPathUtils.GetDirectoryPath(filePath);
+            string actualDirectoryPath = ContentPathUtils.GetDirectoryPath(filePath);
             Assert.Equal(expectedDirectoryPath, actualDirectoryPath);
         }
 
@@ -34,7 +34,7 @@ namespace VersOne.Epub.Test.Unit.Utils
         [InlineData(null, null, null)]
         public void CombineTest(string directory, string fileName, string expectedResult)
         {
-            string actualResult = ZipPathUtils.Combine(directory, fileName);
+            string actualResult = ContentPathUtils.Combine(directory, fileName);
             Assert.Equal(expectedResult, actualResult);
         }
     }

--- a/Source/VersOne.Epub.WpfDemo/Models/BookModel.cs
+++ b/Source/VersOne.Epub.WpfDemo/Models/BookModel.cs
@@ -34,9 +34,9 @@ namespace VersOne.Epub.WpfDemo.Models
 
         public List<HtmlContentFileViewModel> GetReadingOrder(EpubBook epubBook)
         {
-            Dictionary<string, byte[]> images = epubBook.Content.Images.Local.ToDictionary(imageFile => imageFile.Key, imageFile => imageFile.Value.Content);
-            Dictionary<string, string> styleSheets = epubBook.Content.Css.Local.ToDictionary(cssFile => cssFile.Key, cssFile => cssFile.Value.Content);
-            Dictionary<string, byte[]> fonts = epubBook.Content.Fonts.Local.ToDictionary(fontFile => fontFile.Key, fontFile => fontFile.Value.Content);
+            Dictionary<string, byte[]> images = epubBook.Content.Images.Local.ToDictionary(imageFile => imageFile.Key, imageFile => imageFile.Content);
+            Dictionary<string, string> styleSheets = epubBook.Content.Css.Local.ToDictionary(cssFile => cssFile.Key, cssFile => cssFile.Content);
+            Dictionary<string, byte[]> fonts = epubBook.Content.Fonts.Local.ToDictionary(fontFile => fontFile.Key, fontFile => fontFile.Content);
             List<HtmlContentFileViewModel> result = new List<HtmlContentFileViewModel>();
             foreach (EpubLocalTextContentFile epubHtmlFile in epubBook.ReadingOrder)
             {

--- a/Source/VersOne.Epub/Content/Collections/EpubContentCollection.cs
+++ b/Source/VersOne.Epub/Content/Collections/EpubContentCollection.cs
@@ -1,37 +1,194 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace VersOne.Epub
 {
     /// <summary>
     /// A container for a subset of content files within the EPUB book.
     /// </summary>
-    /// <typeparam name="TLocalContentFile">The type of the content files stored within the <see cref="Local" /> dictionary.</typeparam>
-    /// <typeparam name="TRemoteContentFile">The type of the content files stored within the <see cref="Remote" /> dictionary.</typeparam>
+    /// <typeparam name="TLocalContentFile">The type of the content files stored within the <see cref="Local" /> collection.</typeparam>
+    /// <typeparam name="TRemoteContentFile">The type of the content files stored within the <see cref="Remote" /> collection.</typeparam>
     public class EpubContentCollection<TLocalContentFile, TRemoteContentFile>
         where TLocalContentFile : EpubLocalContentFile
         where TRemoteContentFile : EpubRemoteContentFile
     {
+        private readonly Dictionary<string, TLocalContentFile> localByKey;
+        private readonly Dictionary<string, TLocalContentFile> localByFilePath;
+        private readonly Dictionary<string, TRemoteContentFile> remoteByUrl;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EpubContentCollection{TLocalContentFile, TRemoteContentFile}" /> class.
         /// </summary>
         /// <param name="local">Local content files to be stored within this container.</param>
         /// <param name="remote">Remote content files to be stored within this container.</param>
-        public EpubContentCollection(Dictionary<string, TLocalContentFile>? local = null, Dictionary<string, TRemoteContentFile>? remote = null)
+        public EpubContentCollection(ReadOnlyCollection<TLocalContentFile>? local = null, ReadOnlyCollection<TRemoteContentFile>? remote = null)
         {
-            Local = local ?? new Dictionary<string, TLocalContentFile>();
-            Remote = remote ?? new Dictionary<string, TRemoteContentFile>();
+            Local = local ?? new ReadOnlyCollection<TLocalContentFile>(new List<TLocalContentFile>());
+            Remote = remote ?? new ReadOnlyCollection<TRemoteContentFile>(new List<TRemoteContentFile>());
+            localByKey = new Dictionary<string, TLocalContentFile>();
+            localByFilePath = new Dictionary<string, TLocalContentFile>();
+            foreach (TLocalContentFile localContentFile in Local)
+            {
+                if (localByKey.ContainsKey(localContentFile.Key))
+                {
+                    throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{localContentFile.Key}\" is not unique.");
+                }
+                localByKey.Add(localContentFile.Key, localContentFile);
+                if (localByFilePath.ContainsKey(localContentFile.FilePath))
+                {
+                    throw new EpubPackageException($"Incorrect EPUB manifest: item with absolute file path = \"{localContentFile.FilePath}\" is not unique.");
+                }
+                localByFilePath.Add(localContentFile.FilePath, localContentFile);
+            }
+            remoteByUrl = new Dictionary<string, TRemoteContentFile>();
+            foreach (TRemoteContentFile remoteContentFile in Remote)
+            {
+                if (remoteByUrl.ContainsKey(remoteContentFile.Url))
+                {
+                    throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{remoteContentFile.Url}\" is not unique.");
+                }
+                remoteByUrl.Add(remoteContentFile.Url, remoteContentFile);
+            }
         }
 
         /// <summary>
-        /// Gets a collection of key-value pairs where the key is the value of the <see cref="EpubContentFile.Key" /> property of the content file
-        /// and the value is the content file itself. This collection contains only the local content files stored within this container.
+        /// Gets a collection of local content files stored within this container.
         /// </summary>
-        public Dictionary<string, TLocalContentFile> Local { get; }
+        public ReadOnlyCollection<TLocalContentFile> Local { get; }
 
         /// <summary>
-        /// Gets a collection of key-value pairs where the key is the value of the <see cref="EpubContentFile.Key" /> property of the content file
-        /// and the value is the content file itself. This collection contains only the remote content files stored within this container.
+        /// Gets a collection of remote content files stored within this container.
         /// </summary>
-        public Dictionary<string, TRemoteContentFile> Remote { get; }
+        public ReadOnlyCollection<TRemoteContentFile> Remote { get; }
+
+        /// <summary>
+        /// Determines whether a local content file with the specified <see cref="EpubContentFile.Key" /> value exists in this container.
+        /// </summary>
+        /// <param name="key">The <see cref="EpubContentFile.Key" /> value of the local content file to locate in this container.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file with the specified <see cref="EpubContentFile.Key" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
+        public bool ContainsLocalFileWithKey(string key)
+        {
+            return localByKey.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Gets the local content file with the specified <see cref="EpubContentFile.Key" /> value.
+        /// </summary>
+        /// <param name="key">The <see cref="EpubContentFile.Key" /> of the local content file to get.</param>
+        /// <returns>The local content file with the specified <see cref="EpubContentFile.Key" /> value.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
+        /// <exception cref="KeyNotFoundException">
+        /// Local content file with the specified <see cref="EpubContentFile.Key" /> value does not exist in this container.
+        /// </exception>
+        public TLocalContentFile GetLocalFileByKey(string key)
+        {
+            return localByKey[key];
+        }
+
+        /// <summary>
+        /// Gets the local content file with the specified <see cref="EpubContentFile.Key" /> value.
+        /// </summary>
+        /// <param name="key">The <see cref="EpubContentFile.Key" /> of the local content file to get.</param>
+        /// <param name="localContentFile">
+        /// When this method returns, contains the local content file with the specified <see cref="EpubContentFile.Key" /> value,
+        /// if such local content file exists in the container; otherwise, <c>null</c>.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file with the specified <see cref="EpubContentFile.Key" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
+        public bool TryGetLocalFileByKey(string key, out TLocalContentFile localContentFile)
+        {
+            return localByKey.TryGetValue(key, out localContentFile);
+        }
+
+        /// <summary>
+        /// Determines whether a local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value exists in this container.
+        /// </summary>
+        /// <param name="filePath">The <see cref="EpubLocalContentFile.FilePath" /> value of the local content file to locate in this container.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
+        public bool ContainsLocalFileWithFilePath(string filePath)
+        {
+            return localByFilePath.ContainsKey(filePath);
+        }
+
+        /// <summary>
+        /// Gets the local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value.
+        /// </summary>
+        /// <param name="filePath">The <see cref="EpubLocalContentFile.FilePath" /> of the local content file to get.</param>
+        /// <returns>The local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
+        /// <exception cref="KeyNotFoundException">
+        /// Local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value does not exist in this container.
+        /// </exception>
+        public TLocalContentFile GetLocalFileByFilePath(string filePath)
+        {
+            return localByFilePath[filePath];
+        }
+
+        /// <summary>
+        /// Gets the local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value.
+        /// </summary>
+        /// <param name="filePath">The <see cref="EpubLocalContentFile.FilePath" /> of the local content file to get.</param>
+        /// <param name="localContentFile">
+        /// When this method returns, contains the local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value,
+        /// if such local content file exists in the container; otherwise, <c>null</c>.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
+        public bool TryGetLocalFileByFilePath(string filePath, out TLocalContentFile localContentFile)
+        {
+            return localByKey.TryGetValue(filePath, out localContentFile);
+        }
+
+        /// <summary>
+        /// Determines whether a remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value exists in this container.
+        /// </summary>
+        /// <param name="url">The <see cref="EpubRemoteContentFile.Url" /> value of the remote content file to locate in this container.</param>
+        /// <returns>
+        /// <c>true</c> if the remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
+        public bool ContainsRemoteFileWithUrl(string url)
+        {
+            return remoteByUrl.ContainsKey(url);
+        }
+
+        /// <summary>
+        /// Gets the remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value.
+        /// </summary>
+        /// <param name="url">The <see cref="EpubRemoteContentFile.Url" /> of the remote content file to get.</param>
+        /// <returns>The remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
+        /// <exception cref="KeyNotFoundException">
+        /// Remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value does not exist in this container.
+        /// </exception>
+        public TRemoteContentFile GetRemoteFileByUrl(string url)
+        {
+            return remoteByUrl[url];
+        }
+
+        /// <summary>
+        /// Gets the remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value.
+        /// </summary>
+        /// <param name="url">The <see cref="EpubRemoteContentFile.Url" /> of the remote content file to get.</param>
+        /// <param name="remoteContentFile">
+        /// When this method returns, contains the remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value,
+        /// if such remote content file exists in the container; otherwise, <c>null</c>.</param>
+        /// <returns>
+        /// <c>true</c> if the remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
+        public bool TryGetRemoteFileByUrl(string url, out TRemoteContentFile remoteContentFile)
+        {
+            return remoteByUrl.TryGetValue(url, out remoteContentFile);
+        }
     }
 }

--- a/Source/VersOne.Epub/Content/Collections/EpubContentCollection.cs
+++ b/Source/VersOne.Epub/Content/Collections/EpubContentCollection.cs
@@ -183,7 +183,7 @@ namespace VersOne.Epub
             {
                 throw new ArgumentNullException(nameof(filePath));
             }
-            return localByKey.TryGetValue(filePath, out localContentFile);
+            return localByFilePath.TryGetValue(filePath, out localContentFile);
         }
 
         /// <summary>

--- a/Source/VersOne.Epub/Content/Collections/EpubContentCollection.cs
+++ b/Source/VersOne.Epub/Content/Collections/EpubContentCollection.cs
@@ -72,6 +72,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
         public bool ContainsLocalFileWithKey(string key)
         {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
             return localByKey.ContainsKey(key);
         }
 
@@ -81,12 +85,23 @@ namespace VersOne.Epub
         /// <param name="key">The <see cref="EpubContentFile.Key" /> of the local content file to get.</param>
         /// <returns>The local content file with the specified <see cref="EpubContentFile.Key" /> value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
-        /// <exception cref="KeyNotFoundException">
+        /// <exception cref="EpubContentCollectionException">
         /// Local content file with the specified <see cref="EpubContentFile.Key" /> value does not exist in this container.
         /// </exception>
         public TLocalContentFile GetLocalFileByKey(string key)
         {
-            return localByKey[key];
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+            try
+            {
+                return localByKey[key];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new EpubContentCollectionException($"Local content file with key = \"{key}\" does not exist in this container.");
+            }
         }
 
         /// <summary>
@@ -102,6 +117,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
         public bool TryGetLocalFileByKey(string key, out TLocalContentFile localContentFile)
         {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
             return localByKey.TryGetValue(key, out localContentFile);
         }
 
@@ -115,6 +134,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
         public bool ContainsLocalFileWithFilePath(string filePath)
         {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
             return localByFilePath.ContainsKey(filePath);
         }
 
@@ -124,12 +147,23 @@ namespace VersOne.Epub
         /// <param name="filePath">The <see cref="EpubLocalContentFile.FilePath" /> of the local content file to get.</param>
         /// <returns>The local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
-        /// <exception cref="KeyNotFoundException">
+        /// <exception cref="EpubContentCollectionException">
         /// Local content file with the specified <see cref="EpubLocalContentFile.FilePath" /> value does not exist in this container.
         /// </exception>
         public TLocalContentFile GetLocalFileByFilePath(string filePath)
         {
-            return localByFilePath[filePath];
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+            try
+            {
+                return localByFilePath[filePath];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new EpubContentCollectionException($"Local content file with file path = \"{filePath}\" does not exist in this container.");
+            }
         }
 
         /// <summary>
@@ -145,6 +179,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
         public bool TryGetLocalFileByFilePath(string filePath, out TLocalContentFile localContentFile)
         {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
             return localByKey.TryGetValue(filePath, out localContentFile);
         }
 
@@ -158,6 +196,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
         public bool ContainsRemoteFileWithUrl(string url)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
             return remoteByUrl.ContainsKey(url);
         }
 
@@ -167,12 +209,23 @@ namespace VersOne.Epub
         /// <param name="url">The <see cref="EpubRemoteContentFile.Url" /> of the remote content file to get.</param>
         /// <returns>The remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
-        /// <exception cref="KeyNotFoundException">
+        /// <exception cref="EpubContentCollectionException">
         /// Remote content file with the specified <see cref="EpubRemoteContentFile.Url" /> value does not exist in this container.
         /// </exception>
         public TRemoteContentFile GetRemoteFileByUrl(string url)
         {
-            return remoteByUrl[url];
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+            try
+            {
+                return remoteByUrl[url];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new EpubContentCollectionException($"Remote content file with URL = \"{url}\" does not exist in this container.");
+            }
         }
 
         /// <summary>
@@ -188,6 +241,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
         public bool TryGetRemoteFileByUrl(string url, out TRemoteContentFile remoteContentFile)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
             return remoteByUrl.TryGetValue(url, out remoteContentFile);
         }
     }

--- a/Source/VersOne.Epub/Content/Collections/EpubContentCollectionRef.cs
+++ b/Source/VersOne.Epub/Content/Collections/EpubContentCollectionRef.cs
@@ -72,6 +72,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
         public bool ContainsLocalFileRefWithKey(string key)
         {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
             return localByKey.ContainsKey(key);
         }
 
@@ -81,12 +85,23 @@ namespace VersOne.Epub
         /// <param name="key">The <see cref="EpubContentFileRef.Key" /> of the local content file reference to get.</param>
         /// <returns>The local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
-        /// <exception cref="KeyNotFoundException">
+        /// <exception cref="EpubContentCollectionRefException">
         /// Local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value does not exist in this container.
         /// </exception>
         public TLocalContentFileRef GetLocalFileRefByKey(string key)
         {
-            return localByKey[key];
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+            try
+            {
+                return localByKey[key];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new EpubContentCollectionRefException($"Local content file reference with key = \"{key}\" does not exist in this container.");
+            }
         }
 
         /// <summary>
@@ -102,6 +117,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
         public bool TryGetLocalFileRefByKey(string key, out TLocalContentFileRef localContentFileRef)
         {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
             return localByKey.TryGetValue(key, out localContentFileRef);
         }
 
@@ -115,6 +134,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
         public bool ContainsLocalFileRefWithFilePath(string filePath)
         {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
             return localByFilePath.ContainsKey(filePath);
         }
 
@@ -124,12 +147,23 @@ namespace VersOne.Epub
         /// <param name="filePath">The <see cref="EpubLocalContentFileRef.FilePath" /> of the local content file reference to get.</param>
         /// <returns>The local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
-        /// <exception cref="KeyNotFoundException">
+        /// <exception cref="EpubContentCollectionRefException">
         /// Local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value does not exist in this container.
         /// </exception>
         public TLocalContentFileRef GetLocalFileRefByFilePath(string filePath)
         {
-            return localByFilePath[filePath];
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+            try
+            {
+                return localByFilePath[filePath];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new EpubContentCollectionRefException($"Local content file reference with file path = \"{filePath}\" does not exist in this container.");
+            }
         }
 
         /// <summary>
@@ -145,6 +179,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
         public bool TryGetLocalFileRefByFilePath(string filePath, out TLocalContentFileRef localContentFileRef)
         {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
             return localByKey.TryGetValue(filePath, out localContentFileRef);
         }
 
@@ -158,6 +196,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
         public bool ContainsRemoteFileRefWithUrl(string url)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
             return remoteByUrl.ContainsKey(url);
         }
 
@@ -167,12 +209,23 @@ namespace VersOne.Epub
         /// <param name="url">The <see cref="EpubRemoteContentFileRef.Url" /> of the remote content file reference to get.</param>
         /// <returns>The remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
-        /// <exception cref="KeyNotFoundException">
+        /// <exception cref="EpubContentCollectionRefException">
         /// Remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value does not exist in this container.
         /// </exception>
         public TRemoteContentFileRef GetRemoteFileRefByUrl(string url)
         {
-            return remoteByUrl[url];
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+            try
+            {
+                return remoteByUrl[url];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new EpubContentCollectionRefException($"Remote content file reference with URL = \"{url}\" does not exist in this container.");
+            }
         }
 
         /// <summary>
@@ -188,6 +241,10 @@ namespace VersOne.Epub
         /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
         public bool TryGetRemoteFileRefByUrl(string url, out TRemoteContentFileRef remoteContentFileRef)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
             return remoteByUrl.TryGetValue(url, out remoteContentFileRef);
         }
     }

--- a/Source/VersOne.Epub/Content/Collections/EpubContentCollectionRef.cs
+++ b/Source/VersOne.Epub/Content/Collections/EpubContentCollectionRef.cs
@@ -183,7 +183,7 @@ namespace VersOne.Epub
             {
                 throw new ArgumentNullException(nameof(filePath));
             }
-            return localByKey.TryGetValue(filePath, out localContentFileRef);
+            return localByFilePath.TryGetValue(filePath, out localContentFileRef);
         }
 
         /// <summary>

--- a/Source/VersOne.Epub/Content/Collections/EpubContentCollectionRef.cs
+++ b/Source/VersOne.Epub/Content/Collections/EpubContentCollectionRef.cs
@@ -1,37 +1,194 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace VersOne.Epub
 {
     /// <summary>
     /// A container for a subset of content file references within the EPUB book.
     /// </summary>
-    /// <typeparam name="TLocalContentFileRef">The type of the content file references stored within the <see cref="Local" /> dictionary.</typeparam>
-    /// <typeparam name="TRemoteContentFileRef">The type of the content file references stored within the <see cref="Remote" /> dictionary.</typeparam>
+    /// <typeparam name="TLocalContentFileRef">The type of the content file references stored within the <see cref="Local" /> collection.</typeparam>
+    /// <typeparam name="TRemoteContentFileRef">The type of the content file references stored within the <see cref="Remote" /> collection.</typeparam>
     public class EpubContentCollectionRef<TLocalContentFileRef, TRemoteContentFileRef>
         where TLocalContentFileRef : EpubLocalContentFileRef
         where TRemoteContentFileRef : EpubRemoteContentFileRef
     {
+        private readonly Dictionary<string, TLocalContentFileRef> localByKey;
+        private readonly Dictionary<string, TLocalContentFileRef> localByFilePath;
+        private readonly Dictionary<string, TRemoteContentFileRef> remoteByUrl;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EpubContentCollectionRef{TLocalContentFileRef, TRemoteContentFileRef}" /> class.
         /// </summary>
         /// <param name="local">Local content file references to be stored within this container.</param>
         /// <param name="remote">Remote content file references to be stored within this container.</param>
-        public EpubContentCollectionRef(Dictionary<string, TLocalContentFileRef>? local = null, Dictionary<string, TRemoteContentFileRef>? remote = null)
+        public EpubContentCollectionRef(ReadOnlyCollection<TLocalContentFileRef>? local = null, ReadOnlyCollection<TRemoteContentFileRef>? remote = null)
         {
-            Local = local ?? new Dictionary<string, TLocalContentFileRef>();
-            Remote = remote ?? new Dictionary<string, TRemoteContentFileRef>();
+            Local = local ?? new ReadOnlyCollection<TLocalContentFileRef>(new List<TLocalContentFileRef>());
+            Remote = remote ?? new ReadOnlyCollection<TRemoteContentFileRef>(new List<TRemoteContentFileRef>());
+            localByKey = new Dictionary<string, TLocalContentFileRef>();
+            localByFilePath = new Dictionary<string, TLocalContentFileRef>();
+            foreach (TLocalContentFileRef localContentFileRef in Local)
+            {
+                if (localByKey.ContainsKey(localContentFileRef.Key))
+                {
+                    throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{localContentFileRef.Key}\" is not unique.");
+                }
+                localByKey.Add(localContentFileRef.Key, localContentFileRef);
+                if (localByFilePath.ContainsKey(localContentFileRef.FilePath))
+                {
+                    throw new EpubPackageException($"Incorrect EPUB manifest: item with absolute file path = \"{localContentFileRef.FilePath}\" is not unique.");
+                }
+                localByFilePath.Add(localContentFileRef.FilePath, localContentFileRef);
+            }
+            remoteByUrl = new Dictionary<string, TRemoteContentFileRef>();
+            foreach (TRemoteContentFileRef remoteContentFileRef in Remote)
+            {
+                if (remoteByUrl.ContainsKey(remoteContentFileRef.Url))
+                {
+                    throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{remoteContentFileRef.Url}\" is not unique.");
+                }
+                remoteByUrl.Add(remoteContentFileRef.Url, remoteContentFileRef);
+            }
         }
 
         /// <summary>
-        /// Gets a collection of key-value pairs where the key is the value of the <see cref="EpubContentFile.Key" /> property of the content file reference
-        /// and the value is the content file reference itself. This collection contains only the local content file references stored within this container.
+        /// Gets a collection of local content file references stored within this container.
         /// </summary>
-        public Dictionary<string, TLocalContentFileRef> Local { get; }
+        public ReadOnlyCollection<TLocalContentFileRef> Local { get; }
 
         /// <summary>
-        /// Gets a collection of key-value pairs where the key is the value of the <see cref="EpubContentFile.Key" /> property of the content file reference
-        /// and the value is the content file reference itself. This collection contains only the remote content file references stored within this container.
+        /// Gets a collection of remote content file references stored within this container.
         /// </summary>
-        public Dictionary<string, TRemoteContentFileRef> Remote { get; }
+        public ReadOnlyCollection<TRemoteContentFileRef> Remote { get; }
+
+        /// <summary>
+        /// Determines whether a local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value exists in this container.
+        /// </summary>
+        /// <param name="key">The <see cref="EpubContentFileRef.Key" /> value of the local content file reference to locate in this container.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
+        public bool ContainsLocalFileRefWithKey(string key)
+        {
+            return localByKey.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Gets the local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value.
+        /// </summary>
+        /// <param name="key">The <see cref="EpubContentFileRef.Key" /> of the local content file reference to get.</param>
+        /// <returns>The local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
+        /// <exception cref="KeyNotFoundException">
+        /// Local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value does not exist in this container.
+        /// </exception>
+        public TLocalContentFileRef GetLocalFileRefByKey(string key)
+        {
+            return localByKey[key];
+        }
+
+        /// <summary>
+        /// Gets the local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value.
+        /// </summary>
+        /// <param name="key">The <see cref="EpubContentFileRef.Key" /> of the local content file reference to get.</param>
+        /// <param name="localContentFileRef">
+        /// When this method returns, contains the local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value,
+        /// if such local content file reference exists in the container; otherwise, <c>null</c>.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file reference with the specified <see cref="EpubContentFileRef.Key" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is <c>null</c>.</exception>
+        public bool TryGetLocalFileRefByKey(string key, out TLocalContentFileRef localContentFileRef)
+        {
+            return localByKey.TryGetValue(key, out localContentFileRef);
+        }
+
+        /// <summary>
+        /// Determines whether a local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value exists in this container.
+        /// </summary>
+        /// <param name="filePath">The <see cref="EpubLocalContentFileRef.FilePath" /> value of the local content file reference to locate in this container.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
+        public bool ContainsLocalFileRefWithFilePath(string filePath)
+        {
+            return localByFilePath.ContainsKey(filePath);
+        }
+
+        /// <summary>
+        /// Gets the local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value.
+        /// </summary>
+        /// <param name="filePath">The <see cref="EpubLocalContentFileRef.FilePath" /> of the local content file reference to get.</param>
+        /// <returns>The local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
+        /// <exception cref="KeyNotFoundException">
+        /// Local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value does not exist in this container.
+        /// </exception>
+        public TLocalContentFileRef GetLocalFileRefByFilePath(string filePath)
+        {
+            return localByFilePath[filePath];
+        }
+
+        /// <summary>
+        /// Gets the local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value.
+        /// </summary>
+        /// <param name="filePath">The <see cref="EpubLocalContentFileRef.FilePath" /> of the local content file reference to get.</param>
+        /// <param name="localContentFileRef">
+        /// When this method returns, contains the local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value,
+        /// if such local content file reference exists in the container; otherwise, <c>null</c>.</param>
+        /// <returns>
+        /// <c>true</c> if the local content file reference with the specified <see cref="EpubLocalContentFileRef.FilePath" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="filePath" /> is <c>null</c>.</exception>
+        public bool TryGetLocalFileRefByFilePath(string filePath, out TLocalContentFileRef localContentFileRef)
+        {
+            return localByKey.TryGetValue(filePath, out localContentFileRef);
+        }
+
+        /// <summary>
+        /// Determines whether a remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value exists in this container.
+        /// </summary>
+        /// <param name="url">The <see cref="EpubRemoteContentFileRef.Url" /> value of the remote content file reference to locate in this container.</param>
+        /// <returns>
+        /// <c>true</c> if the remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
+        public bool ContainsRemoteFileRefWithUrl(string url)
+        {
+            return remoteByUrl.ContainsKey(url);
+        }
+
+        /// <summary>
+        /// Gets the remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value.
+        /// </summary>
+        /// <param name="url">The <see cref="EpubRemoteContentFileRef.Url" /> of the remote content file reference to get.</param>
+        /// <returns>The remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
+        /// <exception cref="KeyNotFoundException">
+        /// Remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value does not exist in this container.
+        /// </exception>
+        public TRemoteContentFileRef GetRemoteFileRefByUrl(string url)
+        {
+            return remoteByUrl[url];
+        }
+
+        /// <summary>
+        /// Gets the remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value.
+        /// </summary>
+        /// <param name="url">The <see cref="EpubRemoteContentFileRef.Url" /> of the remote content file reference to get.</param>
+        /// <param name="remoteContentFileRef">
+        /// When this method returns, contains the remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value,
+        /// if such remote content file reference exists in the container; otherwise, <c>null</c>.</param>
+        /// <returns>
+        /// <c>true</c> if the remote content file reference with the specified <see cref="EpubRemoteContentFileRef.Url" /> value exists in this container; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="url" /> is <c>null</c>.</exception>
+        public bool TryGetRemoteFileRefByUrl(string url, out TRemoteContentFileRef remoteContentFileRef)
+        {
+            return remoteByUrl.TryGetValue(url, out remoteContentFileRef);
+        }
     }
 }

--- a/Source/VersOne.Epub/Content/Loaders/EpubLocalContentLoader.cs
+++ b/Source/VersOne.Epub/Content/Loaders/EpubLocalContentLoader.cs
@@ -58,7 +58,7 @@ namespace VersOne.Epub.Internal
                 throw new ObjectDisposedException(nameof(epubFile), "EPUB file stored within this local content file loader has been disposed.");
             }
             ReplacementContentFileEntry? newReplacementContentFileEntry = null;
-            string contentFilePath = ZipPathUtils.Combine(contentDirectoryPath, contentFileRefMetadata.Key);
+            string contentFilePath = ContentPathUtils.Combine(contentDirectoryPath, contentFileRefMetadata.Key);
             IZipFileEntry? contentFileEntry = epubFile.GetEntry(contentFilePath);
             if (contentFileEntry == null)
             {

--- a/Source/VersOne.Epub/Content/Remote/EpubRemoteByteContentFile.cs
+++ b/Source/VersOne.Epub/Content/Remote/EpubRemoteByteContentFile.cs
@@ -15,13 +15,11 @@ namespace VersOne.Epub
         /// <param name="key">The content file key as it is declared in the EPUB manifest (in the <see cref="EpubManifestItem.Href" /> property).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
-        /// <param name="url">The absolute URI of the remote content file (as it is specified in the EPUB manifest).</param>
         /// <param name="content">The content of the file.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="contentMimeType" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="url" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="content" /> parameter is <c>null</c>.</exception>
-        public EpubRemoteByteContentFile(string key, EpubContentType contentType, string contentMimeType, string url, byte[]? content)
-            : base(key, contentType, contentMimeType, url)
+        public EpubRemoteByteContentFile(string key, EpubContentType contentType, string contentMimeType, byte[]? content)
+            : base(key, contentType, contentMimeType)
         {
             Content = content;
         }

--- a/Source/VersOne.Epub/Content/Remote/EpubRemoteContentFile.cs
+++ b/Source/VersOne.Epub/Content/Remote/EpubRemoteContentFile.cs
@@ -15,19 +15,16 @@ namespace VersOne.Epub
         /// <param name="key">The content file key as it is declared in the EPUB manifest (in the <see cref="EpubManifestItem.Href" /> property).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
-        /// <param name="url">The absolute URI of the remote content file (as it is specified in the EPUB manifest).</param>
         /// <exception cref="ArgumentNullException">The <paramref name="contentMimeType" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="url" /> parameter is <c>null</c>.</exception>
-        protected EpubRemoteContentFile(string key, EpubContentType contentType, string contentMimeType, string url)
+        protected EpubRemoteContentFile(string key, EpubContentType contentType, string contentMimeType)
             : base(key, contentType, contentMimeType)
         {
-            Url = url ?? throw new ArgumentNullException(nameof(url));
         }
 
         /// <summary>
         /// Gets the absolute URI of the remote content file (as it is specified in the EPUB manifest).
         /// </summary>
-        public string Url { get; }
+        public string Url => Key;
 
         /// <summary>
         /// Gets the location of the content file which is always <see cref="EpubContentLocation.REMOTE" /> for remote content files.

--- a/Source/VersOne.Epub/Content/Remote/EpubRemoteTextContentFile.cs
+++ b/Source/VersOne.Epub/Content/Remote/EpubRemoteTextContentFile.cs
@@ -15,12 +15,10 @@ namespace VersOne.Epub
         /// <param name="key">The content file key as it is declared in the EPUB manifest (in the <see cref="EpubManifestItem.Href" /> property).</param>
         /// <param name="contentType">The type of the content of the file.</param>
         /// <param name="contentMimeType">The MIME type of the content of the file.</param>
-        /// <param name="url">The absolute URI of the remote content file (as it is specified in the EPUB manifest).</param>
         /// <param name="content">The content of the file.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="contentMimeType" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="url" /> parameter is <c>null</c>.</exception>
-        public EpubRemoteTextContentFile(string key, EpubContentType contentType, string contentMimeType, string url, string? content)
-            : base(key, contentType, contentMimeType, url)
+        public EpubRemoteTextContentFile(string key, EpubContentType contentType, string contentMimeType, string? content)
+            : base(key, contentType, contentMimeType)
         {
             Content = content;
         }

--- a/Source/VersOne.Epub/Entities/EpubNavigationItemLink.cs
+++ b/Source/VersOne.Epub/Entities/EpubNavigationItemLink.cs
@@ -39,19 +39,19 @@ namespace VersOne.Epub
         /// <summary>
         /// Initializes a new instance of the <see cref="EpubNavigationItemLink" /> class with specified content file URL without anchor, content file path, and anchor.
         /// </summary>
-        /// <param name="contentFileUrlWithoutAnchor">The file path portion of the content file URL.</param>
+        /// <param name="contentFileUrl">The file path portion of the content file URL without anchor.</param>
         /// <param name="contentFilePath">The file path portion of the content file URL converted to the absolute file path within the EPUB archive.</param>
         /// <param name="anchor">The anchor portion of the content file URL.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="contentFileUrlWithoutAnchor" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="contentFileUrl" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="contentFilePath" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">The <paramref name="contentFileUrlWithoutAnchor" /> parameter points to a remote URL.</exception>
-        public EpubNavigationItemLink(string contentFileUrlWithoutAnchor, string contentFilePath, string? anchor)
+        /// <exception cref="ArgumentException">The <paramref name="contentFileUrl" /> parameter points to a remote URL.</exception>
+        public EpubNavigationItemLink(string contentFileUrl, string contentFilePath, string? anchor)
         {
-            ContentFileUrl = contentFileUrlWithoutAnchor ?? throw new ArgumentNullException(nameof(contentFileUrlWithoutAnchor));
+            ContentFileUrl = contentFileUrl ?? throw new ArgumentNullException(nameof(contentFileUrl));
             ContentFilePath = contentFilePath ?? throw new ArgumentNullException(nameof(contentFilePath));
-            if (!ContentPathUtils.IsLocalPath(contentFileUrlWithoutAnchor))
+            if (!ContentPathUtils.IsLocalPath(contentFileUrl))
             {
-                throw new ArgumentException($"\"{contentFileUrlWithoutAnchor}\" points to a remote resource.");
+                throw new ArgumentException($"\"{contentFileUrl}\" points to a remote resource.");
             }
             Anchor = anchor;
         }

--- a/Source/VersOne.Epub/Entities/EpubNavigationItemLink.cs
+++ b/Source/VersOne.Epub/Entities/EpubNavigationItemLink.cs
@@ -9,38 +9,50 @@ namespace VersOne.Epub
     public class EpubNavigationItemLink
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="EpubNavigationItemLink" /> class using a specified content file URL and a specified base directory path.
+        /// Initializes a new instance of the <see cref="EpubNavigationItemLink" /> class using a specified content file URL with anchor and a specified base directory path.
         /// </summary>
-        /// <param name="contentFileUrl">Relative file path or a URL of the content file with an optional anchor (as it is specified in the EPUB manifest).</param>
+        /// <param name="contentFileUrlWithAnchor">Relative file path of the content file with an optional anchor (as it is specified in the EPUB manifest).</param>
         /// <param name="baseDirectoryPath">The path of the directory within the EPUB archive which acts as a base directory for a relative content file path.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="contentFileUrl" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="contentFileUrlWithAnchor" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="baseDirectoryPath" /> parameter is <c>null</c>.</exception>
-        public EpubNavigationItemLink(string contentFileUrl, string baseDirectoryPath)
+        /// <exception cref="ArgumentException">The <paramref name="contentFileUrlWithAnchor" /> parameter points to a remote URL.</exception>
+        public EpubNavigationItemLink(string contentFileUrlWithAnchor, string baseDirectoryPath)
         {
-            if (contentFileUrl == null)
+            if (contentFileUrlWithAnchor == null)
             {
-                throw new ArgumentNullException(nameof(contentFileUrl));
+                throw new ArgumentNullException(nameof(contentFileUrlWithAnchor));
             }
             if (baseDirectoryPath == null)
             {
                 throw new ArgumentNullException(nameof(baseDirectoryPath));
             }
-            UrlParser urlParser = new(contentFileUrl);
-            ContentFileName = urlParser.Path;
-            ContentFilePath = ZipPathUtils.Combine(baseDirectoryPath, ContentFileName);
+            if (!ContentPathUtils.IsLocalPath(contentFileUrlWithAnchor))
+            {
+                throw new ArgumentException($"\"{contentFileUrlWithAnchor}\" points to a remote resource.");
+            }
+            UrlParser urlParser = new(contentFileUrlWithAnchor);
+            ContentFileUrl = urlParser.Path;
+            ContentFilePath = ContentPathUtils.Combine(baseDirectoryPath, ContentFileUrl);
             Anchor = urlParser.Anchor;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EpubNavigationItemLink" /> class with specified content file name, content file path in EPUB archive, and anchor.
+        /// Initializes a new instance of the <see cref="EpubNavigationItemLink" /> class with specified content file URL without anchor, content file path, and anchor.
         /// </summary>
-        /// <param name="contentFileName">The file path portion of the content file URL.</param>
+        /// <param name="contentFileUrlWithoutAnchor">The file path portion of the content file URL.</param>
         /// <param name="contentFilePath">The file path portion of the content file URL converted to the absolute file path within the EPUB archive.</param>
         /// <param name="anchor">The anchor portion of the content file URL.</param>
-        public EpubNavigationItemLink(string contentFileName, string contentFilePath, string? anchor)
+        /// <exception cref="ArgumentNullException">The <paramref name="contentFileUrlWithoutAnchor" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="contentFilePath" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="contentFileUrlWithoutAnchor" /> parameter points to a remote URL.</exception>
+        public EpubNavigationItemLink(string contentFileUrlWithoutAnchor, string contentFilePath, string? anchor)
         {
-            ContentFileName = contentFileName ?? throw new ArgumentNullException(nameof(contentFileName));
+            ContentFileUrl = contentFileUrlWithoutAnchor ?? throw new ArgumentNullException(nameof(contentFileUrlWithoutAnchor));
             ContentFilePath = contentFilePath ?? throw new ArgumentNullException(nameof(contentFilePath));
+            if (!ContentPathUtils.IsLocalPath(contentFileUrlWithoutAnchor))
+            {
+                throw new ArgumentException($"\"{contentFileUrlWithoutAnchor}\" points to a remote resource.");
+            }
             Anchor = anchor;
         }
 
@@ -48,7 +60,7 @@ namespace VersOne.Epub
         /// Gets the file path portion of the content file URL.
         /// For example, if the content file URL is '../content/chapter1.html#section1', then the value of this property will be '../content/chapter1.html'.
         /// </summary>
-        public string ContentFileName { get; }
+        public string ContentFileUrl { get; }
 
         /// <summary>
         /// Gets the file path portion of the content file URL converted to the absolute file path within the EPUB archive.

--- a/Source/VersOne.Epub/Exceptions/Epub2NcxException.cs
+++ b/Source/VersOne.Epub/Exceptions/Epub2NcxException.cs
@@ -30,7 +30,7 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
-        public Epub2NcxException(string message, Exception innerException)
+        public Epub2NcxException(string message, Exception? innerException)
             : base(message, innerException, EpubSchemaFileType.EPUB2_NCX)
         {
         }

--- a/Source/VersOne.Epub/Exceptions/Epub3NavException.cs
+++ b/Source/VersOne.Epub/Exceptions/Epub3NavException.cs
@@ -30,7 +30,7 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
-        public Epub3NavException(string message, Exception innerException)
+        public Epub3NavException(string message, Exception? innerException)
             : base(message, innerException, EpubSchemaFileType.EPUB3_NAV_DOCUMENT)
         {
         }

--- a/Source/VersOne.Epub/Exceptions/EpubContainerException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubContainerException.cs
@@ -30,7 +30,7 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
-        public EpubContainerException(string message, Exception innerException)
+        public EpubContainerException(string message, Exception? innerException)
             : base(message, innerException, EpubSchemaFileType.META_INF_CONTAINER)
         {
         }

--- a/Source/VersOne.Epub/Exceptions/EpubContentCollectionException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubContentCollectionException.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace VersOne.Epub
+{
+    /// <summary>
+    /// Represents an exception thrown by the EpubReader due to an invalid operation
+    /// performed on an instance of the <see cref="EpubContentCollection{TLocalContentFile, TRemoteContentFile}" /> class.
+    /// </summary>
+    public class EpubContentCollectionException : EpubReaderException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EpubContentCollectionException" /> class.
+        /// </summary>
+        public EpubContentCollectionException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EpubContentCollectionException" /> class with a specified error.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public EpubContentCollectionException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EpubContentCollectionException" /> class with a specified error message and a reference to the inner exception
+        /// that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
+        public EpubContentCollectionException(string message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Source/VersOne.Epub/Exceptions/EpubContentCollectionRefException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubContentCollectionRefException.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace VersOne.Epub
+{
+    /// <summary>
+    /// Represents an exception thrown by the EpubReader due to an invalid operation
+    /// performed on an instance of the <see cref="EpubContentCollectionRef{TLocalContentFileRef, TRemoteContentFileRef}" /> class.
+    /// </summary>
+    public class EpubContentCollectionRefException : EpubReaderException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EpubContentCollectionRefException" /> class.
+        /// </summary>
+        public EpubContentCollectionRefException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EpubContentCollectionRefException" /> class with a specified error.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public EpubContentCollectionRefException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EpubContentCollectionRefException" /> class with a specified error message and a reference to the inner exception
+        /// that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
+        public EpubContentCollectionRefException(string message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Source/VersOne.Epub/Exceptions/EpubContentDownloaderException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubContentDownloaderException.cs
@@ -34,7 +34,7 @@ namespace VersOne.Epub
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
         /// <param name="remoteContentFileUrl">The absolute URI of the remote content file that caused the error.</param>
-        public EpubContentDownloaderException(string message, Exception innerException, string remoteContentFileUrl)
+        public EpubContentDownloaderException(string message, Exception? innerException, string remoteContentFileUrl)
             : base(message, innerException)
         {
             RemoteContentFileUrl = remoteContentFileUrl;

--- a/Source/VersOne.Epub/Exceptions/EpubContentException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubContentException.cs
@@ -34,7 +34,7 @@ namespace VersOne.Epub
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
         /// <param name="contentFilePath">The path of the content file that caused the error.</param>
-        public EpubContentException(string message, Exception innerException, string contentFilePath)
+        public EpubContentException(string message, Exception? innerException, string contentFilePath)
             : base(message, innerException)
         {
             ContentFilePath = contentFilePath;

--- a/Source/VersOne.Epub/Exceptions/EpubPackageException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubPackageException.cs
@@ -30,7 +30,7 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
-        public EpubPackageException(string message, Exception innerException)
+        public EpubPackageException(string message, Exception? innerException)
             : base(message, innerException, EpubSchemaFileType.OPF_PACKAGE)
         {
         }

--- a/Source/VersOne.Epub/Exceptions/EpubReaderException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubReaderException.cs
@@ -29,7 +29,7 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
-        protected EpubReaderException(string message, Exception innerException)
+        protected EpubReaderException(string message, Exception? innerException)
             : base(message, innerException)
         {
         }

--- a/Source/VersOne.Epub/Exceptions/EpubSchemaException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubSchemaException.cs
@@ -34,7 +34,7 @@ namespace VersOne.Epub
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
         /// <param name="schemaFileType">The type of the schema file that caused the error.</param>
-        protected EpubSchemaException(string message, Exception innerException, EpubSchemaFileType schemaFileType)
+        protected EpubSchemaException(string message, Exception? innerException, EpubSchemaFileType schemaFileType)
             : base(message, innerException)
         {
             SchemaFileType = schemaFileType;

--- a/Source/VersOne.Epub/Exceptions/EpubSmilException.cs
+++ b/Source/VersOne.Epub/Exceptions/EpubSmilException.cs
@@ -34,7 +34,7 @@ namespace VersOne.Epub
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
         /// <param name="smilFilePath">The path of the SMIL file that caused the error.</param>
-        public EpubSmilException(string message, Exception innerException, string smilFilePath)
+        public EpubSmilException(string message, Exception? innerException, string smilFilePath)
             : base(message, innerException)
         {
             SmilFilePath = smilFilePath;

--- a/Source/VersOne.Epub/Readers/BookCoverReader.cs
+++ b/Source/VersOne.Epub/Readers/BookCoverReader.cs
@@ -50,16 +50,10 @@ namespace VersOne.Epub.Internal
                 throw new EpubPackageException("Incorrect EPUB metadata: cover item content is missing.");
             }
             EpubManifestItem coverManifestItem =
-                epubSchema.Package.Manifest.Items.FirstOrDefault(manifestItem => manifestItem.Id.CompareOrdinalIgnoreCase(coverMetaItem.Content));
-            if (coverManifestItem == null)
-            {
+                epubSchema.Package.Manifest.Items.FirstOrDefault(manifestItem => manifestItem.Id.CompareOrdinalIgnoreCase(coverMetaItem.Content)) ??
                 throw new EpubPackageException($"Incorrect EPUB manifest: item with ID = \"{coverMetaItem.Content}\" is missing.");
-            }
-            EpubLocalByteContentFileRef? result = GetCoverImageContentRef(imageContentRefs, coverManifestItem.Href);
-            if (result == null)
-            {
+            EpubLocalByteContentFileRef result = GetCoverImageContentRef(imageContentRefs, coverManifestItem.Href) ??
                 throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{coverManifestItem.Href}\" is missing.");
-            }
             return result;
         }
 
@@ -92,22 +86,19 @@ namespace VersOne.Epub.Internal
             {
                 return null;
             }
-            EpubLocalByteContentFileRef? result = GetCoverImageContentRef(imageContentRefs, coverManifestItem.Href);
-            if (result == null)
-            {
+            EpubLocalByteContentFileRef result = GetCoverImageContentRef(imageContentRefs, coverManifestItem.Href) ??
                 throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{coverManifestItem.Href}\" is missing.");
-            }
             return result;
         }
 
         private static EpubLocalByteContentFileRef? GetCoverImageContentRef(
             EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> imageContentRefs, string coverImageContentFileKey)
         {
-            if (imageContentRefs.Remote.ContainsKey(coverImageContentFileKey))
+            if (imageContentRefs.ContainsRemoteFileRefWithUrl(coverImageContentFileKey))
             {
                 throw new EpubPackageException($"Incorrect EPUB manifest: EPUB cover image \"{coverImageContentFileKey}\" cannot be a remote resource.");
             }
-            if (!imageContentRefs.Local.TryGetValue(coverImageContentFileKey, out EpubLocalByteContentFileRef coverImageContentFileRef))
+            if (!imageContentRefs.TryGetLocalFileRefByKey(coverImageContentFileKey, out EpubLocalByteContentFileRef coverImageContentFileRef))
             {
                 return null;
             }

--- a/Source/VersOne.Epub/Readers/ContentReader.cs
+++ b/Source/VersOne.Epub/Readers/ContentReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using VersOne.Epub.Environment;
 using VersOne.Epub.Options;
 using VersOne.Epub.Schema;
@@ -20,12 +21,18 @@ namespace VersOne.Epub.Internal
         {
             EpubLocalByteContentFileRef? cover;
             EpubLocalTextContentFileRef? navigationHtmlFile = null;
-            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> html = new();
-            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> css = new();
-            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> images = new();
-            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> fonts = new();
-            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> audio = new();
-            EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef> allFiles = new();
+            List<EpubLocalTextContentFileRef> htmlLocal = new();
+            List<EpubRemoteTextContentFileRef> htmlRemote = new();
+            List<EpubLocalTextContentFileRef> cssLocal = new();
+            List<EpubRemoteTextContentFileRef> cssRemote = new();
+            List<EpubLocalByteContentFileRef> imagesLocal = new();
+            List<EpubRemoteByteContentFileRef> imagesRemote = new();
+            List<EpubLocalByteContentFileRef> fontsLocal = new();
+            List<EpubRemoteByteContentFileRef> fontsRemote = new();
+            List<EpubLocalByteContentFileRef> audioLocal = new();
+            List<EpubRemoteByteContentFileRef> audioRemote = new();
+            List<EpubLocalContentFileRef> allFilesLocal = new();
+            List<EpubRemoteContentFileRef> allFilesRemote = new();
             EpubLocalContentLoader localContentLoader = new(environmentDependencies, epubFile, epubSchema.ContentDirectoryPath, epubReaderOptions.ContentReaderOptions);
             EpubRemoteContentLoader? remoteContentLoader = null;
             foreach (EpubManifestItem manifestItem in epubSchema.Package.Manifest.Items)
@@ -54,17 +61,17 @@ namespace VersOne.Epub.Internal
                             switch (contentType)
                             {
                                 case EpubContentType.XHTML_1_1:
-                                    html.Local[href] = localTextContentFile;
+                                    htmlLocal.Add(localTextContentFile);
                                     if (navigationHtmlFile == null && manifestItem.Properties != null && manifestItem.Properties.Contains(EpubManifestProperty.NAV))
                                     {
                                         navigationHtmlFile = localTextContentFile;
                                     }
                                     break;
                                 case EpubContentType.CSS:
-                                    css.Local[href] = localTextContentFile;
+                                    cssLocal.Add(localTextContentFile);
                                     break;
                             }
-                            allFiles.Local[href] = localTextContentFile;
+                            allFilesLocal.Add(localTextContentFile);
                         }
                         else
                         {
@@ -73,17 +80,17 @@ namespace VersOne.Epub.Internal
                             switch (contentType)
                             {
                                 case EpubContentType.XHTML_1_1:
-                                    html.Remote[href] = remoteTextContentFile;
                                     if (manifestItem.Properties != null && manifestItem.Properties.Contains(EpubManifestProperty.NAV))
                                     {
                                         throw new EpubPackageException($"Incorrect EPUB manifest: EPUB 3 navigation document \"{href}\" cannot be a remote resource.");
                                     }
+                                    htmlRemote.Add(remoteTextContentFile);
                                     break;
                                 case EpubContentType.CSS:
-                                    css.Remote[href] = remoteTextContentFile;
+                                    cssRemote.Add(remoteTextContentFile);
                                     break;
                             }
-                            allFiles.Remote[href] = remoteTextContentFile;
+                            allFilesRemote.Add(remoteTextContentFile);
                         }
                         break;
                     default:
@@ -98,22 +105,22 @@ namespace VersOne.Epub.Internal
                                 case EpubContentType.IMAGE_PNG:
                                 case EpubContentType.IMAGE_SVG:
                                 case EpubContentType.IMAGE_WEBP:
-                                    images.Local[href] = localByteContentFile;
+                                    imagesLocal.Add(localByteContentFile);
                                     break;
                                 case EpubContentType.FONT_TRUETYPE:
                                 case EpubContentType.FONT_OPENTYPE:
                                 case EpubContentType.FONT_SFNT:
                                 case EpubContentType.FONT_WOFF:
                                 case EpubContentType.FONT_WOFF2:
-                                    fonts.Local[href] = localByteContentFile;
+                                    fontsLocal.Add(localByteContentFile);
                                     break;
                                 case EpubContentType.AUDIO_MP3:
                                 case EpubContentType.AUDIO_MP4:
                                 case EpubContentType.AUDIO_OGG:
-                                    audio.Local[href] = localByteContentFile;
+                                    audioLocal.Add(localByteContentFile);
                                     break;
                             }
-                            allFiles.Local[href] = localByteContentFile;
+                            allFilesLocal.Add(localByteContentFile);
                         }
                         else
                         {
@@ -126,26 +133,32 @@ namespace VersOne.Epub.Internal
                                 case EpubContentType.IMAGE_PNG:
                                 case EpubContentType.IMAGE_SVG:
                                 case EpubContentType.IMAGE_WEBP:
-                                    images.Remote[href] = remoteByteContentFile;
+                                    imagesRemote.Add(remoteByteContentFile);
                                     break;
                                 case EpubContentType.FONT_TRUETYPE:
                                 case EpubContentType.FONT_OPENTYPE:
                                 case EpubContentType.FONT_SFNT:
                                 case EpubContentType.FONT_WOFF:
                                 case EpubContentType.FONT_WOFF2:
-                                    fonts.Remote[href] = remoteByteContentFile;
+                                    fontsRemote.Add(remoteByteContentFile);
                                     break;
                                 case EpubContentType.AUDIO_MP3:
                                 case EpubContentType.AUDIO_MP4:
                                 case EpubContentType.AUDIO_OGG:
-                                    audio.Remote[href] = remoteByteContentFile;
+                                    audioRemote.Add(remoteByteContentFile);
                                     break;
                             }
-                            allFiles.Remote[href] = remoteByteContentFile;
+                            allFilesRemote.Add(remoteByteContentFile);
                         }
                         break;
                 }
             }
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> html = new(htmlLocal.AsReadOnly(), htmlRemote.AsReadOnly());
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> css = new(cssLocal.AsReadOnly(), cssRemote.AsReadOnly());
+            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> images = new(imagesLocal.AsReadOnly(), imagesRemote.AsReadOnly());
+            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> fonts = new(fontsLocal.AsReadOnly(), fontsRemote.AsReadOnly());
+            EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> audio = new(audioLocal.AsReadOnly(), audioRemote.AsReadOnly());
+            EpubContentCollectionRef<EpubLocalContentFileRef, EpubRemoteContentFileRef> allFiles = new(allFilesLocal.AsReadOnly(), allFilesRemote.AsReadOnly());
             cover = BookCoverReader.ReadBookCover(epubSchema, images);
             return new(cover, navigationHtmlFile, html, css, images, fonts, audio, allFiles);
         }

--- a/Source/VersOne.Epub/Readers/ContentReader.cs
+++ b/Source/VersOne.Epub/Readers/ContentReader.cs
@@ -38,7 +38,7 @@ namespace VersOne.Epub.Internal
             foreach (EpubManifestItem manifestItem in epubSchema.Package.Manifest.Items)
             {
                 string href = manifestItem.Href;
-                EpubContentLocation contentLocation = href.Contains("://") ? EpubContentLocation.REMOTE : EpubContentLocation.LOCAL;
+                EpubContentLocation contentLocation = ContentPathUtils.IsLocalPath(href) ? EpubContentLocation.LOCAL : EpubContentLocation.REMOTE;
                 string contentMimeType = manifestItem.MediaType;
                 EpubContentType contentType = GetContentTypeByContentMimeType(contentMimeType);
                 string contentDirectoryPath = epubSchema.ContentDirectoryPath;
@@ -56,7 +56,7 @@ namespace VersOne.Epub.Internal
                     case EpubContentType.SCRIPT:
                         if (contentLocation == EpubContentLocation.LOCAL)
                         {
-                            string contentFilePath = ZipPathUtils.Combine(contentDirectoryPath, href);
+                            string contentFilePath = ContentPathUtils.Combine(contentDirectoryPath, href);
                             EpubLocalTextContentFileRef localTextContentFile = new(contentFileRefMetadata, contentFilePath, localContentLoader);
                             switch (contentType)
                             {
@@ -96,7 +96,7 @@ namespace VersOne.Epub.Internal
                     default:
                         if (contentLocation == EpubContentLocation.LOCAL)
                         {
-                            string contentFilePath = ZipPathUtils.Combine(contentDirectoryPath, href);
+                            string contentFilePath = ContentPathUtils.Combine(contentDirectoryPath, href);
                             EpubLocalByteContentFileRef localByteContentFile = new(contentFileRefMetadata, contentFilePath, localContentLoader);
                             switch (contentType)
                             {

--- a/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
@@ -32,7 +32,7 @@ namespace VersOne.Epub.Internal
             {
                 throw new Epub2NcxException($"EPUB parsing error: TOC item {tocId} not found in EPUB manifest.");
             }
-            string tocFileEntryPath = ZipPathUtils.Combine(contentDirectoryPath, tocManifestItem.Href);
+            string tocFileEntryPath = ContentPathUtils.Combine(contentDirectoryPath, tocManifestItem.Href);
             IZipFileEntry? tocFileEntry = epubFile.GetEntry(tocFileEntryPath);
             if (tocFileEntry == null)
             {

--- a/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
@@ -34,7 +34,7 @@ namespace VersOne.Epub.Internal
                     throw new Epub3NavException("EPUB parsing error: NAV item not found in EPUB manifest.");
                 }
             }
-            string navFileEntryPath = ZipPathUtils.Combine(contentDirectoryPath, navManifestItem.Href);
+            string navFileEntryPath = ContentPathUtils.Combine(contentDirectoryPath, navManifestItem.Href);
             IZipFileEntry navFileEntry = epubFile.GetEntry(navFileEntryPath) ??
                 throw new Epub3NavException($"EPUB parsing error: navigation file {navFileEntryPath} not found in the EPUB file.");
             if (navFileEntry.Length > Int32.MaxValue)

--- a/Source/VersOne.Epub/Readers/NavigationReader.cs
+++ b/Source/VersOne.Epub/Readers/NavigationReader.cs
@@ -41,13 +41,14 @@ namespace VersOne.Epub.Internal
                     Epub2NcxNavigationLabel? firstNavigationLabel = navigationPoint.NavigationLabels.FirstOrDefault() ??
                         throw new Epub2NcxException($"Incorrect EPUB 2 NCX: navigation point \"{navigationPoint.Id}\" should contain at least one navigation label.");
                     string title = firstNavigationLabel.Text;
-                    if (!ContentPathUtils.IsLocalPath(navigationPoint.Content.Source))
+                    string source = Uri.UnescapeDataString(navigationPoint.Content.Source);
+                    if (!ContentPathUtils.IsLocalPath(source))
                     {
-                        throw new Epub2NcxException($"Incorrect EPUB 2 NCX: content source \"{navigationPoint.Content.Source}\" cannot be a remote resource.");
+                        throw new Epub2NcxException($"Incorrect EPUB 2 NCX: content source \"{source}\" cannot be a remote resource.");
                     }
-                    EpubNavigationItemLink link = new(navigationPoint.Content.Source, epubSchema.ContentDirectoryPath);
+                    EpubNavigationItemLink link = new(source, epubSchema.ContentDirectoryPath);
                     EpubLocalTextContentFileRef? htmlContentFileRef = GetLocalHtmlContentFileRef(epubContentRef, link.ContentFilePath) ??
-                        throw new Epub2NcxException($"Incorrect EPUB 2 NCX: content source \"{navigationPoint.Content.Source}\" not found in EPUB manifest.");
+                        throw new Epub2NcxException($"Incorrect EPUB 2 NCX: content source \"{source}\" not found in EPUB manifest.");
                     List<EpubNavigationItemRef> nestedItems = GetNavigationItems(epubSchema, epubContentRef, navigationPoint.ChildNavigationPoints);
                     result.Add(new EpubNavigationItemRef(type, title, link, htmlContentFileRef, nestedItems));
                 }
@@ -99,16 +100,17 @@ namespace VersOne.Epub.Internal
                         List<EpubNavigationItemRef> nestedItems = GetNavigationItems(epubSchema, epubContentRef, epub3NavLi.ChildOl, epub3NavigationBaseDirectoryPath);
                         if (navAnchor.Href != null)
                         {
-                            if (!ContentPathUtils.IsLocalPath(navAnchor.Href))
+                            string href = Uri.UnescapeDataString(navAnchor.Href);
+                            if (!ContentPathUtils.IsLocalPath(href))
                             {
-                                throw new Epub3NavException($"Incorrect EPUB 3 navigation document: anchor href \"{navAnchor.Href}\" cannot be a remote resource.");
+                                throw new Epub3NavException($"Incorrect EPUB 3 navigation document: anchor href \"{href}\" cannot be a remote resource.");
                             }
                             type = EpubNavigationItemType.LINK;
-                            link = new(navAnchor.Href, epub3NavigationBaseDirectoryPath);
+                            link = new(href, epub3NavigationBaseDirectoryPath);
                             htmlContentFileRef = GetLocalHtmlContentFileRef(epubContentRef, link.ContentFilePath);
                             if (htmlContentFileRef == null)
                             {
-                                throw new Epub3NavException($"Incorrect EPUB 3 navigation document: target for anchor href \"{navAnchor.Href}\" not found in EPUB manifest.");
+                                throw new Epub3NavException($"Incorrect EPUB 3 navigation document: target for anchor href \"{href}\" not found in EPUB manifest.");
                             }
                         }
                         else

--- a/Source/VersOne.Epub/Readers/NavigationReader.cs
+++ b/Source/VersOne.Epub/Readers/NavigationReader.cs
@@ -42,7 +42,7 @@ namespace VersOne.Epub.Internal
                         throw new Epub2NcxException($"Incorrect EPUB 2 NCX: navigation point \"{navigationPoint.Id}\" should contain at least one navigation label.");
                     string title = firstNavigationLabel.Text;
                     EpubNavigationItemLink link = new(navigationPoint.Content.Source, epubSchema.ContentDirectoryPath);
-                    EpubLocalTextContentFileRef? htmlContentFileRef = GetHtmlContentFileRef(epubContentRef, link.ContentFileName) ??
+                    EpubLocalTextContentFileRef? htmlContentFileRef = GetHtmlContentFileRef(epubContentRef, link.ContentFileName, link.ContentFilePath) ??
                         throw new Epub2NcxException($"Incorrect EPUB 2 NCX: content source \"{navigationPoint.Content.Source}\" not found in EPUB manifest.");
                     List<EpubNavigationItemRef> nestedItems = GetNavigationItems(epubSchema, epubContentRef, navigationPoint.ChildNavigationPoints);
                     result.Add(new EpubNavigationItemRef(type, title, link, htmlContentFileRef, nestedItems));
@@ -97,7 +97,7 @@ namespace VersOne.Epub.Internal
                         {
                             type = EpubNavigationItemType.LINK;
                             link = new(navAnchor.Href, epub3NavigationBaseDirectoryPath);
-                            htmlContentFileRef = GetHtmlContentFileRef(epubContentRef, link.ContentFileName);
+                            htmlContentFileRef = GetHtmlContentFileRef(epubContentRef, link.ContentFileName, link.ContentFilePath);
                             if (htmlContentFileRef == null)
                             {
                                 throw new Epub3NavException($"Incorrect EPUB 3 navigation document: target for anchor href \"{navAnchor.Href}\" not found in EPUB manifest.");
@@ -122,13 +122,13 @@ namespace VersOne.Epub.Internal
             return result;
         }
 
-        private static EpubLocalTextContentFileRef? GetHtmlContentFileRef(EpubContentRef epubContentRef, string contentFileKey)
+        private static EpubLocalTextContentFileRef? GetHtmlContentFileRef(EpubContentRef epubContentRef, string contentFileKey, string contentFilePath)
         {
-            if (epubContentRef.Html.Remote.ContainsKey(contentFileKey))
+            if (epubContentRef.Html.ContainsRemoteFileRefWithUrl(contentFileKey))
             {
                 throw new EpubPackageException($"Incorrect EPUB manifest: item \"{contentFileKey}\" referenced in the navigation file cannot be a remote resource.");
             }
-            if (!epubContentRef.Html.Local.TryGetValue(contentFileKey, out EpubLocalTextContentFileRef htmlContentFileRef))
+            if (!epubContentRef.Html.TryGetLocalFileRefByFilePath(contentFilePath, out EpubLocalTextContentFileRef htmlContentFileRef))
             {
                 return null;
             }

--- a/Source/VersOne.Epub/Readers/PackageReader.cs
+++ b/Source/VersOne.Epub/Readers/PackageReader.cs
@@ -93,6 +93,8 @@ namespace VersOne.Epub.Internal
             XAttribute? manifestIdAttribute = manifestNode.Attribute("id");
             string? manifestId = manifestIdAttribute?.Value;
             List<EpubManifestItem> items = new();
+            HashSet<string> manifestItemIds = new();
+            HashSet<string> manifestItemHrefs = new();
             foreach (XElement manifestItemNode in manifestNode.Elements())
             {
                 if (manifestItemNode.CompareNameTo("item"))
@@ -164,6 +166,16 @@ namespace VersOne.Epub.Internal
                         }
                         throw new EpubPackageException("Incorrect EPUB manifest: item media type is missing.");
                     }
+                    if (manifestItemIds.Contains(manifestItemId))
+                    {
+                        throw new EpubPackageException($"Incorrect EPUB manifest: item with ID = \"{manifestItemId}\" is not unique.");
+                    }
+                    manifestItemIds.Add(manifestItemId);
+                    if (manifestItemHrefs.Contains(href))
+                    {
+                        throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{href}\" is not unique.");
+                    }
+                    manifestItemHrefs.Add(href);
                     items.Add(new EpubManifestItem(manifestItemId, href, mediaType, mediaOverlay, requiredNamespace, requiredModules, fallback, fallbackStyle, properties));
                 }
             }

--- a/Source/VersOne.Epub/Readers/SchemaReader.cs
+++ b/Source/VersOne.Epub/Readers/SchemaReader.cs
@@ -19,7 +19,7 @@ namespace VersOne.Epub.Internal
         {
             RootFilePathReader rootFilePathReader = new(epubReaderOptions);
             string rootFilePath = await rootFilePathReader.GetRootFilePathAsync(epubFile).ConfigureAwait(false);
-            string contentDirectoryPath = ZipPathUtils.GetDirectoryPath(rootFilePath);
+            string contentDirectoryPath = ContentPathUtils.GetDirectoryPath(rootFilePath);
             PackageReader packageReader = new(epubReaderOptions);
             EpubPackage package = await packageReader.ReadPackageAsync(epubFile, rootFilePath).ConfigureAwait(false);
             Epub2NcxReader epub2NcxReader = new(epubReaderOptions);

--- a/Source/VersOne.Epub/Readers/SmilClockParser.cs
+++ b/Source/VersOne.Epub/Readers/SmilClockParser.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 
-namespace VersOne.Epub.Readers
+namespace VersOne.Epub.Internal
 {
     internal static class SmilClockParser
     {

--- a/Source/VersOne.Epub/Readers/SmilReader.cs
+++ b/Source/VersOne.Epub/Readers/SmilReader.cs
@@ -25,7 +25,7 @@ namespace VersOne.Epub.Internal
             List<Smil> result = new();
             foreach (EpubManifestItem smilManifestItem in package.Manifest.Items.Where(manifestItem => manifestItem.MediaType.CompareOrdinalIgnoreCase("application/smil+xml")))
             {
-                string smilFilePath = ZipPathUtils.Combine(contentDirectoryPath, smilManifestItem.Href);
+                string smilFilePath = ContentPathUtils.Combine(contentDirectoryPath, smilManifestItem.Href);
                 Smil smil = await ReadSmilAsync(epubFile, smilFilePath);
                 result.Add(smil);
             }

--- a/Source/VersOne.Epub/Readers/SpineReader.cs
+++ b/Source/VersOne.Epub/Readers/SpineReader.cs
@@ -11,16 +11,13 @@ namespace VersOne.Epub.Internal
             List<EpubLocalTextContentFileRef> result = new();
             foreach (EpubSpineItemRef spineItemRef in epubSchema.Package.Spine.Items)
             {
-                EpubManifestItem manifestItem = epubSchema.Package.Manifest.Items.FirstOrDefault(item => item.Id == spineItemRef.IdRef);
-                if (manifestItem == null)
-                {
+                EpubManifestItem manifestItem = epubSchema.Package.Manifest.Items.FirstOrDefault(item => item.Id == spineItemRef.IdRef) ??
                     throw new EpubPackageException($"Incorrect EPUB spine: item with IdRef = \"{spineItemRef.IdRef}\" is missing in the manifest.");
-                }
-                if (epubContentRef.Html.Remote.ContainsKey(manifestItem.Href))
+                if (epubContentRef.Html.ContainsRemoteFileRefWithUrl(manifestItem.Href))
                 {
                     throw new EpubPackageException($"Incorrect EPUB manifest: EPUB spine item \"{manifestItem.Href}\" cannot be a remote resource.");
                 }
-                if (!epubContentRef.Html.Local.TryGetValue(manifestItem.Href, out EpubLocalTextContentFileRef htmlContentFileRef))
+                if (!epubContentRef.Html.TryGetLocalFileRefByKey(manifestItem.Href, out EpubLocalTextContentFileRef htmlContentFileRef))
                 {
                     throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{spineItemRef.IdRef}\" is missing in the book.");
                 }

--- a/Source/VersOne.Epub/Utils/ContentPathUtils.cs
+++ b/Source/VersOne.Epub/Utils/ContentPathUtils.cs
@@ -2,9 +2,11 @@
 
 namespace VersOne.Epub.Internal
 {
-    internal static class ZipPathUtils
+    internal static class ContentPathUtils
     {
         private const string DIRECTORY_UP = "../";
+
+        public static bool IsLocalPath(string path) => path != null ? !path.Contains("://") : throw new ArgumentNullException(nameof(path));
 
         public static string GetDirectoryPath(string filePath)
         {


### PR DESCRIPTION
# NavigationReader fix: get content files via absolute file paths

This is:
- [x] a bug fix
- [ ] an enhancement

Related issue: #91

## Description

This pull request:
1. Fixes an issue with obtaining a content file in `NavigationReader` when OPF and navigation files are located in different subdirectories.
2. Refactors `EpubContentCollection` and `EpubContentCollectionRef` classes to provide a way for an application to obtain a content file by its key as well as by its absolute path.

## Testing steps

Open a EPUB book which has OPF and navigation files located in different subdirectories.