### PR TITLE
Unpin .NET SDK version in actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.203
+          dotnet-version: 7
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1.3
       - name: Restore dependencies

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.203
+          dotnet-version: 7
       - name: Restore dependencies
         run: dotnet restore .\Source\VersOne.Epub\VersOne.Epub.csproj
       - name: Install DocFX

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.203
+          dotnet-version: 7
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1.3
       - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.203
+          dotnet-version: 7
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1.3
       - name: Restore dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.203
+          dotnet-version: 7
       - name: Build test project and its dependencies
         run: dotnet build Source\VersOne.Epub.Test -c $env:Configuration
       - name: Run unit tests


### PR DESCRIPTION
GitHub updated Visual Studio to version 17.6 in GitHub Action runners, so .NET SDK version can be unpinned now.