### PR TITLE
Code cleanup

### DIFF
--- a/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
+++ b/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
@@ -1,31 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
-        <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
-        <Authors>vers</Authors>
-        <Copyright>vers, 2015-2022</Copyright>
-        <Version>3.3.1</Version>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net7.0</TargetFramework>
+		<RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+		<Authors>vers</Authors>
+		<Copyright>vers, 2015-2024</Copyright>
+		<Version>3.3.1</Version>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
 		<DocumentationFile></DocumentationFile>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
-    <ItemGroup>
-      <AdditionalFiles Include="stylecop.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.0.0.68202">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\VersOne.Epub\VersOne.Epub.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<AdditionalFiles Include="stylecop.json" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\VersOne.Epub\VersOne.Epub.csproj" />
+	</ItemGroup>
 </Project>

--- a/Source/VersOne.Epub.Test/Integration/Runner/TestRunner.cs
+++ b/Source/VersOne.Epub.Test/Integration/Runner/TestRunner.cs
@@ -69,11 +69,11 @@ namespace VersOne.Epub.Test.Integration.Runner
             return testCaseSerializer.Deserialize(testCasePath, testEpubPath);
         }
 
-        public static IEnumerable<object[]> GetTestCaseDirectories()
+        public static TheoryData<string> GetTestCaseDirectories()
         {
             List<string> directories = new();
             GetTestCaseDirectories(rootTestCasesDirectory, directories);
-            return directories.Select(directory => new[] { directory });
+            return new(directories);
         }
 
         private static void GetTestCaseDirectories(string currentDirectory, List<string> directories)

--- a/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefTests.cs
@@ -145,7 +145,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Reading local text content file asynchronously should succeed")]
-        public async void LocalTextContentFileRefReadContentAsyncTest()
+        public async Task LocalTextContentFileRefReadContentAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
             EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
@@ -163,7 +163,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Reading local byte content file asynchronously should succeed")]
-        public async void LocalByteContentFileRefReadContentAsyncTest()
+        public async Task LocalByteContentFileRefReadContentAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
             EpubLocalByteContentFileRef epubLocalByteContentFileRef = new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testEpubContentLoader);
@@ -181,7 +181,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Reading local content file as text asynchronously should succeed")]
-        public async void LocalContentFileRefReadContentAsTextAsyncTest()
+        public async Task LocalContentFileRefReadContentAsTextAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
             EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
@@ -199,7 +199,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Reading local content file as bytes asynchronously should succeed")]
-        public async void LocalContentFileRefReadContentAsBytesAsyncTest()
+        public async Task LocalContentFileRefReadContentAsBytesAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
             EpubLocalByteContentFileRef epubLocalByteContentFileRef = new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testEpubContentLoader);
@@ -218,7 +218,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Getting local content file stream asynchronously should succeed")]
-        public async void LocalContentFileRefGetContentStreamAsyncTest()
+        public async Task LocalContentFileRefGetContentStreamAsyncTest()
         {
             using MemoryStream testStream = new();
             TestEpubContentLoader testEpubContentLoader = new(testStream);
@@ -237,7 +237,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Downloading remote text content file asynchronously should succeed")]
-        public async void RemoteTextContentFileRefDownloadContentAsyncTest()
+        public async Task RemoteTextContentFileRefDownloadContentAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
             EpubRemoteTextContentFileRef epubRemoteTextContentFileRef = new(RemoteTextFileRefMetadata, testEpubContentLoader);
@@ -255,7 +255,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Downloading remote byte content file asynchronously should succeed")]
-        public async void RemoteByteContentFileRefDownloadContentAsyncTest()
+        public async Task RemoteByteContentFileRefDownloadContentAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
             EpubRemoteByteContentFileRef epubRemoteByteContentFileRef = new(RemoteByteFileRefMetadata, testEpubContentLoader);
@@ -273,7 +273,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Downloading remote content file as text asynchronously should succeed")]
-        public async void RemoteContentFileRefDownloadContentAsTextAsyncTest()
+        public async Task RemoteContentFileRefDownloadContentAsTextAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
             EpubRemoteTextContentFileRef epubRemoteTextContentFileRef = new(RemoteTextFileRefMetadata, testEpubContentLoader);
@@ -291,7 +291,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Downloading remote content file as bytes asynchronously should succeed")]
-        public async void RemoteContentFileRefDownloadContentAsBytesAsyncTest()
+        public async Task RemoteContentFileRefDownloadContentAsBytesAsyncTest()
         {
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
             EpubRemoteByteContentFileRef epubRemoteByteContentFileRef = new(RemoteByteFileRefMetadata, testEpubContentLoader);
@@ -310,7 +310,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         }
 
         [Fact(DisplayName = "Getting remote content file stream asynchronously should succeed")]
-        public async void RemoteContentFileRefGetDownloadingContentStreamAsyncTest()
+        public async Task RemoteContentFileRefGetDownloadingContentStreamAsyncTest()
         {
             MemoryStream testStream = new();
             TestEpubContentLoader testEpubContentLoader = new(testStream);

--- a/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubLocalContentLoaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubLocalContentLoaderTests.cs
@@ -65,7 +65,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "Loading content of an existing text file asynchronously should succeed")]
-        public async void LoadContentAsTextAsyncTest()
+        public async Task LoadContentAsTextAsyncTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(TEXT_FILE_PATH, TEXT_FILE_CONTENT);
@@ -85,7 +85,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "Loading content of an existing byte file asynchronously should succeed")]
-        public async void LoadContentAsBytesAsyncTest()
+        public async Task LoadContentAsBytesAsyncTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(BYTE_FILE_PATH, BYTE_FILE_CONTENT);
@@ -106,7 +106,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "Getting content stream of an existing file asynchronously should succeed")]
-        public async void GetContentStreamAsyncTest()
+        public async Task GetContentStreamAsyncTest()
         {
             TestZipFile testZipFile = new();
             using MemoryStream testContentStream = new();
@@ -138,7 +138,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsTextAsync should throw EpubContentException if the file is missing in the EPUB archive")]
-        public async void LoadContentAsTextAsyncWithMissingFileTest()
+        public async Task LoadContentAsTextAsyncWithMissingFileTest()
         {
             TestZipFile testZipFile = new();
             EpubLocalContentLoader epubLocalContentLoader = CreateEpubLocalContentLoader(testZipFile);
@@ -154,7 +154,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsBytesAsync should throw EpubContentException if the file is missing in the EPUB archive")]
-        public async void LoadContentAsBytesAsyncWithMissingFileTest()
+        public async Task LoadContentAsBytesAsyncWithMissingFileTest()
         {
             TestZipFile testZipFile = new();
             EpubLocalContentLoader epubLocalContentLoader = CreateEpubLocalContentLoader(testZipFile);
@@ -170,7 +170,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "GetContentStreamAsync should throw EpubContentException if the file is missing in the EPUB archive")]
-        public async void GetContentStreamAsyncWithMissingFileTest()
+        public async Task GetContentStreamAsyncWithMissingFileTest()
         {
             TestZipFile testZipFile = new();
             EpubLocalContentLoader epubLocalContentLoader = CreateEpubLocalContentLoader(testZipFile);
@@ -187,7 +187,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsTextAsync should throw EpubContentException if the file is larger than 2 GB")]
-        public async void LoadContentAsTextAsyncWithLargeFileTest()
+        public async Task LoadContentAsTextAsyncWithLargeFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(TEXT_FILE_PATH, new Test4GbZipFileEntry());
@@ -205,7 +205,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsBytesAsync should throw EpubContentException if the file is larger than 2 GB")]
-        public async void LoadContentAsBytesAsyncWithLargeFileTest()
+        public async Task LoadContentAsBytesAsyncWithLargeFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(BYTE_FILE_PATH, new Test4GbZipFileEntry());
@@ -223,7 +223,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "GetContentStreamAsync should throw EpubContentException if the file is larger than 2 GB")]
-        public async void GetContentStreamAsyncWithLargeFileTest()
+        public async Task GetContentStreamAsyncWithLargeFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(TEXT_FILE_PATH, new Test4GbZipFileEntry());
@@ -241,7 +241,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsTextAsync should throw ObjectDisposedException if the EPUB file is disposed")]
-        public async void LoadContentAsTextAsyncWithDisposedEpubFileTest()
+        public async Task LoadContentAsTextAsyncWithDisposedEpubFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.Dispose();
@@ -259,7 +259,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsBytesAsync should throw ObjectDisposedException if the EPUB file is disposed")]
-        public async void LoadContentAsBytesAsyncWithDisposedEpubFileTest()
+        public async Task LoadContentAsBytesAsyncWithDisposedEpubFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.Dispose();
@@ -277,7 +277,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "GetContentStreamAsync should throw ObjectDisposedException if the EPUB file is disposed")]
-        public async void GetContentStreamAsyncWithDisposedEpubFileTest()
+        public async Task GetContentStreamAsyncWithDisposedEpubFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.Dispose();

--- a/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubRemoteContentLoaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubRemoteContentLoaderTests.cs
@@ -49,7 +49,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "Loading text file content asynchronously should succeed")]
-        public async void LoadContentAsTextAsyncTest()
+        public async Task LoadContentAsTextAsyncTest()
         {
             TestContentDownloader testContentDownloader = new(TEXT_FILE_HREF, TEXT_FILE_CONTENT);
             EpubRemoteContentLoader epubRemoteContentLoader = CreateEpubRemoteContentLoader(testContentDownloader);
@@ -67,7 +67,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "Loading byte file content asynchronously should succeed")]
-        public async void LoadContentAsBytesAsyncTest()
+        public async Task LoadContentAsBytesAsyncTest()
         {
             TestContentDownloader testContentDownloader = new(BYTE_FILE_HREF, BYTE_FILE_CONTENT);
             EpubRemoteContentLoader epubRemoteContentLoader = CreateEpubRemoteContentLoader(testContentDownloader);
@@ -86,7 +86,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "Getting file content stream asynchronously should succeed")]
-        public async void GetContentStreamAsyncTest()
+        public async Task GetContentStreamAsyncTest()
         {
             using MemoryStream testContentStream = new();
             TestContentDownloader testContentDownloader = new(TEXT_FILE_HREF, testContentStream);
@@ -120,7 +120,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsTextAsync should throw EpubContentDownloaderException if ContentDownloaderOptions.DownloadContent is false")]
-        public async void LoadContentAsTextAsyncWithDownloadContentFalseTest()
+        public async Task LoadContentAsTextAsyncWithDownloadContentFalseTest()
         {
             ContentDownloaderOptions contentDownloaderOptions = new()
             {
@@ -142,7 +142,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "LoadContentAsBytesAsync should throw EpubContentDownloaderException if ContentDownloaderOptions.DownloadContent is false")]
-        public async void LoadContentAsBytesAsyncWithDownloadContentFalseTest()
+        public async Task LoadContentAsBytesAsyncWithDownloadContentFalseTest()
         {
             ContentDownloaderOptions contentDownloaderOptions = new()
             {
@@ -164,7 +164,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         }
 
         [Fact(DisplayName = "GetContentStreamAsync should throw EpubContentDownloaderException if ContentDownloaderOptions.DownloadContent is false")]
-        public async void GetContentStreamAsyncWithDownloadContentFalseTest()
+        public async Task GetContentStreamAsyncWithDownloadContentFalseTest()
         {
             ContentDownloaderOptions contentDownloaderOptions = new()
             {

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
@@ -128,7 +128,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         }
 
         [Fact(DisplayName = "Reading the existing cover asynchronously should succeed")]
-        public async void ReadCoverAsyncTest()
+        public async Task ReadCoverAsyncTest()
         {
             EpubBookRef epubBookRef = CreateEpubBookRefWithCover(COVER_FILE_CONTENT);
             byte[]? coverContent = await epubBookRef.ReadCoverAsync();
@@ -145,7 +145,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         }
 
         [Fact(DisplayName = "ReadCoverAsync should return null if the cover is missing")]
-        public async void ReadCoverAsyncWithoutCoverTest()
+        public async Task ReadCoverAsyncWithoutCoverTest()
         {
             TestZipFile testZipFile = new();
             EpubBookRef epubBookRef = CreateEpubBookRef(testZipFile, EpubVersion.EPUB_3);
@@ -166,7 +166,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         }
 
         [Fact(DisplayName = "Getting reading order asynchronously should succeed")]
-        public async void GetReadingOrderAsyncTest()
+        public async Task GetReadingOrderAsyncTest()
         {
             EpubBookRef epubBookRef = CreateEpubBookRefWithReadingOrder(HTML_FILE_NAME, HTML_FILE_PATH);
             List<EpubLocalTextContentFileRef> expectedReadingOrder = new()
@@ -190,7 +190,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         }
 
         [Fact(DisplayName = "Getting navigation items asynchronously should succeed")]
-        public async void GetNavigationAsyncTest()
+        public async Task GetNavigationAsyncTest()
         {
             EpubBookRef epubBookRef = CreateEpubBookRefWithNavigation(HTML_FILE_NAME, HTML_FILE_PATH, TEST_ANCHOR_TEXT);
             List<EpubNavigationItemRef> expectedNavigationItems = new()
@@ -218,7 +218,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         }
 
         [Fact(DisplayName = "GetNavigationAsync should return null for EPUB 2 books with no navigation")]
-        public async void GetNavigationAsyncForEpub2WithNoNavigationTest()
+        public async Task GetNavigationAsyncForEpub2WithNoNavigationTest()
         {
             EpubBookRef epubBookRef = CreateEpubBookRef(new TestZipFile(), EpubVersion.EPUB_2);
             List<EpubNavigationItemRef>? navigationItems = await epubBookRef.GetNavigationAsync();
@@ -226,7 +226,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         }
 
         [Fact(DisplayName = "GetNavigationAsync should return null for EPUB 3 books with no navigation")]
-        public async void GetNavigationAsyncForEpub3WithNoNavigationTest()
+        public async Task GetNavigationAsyncForEpub3WithNoNavigationTest()
         {
             EpubBookRef epubBookRef = CreateEpubBookRef(new TestZipFile(), EpubVersion.EPUB_3);
             List<EpubNavigationItemRef>? navigationItems = await epubBookRef.GetNavigationAsync();
@@ -275,7 +275,7 @@ namespace VersOne.Epub.Test.Unit.Entities
                 (
                     items: new List<EpubManifestItem>()
                     {
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-1",
                             href: htmlFileName,
@@ -287,7 +287,7 @@ namespace VersOne.Epub.Test.Unit.Entities
                 (
                     items: new List<EpubSpineItemRef>()
                     {
-                        new EpubSpineItemRef
+                        new
                         (
                             idRef: "item-1"
                         )
@@ -317,14 +317,14 @@ namespace VersOne.Epub.Test.Unit.Entities
                     filePath: navigationFileRef.FilePath,
                     navs: new List<Epub3Nav>()
                     {
-                        new Epub3Nav
+                        new
                         (
                             type: Epub3StructuralSemanticsProperty.TOC,
                             ol: new Epub3NavOl
                             (
                                 lis: new List<Epub3NavLi>()
                                 {
-                                    new Epub3NavLi
+                                    new
                                     (
                                         anchor: new Epub3NavAnchor
                                         (

--- a/Source/VersOne.Epub.Test/Unit/Readers/BookReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/BookReaderTests.cs
@@ -75,7 +75,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a full EPUB book from a file asynchronously without downloading remote files should succeed")]
-        public async void ReadBookFromFileAsyncWithoutDownloadingRemoteFilesTest()
+        public async Task ReadBookFromFileAsyncWithoutDownloadingRemoteFilesTest()
         {
             TestZipFile testEpubFile = TestEpubFiles.CreateFullTestEpubFile();
             environmentDependencies.FileSystem = new TestFileSystem(EPUB_FILE_PATH, testEpubFile);
@@ -98,7 +98,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a full EPUB book from a stream asynchronously without downloading remote files should succeed")]
-        public async void ReadBookFromStreamAsyncWithoutDownloadingRemoteFilesTest()
+        public async Task ReadBookFromStreamAsyncWithoutDownloadingRemoteFilesTest()
         {
             TestZipFile testEpubFile = TestEpubFiles.CreateFullTestEpubFile();
             MemoryStream epubFileStream = new();
@@ -122,7 +122,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a full EPUB book from a file asynchronously with downloading remote files should succeed")]
-        public async void ReadBookFromFileAsyncWithDownloadingRemoteFilesTest()
+        public async Task ReadBookFromFileAsyncWithDownloadingRemoteFilesTest()
         {
             TestZipFile testEpubFile = TestEpubFiles.CreateFullTestEpubFile();
             environmentDependencies.FileSystem = new TestFileSystem(EPUB_FILE_PATH, testEpubFile);
@@ -147,7 +147,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a full EPUB book from a stream asynchronously with downloading remote files should succeed")]
-        public async void ReadBookFromStreamAsyncWithDownloadingRemoteFilesTest()
+        public async Task ReadBookFromStreamAsyncWithDownloadingRemoteFilesTest()
         {
             TestZipFile testEpubFile = TestEpubFiles.CreateFullTestEpubFile();
             MemoryStream epubFileStream = new();
@@ -182,7 +182,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadBookAsync should throw FileNotFoundException if the specified file does not exist")]
-        public async void ReadBookFromFileAsyncWithMissingFileTest()
+        public async Task ReadBookFromFileAsyncWithMissingFileTest()
         {
             BookReader bookReader = new(environmentDependencies, null);
             await Assert.ThrowsAsync<FileNotFoundException>(() => bookReader.ReadBookAsync(EPUB_FILE_PATH));
@@ -198,7 +198,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadBookAsync should rethrow EPUB parsing exceptions")]
-        public async void ReadBookFromFileAsyncWithIncorrectEpubTest()
+        public async Task ReadBookFromFileAsyncWithIncorrectEpubTest()
         {
             TestZipFile incorrectEpubFile = new();
             environmentDependencies.FileSystem = new TestFileSystem(EPUB_FILE_PATH, incorrectEpubFile);

--- a/Source/VersOne.Epub.Test/Unit/Readers/BookRefReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/BookRefReaderTests.cs
@@ -46,7 +46,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Opening a full EPUB book from a file asynchronously should succeed")]
-        public async void OpenBookFromFileAsyncTest()
+        public async Task OpenBookFromFileAsyncTest()
         {
             TestZipFile testEpubFile = TestEpubFiles.CreateFullTestEpubFile();
             environmentDependencies.FileSystem = new TestFileSystem(EPUB_FILE_PATH, testEpubFile);
@@ -80,7 +80,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Opening a full EPUB book from a stream asynchronously should succeed")]
-        public async void OpenBookFromStreamAsyncTest()
+        public async Task OpenBookFromStreamAsyncTest()
         {
             TestZipFile testEpubFile = TestEpubFiles.CreateFullTestEpubFile();
             MemoryStream epubFileStream = new();
@@ -99,7 +99,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "OpenBookAsync should throw FileNotFoundException if the specified file does not exist")]
-        public async void OpenBookFromFileAsyncWithMissingFileTest()
+        public async Task OpenBookFromFileAsyncWithMissingFileTest()
         {
             BookRefReader bookRefReader = new(environmentDependencies, null);
             await Assert.ThrowsAsync<FileNotFoundException>(() => bookRefReader.OpenBookAsync(EPUB_FILE_PATH));
@@ -115,7 +115,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "OpenBookAsync should rethrow EPUB parsing exceptions")]
-        public async void OpenBookFromFileAsyncWithIncorrectEpubTest()
+        public async Task OpenBookFromFileAsyncWithIncorrectEpubTest()
         {
             TestZipFile incorrectEpubFile = new();
             environmentDependencies.FileSystem = new TestFileSystem(EPUB_FILE_PATH, incorrectEpubFile);

--- a/Source/VersOne.Epub.Test/Unit/Readers/Epub2NcxReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/Epub2NcxReaderTests.cs
@@ -396,7 +396,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<EpubManifestItem>()
                     {
-                        new EpubManifestItem
+                        new
                         (
                             id: TOC_ID,
                             href: NCX_FILE_NAME,
@@ -431,32 +431,32 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<Epub2NcxHeadMeta>
                     {
-                        new Epub2NcxHeadMeta
+                        new
                         (
                             name: "dtb:uid",
                             content: "9781234567890"
                         ),
-                        new Epub2NcxHeadMeta
+                        new
                         (
                             name: "dtb:depth",
                             content: "1"
                         ),
-                        new Epub2NcxHeadMeta
+                        new
                         (
                             name: "dtb:generator",
                             content: "EpubWriter"
                         ),
-                        new Epub2NcxHeadMeta
+                        new
                         (
                             name: "dtb:totalPageCount",
                             content: "0"
                         ),
-                        new Epub2NcxHeadMeta
+                        new
                         (
                             name: "dtb:maxPageNumber",
                             content: "0"
                         ),
-                        new Epub2NcxHeadMeta
+                        new
                         (
                             name: "location",
                             content: "https://example.com/books/123/ncx",
@@ -474,18 +474,18 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<Epub2NcxNavigationPoint>()
                     {
-                        new Epub2NcxNavigationPoint
+                        new
                         (
                             id: "navpoint-1",
                             @class: "chapter",
                             playOrder: "1",
                             navigationLabels: new List<Epub2NcxNavigationLabel>()
                             {
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "Chapter 1"
                                 ),
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "Capitolo 1"
                                 )
@@ -497,14 +497,14 @@ namespace VersOne.Epub.Test.Unit.Readers
                             ),
                             childNavigationPoints: new List<Epub2NcxNavigationPoint>()
                             {
-                                new Epub2NcxNavigationPoint
+                                new
                                 (
                                     id: "navpoint-1-1",
                                     @class: "section",
                                     playOrder: null,
                                     navigationLabels: new List<Epub2NcxNavigationLabel>()
                                     {
-                                        new Epub2NcxNavigationLabel
+                                        new
                                         (
                                             text: "Chapter 1.1"
                                         )
@@ -516,14 +516,14 @@ namespace VersOne.Epub.Test.Unit.Readers
                                     ),
                                     childNavigationPoints: null
                                 ),
-                                new Epub2NcxNavigationPoint
+                                new
                                 (
                                     id: "navpoint-1-2",
                                     @class: "section",
                                     playOrder: null,
                                     navigationLabels: new List<Epub2NcxNavigationLabel>()
                                     {
-                                        new Epub2NcxNavigationLabel
+                                        new
                                         (
                                             text: "Chapter 1.2"
                                         )
@@ -537,12 +537,12 @@ namespace VersOne.Epub.Test.Unit.Readers
                                 )
                             }
                         ),
-                        new Epub2NcxNavigationPoint
+                        new
                         (
                             id: "navpoint-2",
                             navigationLabels: new List<Epub2NcxNavigationLabel>()
                             {
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "Chapter 2"
                                 )
@@ -558,7 +558,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<Epub2NcxPageTarget>()
                     {
-                        new Epub2NcxPageTarget
+                        new
                         (
                             id: "page-target-1",
                             value: "1",
@@ -567,11 +567,11 @@ namespace VersOne.Epub.Test.Unit.Readers
                             playOrder: "1",
                             navigationLabels: new List<Epub2NcxNavigationLabel>()
                             {
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "1"
                                 ),
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "I"
                                 )
@@ -581,12 +581,12 @@ namespace VersOne.Epub.Test.Unit.Readers
                                 source: "front.html"
                             )
                         ),
-                        new Epub2NcxPageTarget
+                        new
                         (
                             type: Epub2NcxPageTargetType.NORMAL,
                             navigationLabels: new List<Epub2NcxNavigationLabel>()
                             {
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "2"
                                 )
@@ -601,24 +601,24 @@ namespace VersOne.Epub.Test.Unit.Readers
                 ),
                 navLists: new List<Epub2NcxNavigationList>()
                 {
-                    new Epub2NcxNavigationList
+                    new
                     (
                         id: "navlist-1",
                         @class: "navlist-illustrations",
                         navigationLabels: new List<Epub2NcxNavigationLabel>()
                         {
-                            new Epub2NcxNavigationLabel
+                            new
                             (
                                 text: "List of Illustrations"
                             ),
-                            new Epub2NcxNavigationLabel
+                            new
                             (
                                 text: "Illustrazioni"
                             )
                         },
                         navigationTargets: new List<Epub2NcxNavigationTarget>()
                         {
-                            new Epub2NcxNavigationTarget
+                            new
                             (
                                 id: "navtarget-1",
                                 value: "Illustration 1",
@@ -626,11 +626,11 @@ namespace VersOne.Epub.Test.Unit.Readers
                                 playOrder: "1",
                                 navigationLabels: new List<Epub2NcxNavigationLabel>()
                                 {
-                                    new Epub2NcxNavigationLabel
+                                    new
                                     (
                                         text: "Illustration 1"
                                     ),
-                                    new Epub2NcxNavigationLabel
+                                    new
                                     (
                                         text: "Illustrazione 1"
                                     )
@@ -642,37 +642,37 @@ namespace VersOne.Epub.Test.Unit.Readers
                             )
                         }
                     ),
-                    new Epub2NcxNavigationList
+                    new
                     (
                         id: "navlist-2",
                         @class: "navlist-tables",
                         navigationLabels: new List<Epub2NcxNavigationLabel>()
                         {
-                            new Epub2NcxNavigationLabel
+                            new
                             (
                                 text: "List of Tables"
                             )
                         },
                         navigationTargets: new List<Epub2NcxNavigationTarget>()
                         {
-                            new Epub2NcxNavigationTarget
+                            new
                             (
                                 id: "navtarget-2",
                                 navigationLabels: new List<Epub2NcxNavigationLabel>()
                                 {
-                                    new Epub2NcxNavigationLabel
+                                    new
                                     (
                                         text: "Tables"
                                     )
                                 },
                                 content: null
                             ),
-                            new Epub2NcxNavigationTarget
+                            new
                             (
                                 id: "navtarget-3",
                                 navigationLabels: new List<Epub2NcxNavigationLabel>()
                                 {
-                                    new Epub2NcxNavigationLabel
+                                    new
                                     (
                                         text: "Table 1"
                                     )
@@ -699,12 +699,12 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<Epub2NcxPageTarget>()
                     {
-                        new Epub2NcxPageTarget
+                        new
                         (
                             type: Epub2NcxPageTargetType.UNKNOWN,
                             navigationLabels: new List<Epub2NcxNavigationLabel>()
                             {
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "1"
                                 )
@@ -732,19 +732,19 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a minimal NCX file should succeed")]
-        public async void ReadEpub2NcxAsyncWithMinimalNcxFileTest()
+        public async Task ReadEpub2NcxAsyncWithMinimalNcxFileTest()
         {
             await TestSuccessfulReadOperation(MINIMAL_NCX_FILE, MinimalEpub2Ncx);
         }
 
         [Fact(DisplayName = "Reading a full NCX file should succeed")]
-        public async void ReadEpub2NcxAsyncWithFullNcxFileTest()
+        public async Task ReadEpub2NcxAsyncWithFullNcxFileTest()
         {
             await TestSuccessfulReadOperation(FULL_NCX_FILE, FullEpub2Ncx);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should return null if EpubPackage is missing spine TOC")]
-        public async void ReadEpub2NcxAsyncWithoutTocTest()
+        public async Task ReadEpub2NcxAsyncWithoutTocTest()
         {
             TestZipFile testZipFile = new();
             EpubPackage epubPackage = new
@@ -762,7 +762,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if EpubPackage is missing the manifest item referenced by the spine TOC")]
-        public async void ReadEpub2NcxAsyncWithoutTocManifestItemTest()
+        public async Task ReadEpub2NcxAsyncWithoutTocManifestItemTest()
         {
             TestZipFile testZipFile = new();
             EpubPackage epubPackage = new
@@ -782,7 +782,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if EPUB file is missing the NCX file specified in the EpubPackage")]
-        public async void ReadEpub2NcxAsyncWithoutNcxFileTest()
+        public async Task ReadEpub2NcxAsyncWithoutNcxFileTest()
         {
             TestZipFile testZipFile = new();
             Epub2NcxReader epub2NcxReader = new();
@@ -790,7 +790,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file is larger than 2 GB")]
-        public async void ReadEpub2NcxAsyncWithLargeNcxFileTest()
+        public async Task ReadEpub2NcxAsyncWithLargeNcxFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(NCX_FILE_PATH, new Test4GbZipFileEntry());
@@ -799,73 +799,73 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'ncx' XML element")]
-        public async void ReadEpub2NcxAsyncWithoutNcxElementTest()
+        public async Task ReadEpub2NcxAsyncWithoutNcxElementTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NCX_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'head' XML element")]
-        public async void ReadEpub2NcxAsyncWithoutHeadElementTest()
+        public async Task ReadEpub2NcxAsyncWithoutHeadElementTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_HEAD_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'docTitle' XML element")]
-        public async void ReadEpub2NcxAsyncWithoutDocTitleElementTest()
+        public async Task ReadEpub2NcxAsyncWithoutDocTitleElementTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_DOCTITLE_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if the NCX file has no 'navMap' XML element")]
-        public async void ReadEpub2NcxAsyncWithoutNavMapElementTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavMapElementTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVMAP_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'meta' XML element has no 'name' attribute")]
-        public async void ReadEpub2NcxAsyncWithoutMetaNameTest()
+        public async Task ReadEpub2NcxAsyncWithoutMetaNameTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_META_NAME_ATTRIBUTE);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'meta' XML element has no 'content' attribute")]
-        public async void ReadEpub2NcxAsyncWithoutMetaContentTest()
+        public async Task ReadEpub2NcxAsyncWithoutMetaContentTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_META_CONTENT_ATTRIBUTE);
         }
 
         [Fact(DisplayName = "Reading an NCX file with unknown XML element in the 'docTitle' element should succeed")]
-        public async void ReadEpub2NcxAsyncWithUnknownElementInDocTitleTest()
+        public async Task ReadEpub2NcxAsyncWithUnknownElementInDocTitleTest()
         {
             await TestSuccessfulReadOperation(MINIMAL_NCX_FILE_WITH_UNKNOWN_ELEMENT_IN_DOCTITLE, MinimalEpub2Ncx);
         }
 
         [Fact(DisplayName = "Reading an NCX file with unknown XML element in the 'docAuthor' element should succeed")]
-        public async void ReadEpub2NcxAsyncWithUnknownElementInDocAuthorTest()
+        public async Task ReadEpub2NcxAsyncWithUnknownElementInDocAuthorTest()
         {
             await TestSuccessfulReadOperation(MINIMAL_NCX_FILE_WITH_UNKNOWN_ELEMENT_IN_DOCAUTHOR, MinimalEpub2Ncx);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navpoint' XML element has no 'id' attribute")]
-        public async void ReadEpub2NcxAsyncWithoutNavPointIdTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavPointIdTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVPOINT_ID_ATTRIBUTE);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navpoint' XML element has no 'navlabel' elements")]
-        public async void ReadEpub2NcxAsyncWithoutNavPointNavLabelsTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavPointNavLabelsTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVPOINT_NAVLABEL_ELEMENTS);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navpoint' XML element has no 'content' element")]
-        public async void ReadEpub2NcxAsyncWithoutNavPointContentTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavPointContentTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVPOINT_CONTENT_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navpoint' XML element has no 'content' element and Epub2NcxReaderOptions is null")]
-        public async void ReadEpub2NcxAsyncWithoutNavPointContentAndWithNullEpub2NcxReaderOptionsTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavPointContentAndWithNullEpub2NcxReaderOptionsTest()
         {
             EpubReaderOptions epubReaderOptions = new()
             {
@@ -875,7 +875,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading an NCX file without 'content' element in a 'navpoint' XML element with IgnoreMissingContentForNavigationPoints = true should succeed")]
-        public async void ReadEpub2NcxAsyncWithoutNavPointContentWithIgnoreMissingContentForNavigationPointsTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavPointContentWithIgnoreMissingContentForNavigationPointsTest()
         {
             EpubReaderOptions epubReaderOptions = new()
             {
@@ -888,13 +888,13 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navlabel' XML element has no 'text' element")]
-        public async void ReadEpub2NcxAsyncWithoutNavLabelTextTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavLabelTextTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVLABEL_TEXT_ELEMENT);
         }
 
         [Fact(DisplayName = "Reading an NCX file with a URI-escaped 'src' attribute in a 'content' XML element should succeed")]
-        public async void ReadEpub2NcxAsyncWithEscapedContentSrcTest()
+        public async Task ReadEpub2NcxAsyncWithEscapedContentSrcTest()
         {
             Epub2Ncx expectedEpub2Ncx = new
             (
@@ -906,12 +906,12 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<Epub2NcxNavigationPoint>()
                     {
-                        new Epub2NcxNavigationPoint
+                        new
                         (
                             id: "navpoint-1",
                             navigationLabels: new List<Epub2NcxNavigationLabel>()
                             {
-                                new Epub2NcxNavigationLabel
+                                new
                                 (
                                     text: "Chapter 1"
                                 )
@@ -930,43 +930,43 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'content' XML element has no 'src' attribute")]
-        public async void ReadEpub2NcxAsyncWithoutContentSrcTest()
+        public async Task ReadEpub2NcxAsyncWithoutContentSrcTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_CONTENT_SRC_ATTRIBUTE);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'pageTarget' XML element has no 'type' attribute")]
-        public async void ReadEpub2NcxAsyncWithoutPageTargetTypeTest()
+        public async Task ReadEpub2NcxAsyncWithoutPageTargetTypeTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_PAGETARGET_TYPE_ATTRIBUTE);
         }
 
         [Fact(DisplayName = "Reading an NCX file with unknown value of the 'type' attribute of a 'pageTarget' XML element should succeed")]
-        public async void ReadEpub2NcxAsyncWithUnknownPageTargetTypeTest()
+        public async Task ReadEpub2NcxAsyncWithUnknownPageTargetTypeTest()
         {
             await TestSuccessfulReadOperation(MINIMAL_NCX_FILE_WITH_UNKNOWN_PAGETARGET_TYPE, MinimalEpub2NcxWithUnknownPageTargetType);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'pageTarget' XML element has no 'navlabel' elements")]
-        public async void ReadEpub2NcxAsyncWithoutPageTargetNavLabelsTest()
+        public async Task ReadEpub2NcxAsyncWithoutPageTargetNavLabelsTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_PAGETARGET_NAVLABEL_ELEMENTS);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navList' XML element has no 'navlabel' elements")]
-        public async void ReadEpub2NcxAsyncWithoutNavListNavLabelsTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavListNavLabelsTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVLIST_NAVLABEL_ELEMENTS);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navTarget' XML element has no 'id' attribute")]
-        public async void ReadEpub2NcxAsyncWithoutNavTargetIdTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavTargetIdTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVTARGET_ID_ATTRIBUTE);
         }
 
         [Fact(DisplayName = "ReadEpub2NcxAsync should throw Epub2NcxException if a 'navTarget' XML element has no 'navlabel' elements")]
-        public async void ReadEpub2NcxAsyncWithoutNavTargetNavLabelsTest()
+        public async Task ReadEpub2NcxAsyncWithoutNavTargetNavLabelsTest()
         {
             await TestFailingReadOperation(NCX_FILE_WITHOUT_NAVTARGET_NAVLABEL_ELEMENTS);
         }

--- a/Source/VersOne.Epub.Test/Unit/Readers/Epub3NavDocumentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/Epub3NavDocumentReaderTests.cs
@@ -169,7 +169,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<EpubManifestItem>()
                     {
-                        new EpubManifestItem
+                        new
                         (
                             id: "nav",
                             href: NAV_FILE_NAME,
@@ -197,7 +197,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 filePath: NAV_FILE_PATH,
                 navs: new List<Epub3Nav>()
                 {
-                    new Epub3Nav
+                    new
                     (
                         type: Epub3StructuralSemanticsProperty.TOC,
                         isHidden: false,
@@ -207,7 +207,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                             isHidden: false,
                             lis: new List<Epub3NavLi>()
                             {
-                                new Epub3NavLi
+                                new
                                 (
                                     span: new Epub3NavSpan
                                     (
@@ -220,7 +220,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                         isHidden: false,
                                         lis: new List<Epub3NavLi>()
                                         {
-                                            new Epub3NavLi
+                                            new
                                             (
                                                 anchor: new Epub3NavAnchor
                                                 (
@@ -233,7 +233,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                         }
                                     )
                                 ),
-                                new Epub3NavLi
+                                new
                                 (
                                     anchor: new Epub3NavAnchor
                                     (
@@ -245,7 +245,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                             }
                         )
                     ),
-                    new Epub3Nav
+                    new
                     (
                         type: Epub3StructuralSemanticsProperty.PAGE_LIST,
                         isHidden: true,
@@ -255,7 +255,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                             isHidden: true,
                             lis: new List<Epub3NavLi>()
                             {
-                                new Epub3NavLi
+                                new
                                 (
                                     anchor: new Epub3NavAnchor
                                     (
@@ -275,7 +275,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 filePath: NAV_FILE_PATH,
                 navs: new List<Epub3Nav>()
                 {
-                    new Epub3Nav
+                    new
                     (
                         type: null,
                         isHidden: false,
@@ -311,26 +311,26 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a minimal NAV file should succeed")]
-        public async void ReadEpub3NavDocumentAsyncWithMinimalNavFileTest()
+        public async Task ReadEpub3NavDocumentAsyncWithMinimalNavFileTest()
         {
             await TestSuccessfulReadOperation(MINIMAL_NAV_FILE, MinimalEpub3NavDocument);
         }
 
         [Fact(DisplayName = "Reading a full NAV file should succeed")]
-        public async void ReadEpub3NavDocumentAsyncWithFullNavFileTest()
+        public async Task ReadEpub3NavDocumentAsyncWithFullNavFileTest()
         {
             await TestSuccessfulReadOperation(FULL_NAV_FILE, FullEpub3NavDocument);
         }
 
         [Theory(DisplayName = "Reading minimal NAV packages with h1-h6 headers should succeed")]
         [MemberData(nameof(ReadEpub3NavDocumentAsyncWithMinimalNavFileWithHeaderTestData))]
-        public async void ReadEpub3NavDocumentAsyncWithMinimalNavFileWithHeaderTest(string navFileContent, Epub3NavDocument expectedEpub3NavDocument)
+        public async Task ReadEpub3NavDocumentAsyncWithMinimalNavFileWithHeaderTest(string navFileContent, Epub3NavDocument expectedEpub3NavDocument)
         {
             await TestSuccessfulReadOperation(navFileContent, expectedEpub3NavDocument);
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should throw Epub3NavException if EpubPackage is missing the NAV item and EpubVersion is not EPUB_2")]
-        public async void ReadEpub3NavDocumentAsyncForEpub3WithoutNavManifestItemTest()
+        public async Task ReadEpub3NavDocumentAsyncForEpub3WithoutNavManifestItemTest()
         {
             TestZipFile testZipFile = new();
             EpubPackage epubPackage = new
@@ -342,7 +342,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<EpubManifestItem>()
                     {
-                        new EpubManifestItem
+                        new
                         (
                             id: "test",
                             href: "test.html",
@@ -358,7 +358,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should return null if EpubPackage is missing the NAV item and EpubVersion is EPUB_2")]
-        public async void ReadEpub3NavDocumentAsyncForEpub2WithoutNavManifestItemTest()
+        public async Task ReadEpub3NavDocumentAsyncForEpub2WithoutNavManifestItemTest()
         {
             TestZipFile testZipFile = new();
             EpubPackage epubPackage = new
@@ -376,7 +376,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should throw Epub3NavException if EPUB file is missing the NAV file specified in the EpubPackage")]
-        public async void ReadEpub3NavDocumentAsyncWithoutNavFileTest()
+        public async Task ReadEpub3NavDocumentAsyncWithoutNavFileTest()
         {
             TestZipFile testZipFile = new();
             Epub3NavDocumentReader epub3NavDocumentReader = new();
@@ -384,7 +384,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should throw Epub3NavException if the NCX file is larger than 2 GB")]
-        public async void ReadEpub3NavDocumentAsyncWithLargeNavFileTest()
+        public async Task ReadEpub3NavDocumentAsyncWithLargeNavFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(NAV_FILE_PATH, new Test4GbZipFileEntry());
@@ -393,45 +393,45 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should throw Epub3NavException if the NAV file is missing the 'html' XML element")]
-        public async void ReadEpub3NavDocumentAsyncWithoutHtmlElement()
+        public async Task ReadEpub3NavDocumentAsyncWithoutHtmlElement()
         {
             await TestFailingReadOperation(NAV_FILE_WITHOUT_HTML_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should throw Epub3NavException if the NAV file is missing the 'body' XML element")]
-        public async void ReadEpub3NavDocumentAsyncWithoutBodyElement()
+        public async Task ReadEpub3NavDocumentAsyncWithoutBodyElement()
         {
             await TestFailingReadOperation(NAV_FILE_WITHOUT_BODY_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should throw Epub3NavException if the NAV file is missing the top 'ol' XML element")]
-        public async void ReadEpub3NavDocumentAsyncWithoutTopOlElement()
+        public async Task ReadEpub3NavDocumentAsyncWithoutTopOlElement()
         {
             await TestFailingReadOperation(NAV_FILE_WITHOUT_TOP_OL_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadEpub3NavDocumentAsync should throw Epub3NavException if the NAV file has an empty 'li' XML element")]
-        public async void ReadEpub3NavDocumentAsyncWithEmptyLiElement()
+        public async Task ReadEpub3NavDocumentAsyncWithEmptyLiElement()
         {
             await TestFailingReadOperation(NAV_FILE_WITH_EMPTY_LI_ELEMENT);
         }
 
         [Fact(DisplayName = "Reading a NAV file with a URI-escaped 'href' attribute in an 'a' XML element should succeed")]
-        public async void ReadEpub3NavDocumentAsyncWithEscapedAHrefTest()
+        public async Task ReadEpub3NavDocumentAsyncWithEscapedAHrefTest()
         {
             Epub3NavDocument expectedEpub3NavDocument = new
             (
                 filePath: NAV_FILE_PATH,
                 navs: new List<Epub3Nav>()
                 {
-                    new Epub3Nav
+                    new
                     (
                         type: Epub3StructuralSemanticsProperty.TOC,
                         ol: new Epub3NavOl
                         (
                             lis: new List<Epub3NavLi>()
                             {
-                                new Epub3NavLi
+                                new
                                 (
                                     anchor: new Epub3NavAnchor
                                     (

--- a/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
@@ -1,37 +1,13 @@
-﻿using Newtonsoft.Json;
-using VersOne.Epub.Internal;
+﻿using VersOne.Epub.Internal;
 using VersOne.Epub.Options;
 using VersOne.Epub.Schema;
 using VersOne.Epub.Test.Comparers;
 using VersOne.Epub.Test.Unit.Mocks;
-using Xunit.Abstractions;
 
 namespace VersOne.Epub.Test.Unit.Readers
 {
     public class PackageReaderTests
     {
-        public class ReadPackageTestData : IXunitSerializable
-        {
-            public required string Name { get; init; }
-            public required string OpfFileContent { get; init; }
-            public required EpubPackage ExpectedEpubPackage { get; init; }
-
-            public void Deserialize(IXunitSerializationInfo info)
-            {
-                JsonConvert.PopulateObject(info.GetValue<string>("Value"), this);
-            }
-
-            public void Serialize(IXunitSerializationInfo info)
-            {
-                info.AddValue("Value", JsonConvert.SerializeObject(this));
-            }
-
-            public override string ToString()
-            {
-                return Name;
-            }
-        }
-
         private const string CONTAINER_FILE_PATH = "META-INF/container.xml";
         private const string OPF_FILE_PATH = "content.opf";
 
@@ -671,27 +647,21 @@ namespace VersOne.Epub.Test.Unit.Readers
                 guide: null
             );
 
-        public static TheoryData<ReadPackageTestData> ReadMinimalPackageAsyncTestData
+        public static IEnumerable<object[]> ReadMinimalPackageAsyncTestData
         {
             get
             {
-                return new()
-                {
-                    new ReadPackageTestData { Name = "Minimal EPUB 2 package", OpfFileContent = MINIMAL_EPUB2_OPF_FILE, ExpectedEpubPackage = MinimalEpub2Package },
-                    new ReadPackageTestData { Name = "Minimal EPUB 3 package", OpfFileContent = MINIMAL_EPUB3_OPF_FILE, ExpectedEpubPackage = MinimalEpub3Package },
-                    new ReadPackageTestData { Name = "Minimal EPUB 3.1 package", OpfFileContent = MINIMAL_EPUB3_1_OPF_FILE, ExpectedEpubPackage = MinimalEpub31Package }
-                };
+                yield return new object[] { MINIMAL_EPUB2_OPF_FILE, MinimalEpub2Package };
+                yield return new object[] { MINIMAL_EPUB3_OPF_FILE, MinimalEpub3Package };
+                yield return new object[] { MINIMAL_EPUB3_1_OPF_FILE, MinimalEpub31Package };
             }
         }
 
-        public static TheoryData<ReadPackageTestData> ReadFullPackageAsyncTestData
+        public static IEnumerable<object[]> ReadFullPackageAsyncTestData
         {
             get
             {
-                return new()
-                {
-                    new ReadPackageTestData { Name = "Full EPUB 3 package", OpfFileContent = FULL_OPF_FILE, ExpectedEpubPackage = FullPackage },
-                };
+                yield return new object[] { FULL_OPF_FILE, FullPackage };
             }
         }
 
@@ -709,16 +679,16 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         [Theory(DisplayName = "Reading a minimal OPF package should succeed")]
         [MemberData(nameof(ReadMinimalPackageAsyncTestData))]
-        public async Task ReadMinimalPackageAsyncTest(ReadPackageTestData testData)
+        public async Task ReadMinimalPackageAsyncTest(string opfFileContent, EpubPackage expectedEpubPackage)
         {
-            await TestSuccessfulReadOperation(testData.OpfFileContent, testData.ExpectedEpubPackage);
+            await TestSuccessfulReadOperation(opfFileContent, expectedEpubPackage);
         }
 
         [Theory(DisplayName = "Reading a full OPF package should succeed")]
         [MemberData(nameof(ReadFullPackageAsyncTestData))]
-        public async Task ReadFullPackageAsyncTest(ReadPackageTestData testData)
+        public async Task ReadFullPackageAsyncTest(string opfFileContent, EpubPackage expectedEpubPackage)
         {
-            await TestSuccessfulReadOperation(testData.OpfFileContent, testData.ExpectedEpubPackage);
+            await TestSuccessfulReadOperation(opfFileContent, expectedEpubPackage);
         }
          
         [Fact(DisplayName = "Trying to read OPF package from the EPUB file with no OPF package should fail with EpubContainerException")]

--- a/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/PackageReaderTests.cs
@@ -1,13 +1,37 @@
-﻿using VersOne.Epub.Internal;
+﻿using Newtonsoft.Json;
+using VersOne.Epub.Internal;
 using VersOne.Epub.Options;
 using VersOne.Epub.Schema;
 using VersOne.Epub.Test.Comparers;
 using VersOne.Epub.Test.Unit.Mocks;
+using Xunit.Abstractions;
 
 namespace VersOne.Epub.Test.Unit.Readers
 {
     public class PackageReaderTests
     {
+        public class ReadPackageTestData : IXunitSerializable
+        {
+            public required string Name { get; init; }
+            public required string OpfFileContent { get; init; }
+            public required EpubPackage ExpectedEpubPackage { get; init; }
+
+            public void Deserialize(IXunitSerializationInfo info)
+            {
+                JsonConvert.PopulateObject(info.GetValue<string>("Value"), this);
+            }
+
+            public void Serialize(IXunitSerializationInfo info)
+            {
+                info.AddValue("Value", JsonConvert.SerializeObject(this));
+            }
+
+            public override string ToString()
+            {
+                return Name;
+            }
+        }
+
         private const string CONTAINER_FILE_PATH = "META-INF/container.xml";
         private const string OPF_FILE_PATH = "content.opf";
 
@@ -332,21 +356,21 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     titles: new List<EpubMetadataTitle>()
                     {
-                        new EpubMetadataTitle
+                        new
                         (
                             title: "Test title"
                         )
                     },
                     creators: new List<EpubMetadataCreator>()
                     {
-                        new EpubMetadataCreator
+                        new
                         (
                             creator: "John Doe"
                         )
                     },
                     identifiers: new List<EpubMetadataIdentifier>()
                     {
-                        new EpubMetadataIdentifier
+                        new
                         (
                             identifier: "9781234567890",
                             id: "book-uid"
@@ -354,14 +378,14 @@ namespace VersOne.Epub.Test.Unit.Readers
                     },
                     languages: new List<EpubMetadataLanguage>()
                     {
-                        new EpubMetadataLanguage
+                        new
                         (
                             language: "en"
                         )
                     },
                     metaItems: new List<EpubMetadataMeta>()
                     {
-                        new EpubMetadataMeta
+                        new
                         (
                             name: null,
                             content: "2021-12-31T00:00:00Z",
@@ -374,19 +398,19 @@ namespace VersOne.Epub.Test.Unit.Readers
                     id: "manifest-id",
                     items: new List<EpubManifestItem>()
                     {
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-front",
                             href: "front.html",
                             mediaType: "application/xhtml+xml"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "cover",
                             href: "cover.html",
                             mediaType: "application/xhtml+xml"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "cover-image",
                             href: "cover.jpg",
@@ -396,19 +420,19 @@ namespace VersOne.Epub.Test.Unit.Readers
                                 EpubManifestProperty.COVER_IMAGE
                             }
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-css",
                             href: "styles.css",
                             mediaType: "text/css"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-font",
                             href: "font.ttf",
                             mediaType: "application/x-font-truetype"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-1",
                             href: "chapter1.html",
@@ -420,19 +444,19 @@ namespace VersOne.Epub.Test.Unit.Readers
                             fallbackStyle: null,
                             properties: null
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-1-smil",
                             href: "chapter1.smil",
                             mediaType: "application/smil+xml"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-2",
                             href: "chapter2.html",
                             mediaType: "application/xhtml+xml"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-2-fall",
                             href: "chapter2.xml",
@@ -444,13 +468,13 @@ namespace VersOne.Epub.Test.Unit.Readers
                             fallbackStyle: "item-css",
                             properties: null
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-3",
                             href: "chapter3.html",
                             mediaType: "application/xhtml+xml"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-3-fall",
                             href: "chapter3.xml",
@@ -462,31 +486,31 @@ namespace VersOne.Epub.Test.Unit.Readers
                             fallbackStyle: null,
                             properties: null
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-3-remote-audio",
                             href: "http://example.com/audio/123/chapter3.mp4",
                             mediaType: "audio/mp4"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-image",
                             href: "image.jpg",
                             mediaType: "image/jpeg"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-title-audio",
                             href: "title.mp3",
                             mediaType: "audio/mpeg"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-atom",
                             href: "book.atom",
                             mediaType: "application/atom+xml"
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-toc",
                             href: "toc.html",
@@ -496,7 +520,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                 EpubManifestProperty.NAV
                             }
                         ),
-                        new EpubManifestItem
+                        new
                         (
                             id: "ncx",
                             href: "toc.ncx",
@@ -511,25 +535,25 @@ namespace VersOne.Epub.Test.Unit.Readers
                     toc: "ncx",
                     items: new List<EpubSpineItemRef>()
                     {
-                        new EpubSpineItemRef
+                        new
                         (
                             id: "itemref-1",
                             idRef: "item-front",
                             isLinear: true
                         ),
-                        new EpubSpineItemRef
+                        new
                         (
                             id: "itemref-2",
                             idRef: "item-toc",
                             isLinear: false
                         ),
-                        new EpubSpineItemRef
+                        new
                         (
                             id: "itemref-3",
                             idRef: "item-1",
                             isLinear: true
                         ),
-                        new EpubSpineItemRef
+                        new
                         (
                             id: "itemref-4",
                             idRef: "item-2",
@@ -539,7 +563,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                 EpubSpineProperty.PAGE_SPREAD_LEFT
                             }
                         ),
-                        new EpubSpineItemRef
+                        new
                         (
                             id: "itemref-5",
                             idRef: "item-3",
@@ -555,7 +579,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 (
                     items: new List<EpubGuideReference>()
                     {
-                        new EpubGuideReference
+                        new
                         (
                             type: "toc",
                             title: "Contents",
@@ -565,14 +589,14 @@ namespace VersOne.Epub.Test.Unit.Readers
                 ),
                 collections: new List<EpubCollection>()
                 {
-                    new EpubCollection
+                    new
                     (
                         role: "http://example.org/roles/group",
                         metadata: new EpubMetadata
                         (
                             titles: new List<EpubMetadataTitle>()
                             {
-                                new EpubMetadataTitle
+                                new
                                 (
                                     title: "Test title for collection 1",
                                     id: "collection-1-title",
@@ -583,14 +607,14 @@ namespace VersOne.Epub.Test.Unit.Readers
                         ),
                         nestedCollections: new List<EpubCollection>()
                         {
-                            new EpubCollection
+                            new
                             (
                                 role: "http://example.org/roles/unit",
                                 metadata: new EpubMetadata
                                 (
                                     titles: new List<EpubMetadataTitle>()
                                     {
-                                        new EpubMetadataTitle
+                                        new
                                         (
                                             title: "Test title for collection 2",
                                             id: "collection-2-title",
@@ -608,7 +632,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                         },
                         links: new List<EpubMetadataLink>()
                         {
-                            new EpubMetadataLink
+                            new
                             (
                                 href: "https://example.com/onix/123",
                                 id: "collection-1-link",
@@ -647,21 +671,27 @@ namespace VersOne.Epub.Test.Unit.Readers
                 guide: null
             );
 
-        public static IEnumerable<object[]> ReadMinimalPackageAsyncTestData
+        public static TheoryData<ReadPackageTestData> ReadMinimalPackageAsyncTestData
         {
             get
             {
-                yield return new object[] { MINIMAL_EPUB2_OPF_FILE, MinimalEpub2Package };
-                yield return new object[] { MINIMAL_EPUB3_OPF_FILE, MinimalEpub3Package };
-                yield return new object[] { MINIMAL_EPUB3_1_OPF_FILE, MinimalEpub31Package };
+                return new()
+                {
+                    new ReadPackageTestData { Name = "Minimal EPUB 2 package", OpfFileContent = MINIMAL_EPUB2_OPF_FILE, ExpectedEpubPackage = MinimalEpub2Package },
+                    new ReadPackageTestData { Name = "Minimal EPUB 3 package", OpfFileContent = MINIMAL_EPUB3_OPF_FILE, ExpectedEpubPackage = MinimalEpub3Package },
+                    new ReadPackageTestData { Name = "Minimal EPUB 3.1 package", OpfFileContent = MINIMAL_EPUB3_1_OPF_FILE, ExpectedEpubPackage = MinimalEpub31Package }
+                };
             }
         }
 
-        public static IEnumerable<object[]> ReadFullPackageAsyncTestData
+        public static TheoryData<ReadPackageTestData> ReadFullPackageAsyncTestData
         {
             get
             {
-                yield return new object[] { FULL_OPF_FILE, FullPackage };
+                return new()
+                {
+                    new ReadPackageTestData { Name = "Full EPUB 3 package", OpfFileContent = FULL_OPF_FILE, ExpectedEpubPackage = FullPackage },
+                };
             }
         }
 
@@ -679,20 +709,20 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         [Theory(DisplayName = "Reading a minimal OPF package should succeed")]
         [MemberData(nameof(ReadMinimalPackageAsyncTestData))]
-        public async void ReadMinimalPackageAsyncTest(string opfFileContent, EpubPackage expectedEpubPackage)
+        public async Task ReadMinimalPackageAsyncTest(ReadPackageTestData testData)
         {
-            await TestSuccessfulReadOperation(opfFileContent, expectedEpubPackage);
+            await TestSuccessfulReadOperation(testData.OpfFileContent, testData.ExpectedEpubPackage);
         }
 
         [Theory(DisplayName = "Reading a full OPF package should succeed")]
         [MemberData(nameof(ReadFullPackageAsyncTestData))]
-        public async void ReadFullPackageAsyncTest(string opfFileContent, EpubPackage expectedEpubPackage)
+        public async Task ReadFullPackageAsyncTest(ReadPackageTestData testData)
         {
-            await TestSuccessfulReadOperation(opfFileContent, expectedEpubPackage);
+            await TestSuccessfulReadOperation(testData.OpfFileContent, testData.ExpectedEpubPackage);
         }
          
         [Fact(DisplayName = "Trying to read OPF package from the EPUB file with no OPF package should fail with EpubContainerException")]
-        public async void ReadPackageWithNoOpfFileTest()
+        public async Task ReadPackageWithNoOpfFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(CONTAINER_FILE_PATH, CONTAINER_FILE);
@@ -701,61 +731,61 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Trying to read OPF package with non-supported EPUB version should fail with EpubPackageException")]
-        public async void ReadPackageWithNonSupportedEpubVersionTest()
+        public async Task ReadPackageWithNonSupportedEpubVersionTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITH_NON_SUPPORTED_EPUB_VERSION);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'package' XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutPackageNodeTest()
+        public async Task ReadPackageWithoutPackageNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_PACKAGE);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'metadata' XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutMetadataNodeTest()
+        public async Task ReadPackageWithoutMetadataNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_METADATA);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'manifest' XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutManifestNodeTest()
+        public async Task ReadPackageWithoutManifestNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_MANIFEST);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'spine' XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutSpineNodeTest()
+        public async Task ReadPackageWithoutSpineNodeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_SPINE);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'version' attribute in a package XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutVersionTest()
+        public async Task ReadPackageWithoutVersionTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_VERSION_IN_PACKAGE);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'id' attribute in a manifest item XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutManifestItemIdTest()
+        public async Task ReadPackageWithoutManifestItemIdTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_ID_IN_MANIFEST_ITEM);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'id' attribute in a manifest item XML node and null PackageReaderOptions should fail with EpubPackageException")]
-        public async void ReadPackageWithoutManifestItemIdWithNullPackageReaderOptionsTest()
+        public async Task ReadPackageWithoutManifestItemIdWithNullPackageReaderOptionsTest()
         {
             await TestFailingReadOperationWithNullPackageReaderOptions(OPF_FILE_WITHOUT_ID_IN_MANIFEST_ITEM);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'id' attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
-        public async void ReadPackageWithoutManifestItemIdWithSkippingInvalidManifestItemsTest()
+        public async Task ReadPackageWithoutManifestItemIdWithSkippingInvalidManifestItemsTest()
         {
             await TestSuccessfulReadOperationWithSkippingInvalidManifestItems(OPF_FILE_WITHOUT_ID_IN_MANIFEST_ITEM, MinimalEpub3Package);
         }
 
         [Fact(DisplayName = "Read an OPF package with a URI-escaped 'href' attribute in a manifest item XML node should succeed")]
-        public async void ReadPackageWithEscapedManifestItemHrefTest()
+        public async Task ReadPackageWithEscapedManifestItemHrefTest()
         {
             EpubPackage expectedPackage = new
             (
@@ -767,7 +797,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     id: null,
                     items: new List<EpubManifestItem>()
                     {
-                        new EpubManifestItem
+                        new
                         (
                             id: "item-1",
                             href: "chapter1.html",
@@ -782,79 +812,79 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'href' attribute in a manifest item XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutManifestItemHrefTest()
+        public async Task ReadPackageWithoutManifestItemHrefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_HREF_IN_MANIFEST_ITEM);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'href' attribute in a manifest item XML node and null PackageReaderOptions should fail with EpubPackageException")]
-        public async void ReadPackageWithoutManifestItemHrefWithNullPackageReaderOptionsTest()
+        public async Task ReadPackageWithoutManifestItemHrefWithNullPackageReaderOptionsTest()
         {
             await TestFailingReadOperationWithNullPackageReaderOptions(OPF_FILE_WITHOUT_HREF_IN_MANIFEST_ITEM);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'href' attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
-        public async void ReadPackageWithoutManifestItemHrefWithSkippingInvalidManifestItemsTest()
+        public async Task ReadPackageWithoutManifestItemHrefWithSkippingInvalidManifestItemsTest()
         {
             await TestSuccessfulReadOperationWithSkippingInvalidManifestItems(OPF_FILE_WITHOUT_HREF_IN_MANIFEST_ITEM, MinimalEpub3Package);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'media-type' attribute in a manifest item XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutManifestItemMediaTypeTest()
+        public async Task ReadPackageWithoutManifestItemMediaTypeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_MEDIA_TYPE_IN_MANIFEST_ITEM);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'media-type' attribute in a manifest item XML node and null PackageReaderOptions should fail with EpubPackageException")]
-        public async void ReadPackageWithoutManifestItemMediaTypeWithNullPackageReaderOptionsTest()
+        public async Task ReadPackageWithoutManifestItemMediaTypeWithNullPackageReaderOptionsTest()
         {
             await TestFailingReadOperationWithNullPackageReaderOptions(OPF_FILE_WITHOUT_MEDIA_TYPE_IN_MANIFEST_ITEM);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'media-type' attribute in a manifest item XML node with SkipInvalidManifestItems = true should succeed")]
-        public async void ReadPackageWithoutManifestItemMediaTypeWithSkippingInvalidManifestItemsTest()
+        public async Task ReadPackageWithoutManifestItemMediaTypeWithSkippingInvalidManifestItemsTest()
         {
             await TestSuccessfulReadOperationWithSkippingInvalidManifestItems(OPF_FILE_WITHOUT_MEDIA_TYPE_IN_MANIFEST_ITEM, MinimalEpub3Package);
         }
 
         [Fact(DisplayName = "Trying to read OPF package with duplicating 'id' attributes in manifest item XML nodes should fail with EpubPackageException")]
-        public async void ReadPackageWithDuplicatingManifestItemIdsTest()
+        public async Task ReadPackageWithDuplicatingManifestItemIdsTest()
         {
             await TestFailingReadOperationWithNullPackageReaderOptions(OPF_FILE_WITH_DUPLICATING_MANIFEST_ITEM_IDS);
         }
 
         [Fact(DisplayName = "Trying to read OPF package with duplicating 'href' attributes in manifest item XML nodes should fail with EpubPackageException")]
-        public async void ReadPackageWithDuplicatingManifestItemHrefsTest()
+        public async Task ReadPackageWithDuplicatingManifestItemHrefsTest()
         {
             await TestFailingReadOperationWithNullPackageReaderOptions(OPF_FILE_WITH_DUPLICATING_MANIFEST_ITEM_HREFS);
         }
 
         [Fact(DisplayName = "Trying to read EPUB 2 OPF package without 'toc' attribute in the spine XML node should fail with EpubPackageException")]
-        public async void ReadEpub2PackageWithoutSpineTocTest()
+        public async Task ReadEpub2PackageWithoutSpineTocTest()
         {
             await TestFailingReadOperation(EPUB2_OPF_FILE_WITHOUT_SPINE_TOC);
         }
 
         [Fact(DisplayName = "Trying to read EPUB 2 OPF package without 'toc' attribute in the spine XML node and null PackageReaderOptions should fail with EpubPackageException")]
-        public async void ReadEpub2PackageWithoutSpineTocWithNullPackageReaderOptionsTest()
+        public async Task ReadEpub2PackageWithoutSpineTocWithNullPackageReaderOptionsTest()
         {
             await TestFailingReadOperationWithNullPackageReaderOptions(EPUB2_OPF_FILE_WITHOUT_SPINE_TOC);
         }
 
         [Fact(DisplayName = "Trying to read EPUB 2 OPF package with empty 'toc' attribute in the spine XML node should fail with EpubPackageException")]
-        public async void ReadEpub2PackageWithEmptySpineTocTest()
+        public async Task ReadEpub2PackageWithEmptySpineTocTest()
         {
             await TestFailingReadOperation(EPUB2_OPF_FILE_WITH_EMPTY_SPINE_TOC);
         }
 
         [Fact(DisplayName = "Trying to read EPUB 2 OPF package with empty 'toc' attribute in the spine XML node and null PackageReaderOptions should fail with EpubPackageException")]
-        public async void ReadEpub2PackageWithEmptySpineTocWithNullPackageReaderOptionsTest()
+        public async Task ReadEpub2PackageWithEmptySpineTocWithNullPackageReaderOptionsTest()
         {
             await TestFailingReadOperationWithNullPackageReaderOptions(EPUB2_OPF_FILE_WITH_EMPTY_SPINE_TOC);
         }
 
         [Fact(DisplayName = "Trying to read EPUB 2 OPF package without 'toc' attribute in the spine XML node with IgnoreMissingToc = true should succeed")]
-        public async void ReadEpub2PackageWithoutSpineTocWithIgnoreMissingTocTest()
+        public async Task ReadEpub2PackageWithoutSpineTocWithIgnoreMissingTocTest()
         {
             EpubReaderOptions epubReaderOptions = new()
             {
@@ -867,25 +897,25 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'idref' attribute in a spine item ref XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutSpineItemRefIdRefTest()
+        public async Task ReadPackageWithoutSpineItemRefIdRefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_IDREF_IN_SPINE_ITEMREF);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'type' attribute in a guide reference XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutGuideReferenceTypeTest()
+        public async Task ReadPackageWithoutGuideReferenceTypeTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_TYPE_IN_GUIDE_REFERENCE);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'href' attribute in a guide reference XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutGuideReferenceHrefTest()
+        public async Task ReadPackageWithoutGuideReferenceHrefTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_HREF_IN_GUIDE_REFERENCE);
         }
 
         [Fact(DisplayName = "Trying to read OPF package without 'role' attribute in a collection XML node should fail with EpubPackageException")]
-        public async void ReadPackageWithoutCollectionRoleTest()
+        public async Task ReadPackageWithoutCollectionRoleTest()
         {
             await TestFailingReadOperation(OPF_FILE_WITHOUT_ROLE_IN_COLLECTION);
         }

--- a/Source/VersOne.Epub.Test/Unit/Readers/RootFilePathReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/RootFilePathReaderTests.cs
@@ -59,7 +59,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Getting root file path from a ZIP archive with a correct container file should succeed")]
-        public async void TestGetRootFilePathAsyncWithCorrectContainerFile()
+        public async Task TestGetRootFilePathAsyncWithCorrectContainerFile()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(EPUB_CONTAINER_FILE_PATH, CORRECT_CONTAINER_FILE);
@@ -69,7 +69,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Getting root file path from a ZIP archive without a container file should throw EpubContainerException")]
-        public async void TestGetRootFilePathAsyncWithNoContainerFile()
+        public async Task TestGetRootFilePathAsyncWithNoContainerFile()
         {
             TestZipFile testZipFile = new();
             RootFilePathReader rootFilePathReader = new();
@@ -81,7 +81,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         [InlineData(INCORRECT_CONTAINER_FILE_NO_ROOTFILE_ELEMENT)]
         [InlineData(INCORRECT_CONTAINER_FILE_NO_ROOTFILES_ELEMENT)]
         [InlineData(INCORRECT_CONTAINER_FILE_NO_CONTAINER_ELEMENT)]
-        public async void TestGetRootFilePathAsyncWithIncorrectContainerFile(string containerFileContent)
+        public async Task TestGetRootFilePathAsyncWithIncorrectContainerFile(string containerFileContent)
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(EPUB_CONTAINER_FILE_PATH, containerFileContent);

--- a/Source/VersOne.Epub.Test/Unit/Readers/SchemaReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SchemaReaderTests.cs
@@ -126,7 +126,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a typical schema from a EPUB file should succeed")]
-        public async void ReadSchemaAsyncTest()
+        public async Task ReadSchemaAsyncTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(EPUB_CONTAINER_FILE_PATH, META_INF_CONTAINER_FILE);
@@ -144,21 +144,21 @@ namespace VersOne.Epub.Test.Unit.Readers
                     (
                         titles: new List<EpubMetadataTitle>()
                         {
-                            new EpubMetadataTitle
+                            new
                             (
                                 title: "Test title"
                             )
                         },
                         creators: new List<EpubMetadataCreator>()
                         {
-                            new EpubMetadataCreator
+                            new
                             (
                                 creator: "John Doe"
                             )
                         },
                         identifiers: new List<EpubMetadataIdentifier>()
                         {
-                            new EpubMetadataIdentifier
+                            new
                             (
                                 identifier: "9781234567890",
                                 id: "book-uid"
@@ -169,19 +169,19 @@ namespace VersOne.Epub.Test.Unit.Readers
                     (
                         items: new List<EpubManifestItem>()
                         {
-                            new EpubManifestItem
+                            new
                             (
                                 id: "item-1",
                                 href: "chapter1.html",
                                 mediaType: "application/xhtml+xml"
                             ),
-                            new EpubManifestItem
+                            new
                             (
                                 id: "item-2",
                                 href: "chapter2.html",
                                 mediaType: "application/xhtml+xml"
                             ),
-                            new EpubManifestItem
+                            new
                             (
                                 id: "item-toc",
                                 href: NAV_FILE_NAME,
@@ -191,7 +191,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                     EpubManifestProperty.NAV
                                 }
                             ),
-                            new EpubManifestItem
+                            new
                             (
                                 id: "ncx",
                                 href: NCX_FILE_NAME,
@@ -204,13 +204,13 @@ namespace VersOne.Epub.Test.Unit.Readers
                         toc: "ncx",
                         items: new List<EpubSpineItemRef>()
                         {
-                            new EpubSpineItemRef
+                            new
                             (
                                 id: "itemref-1",
                                 idRef: "item-1",
                                 isLinear: true
                             ),
-                            new EpubSpineItemRef
+                            new
                             (
                                 id: "itemref-2",
                                 idRef: "item-2",
@@ -227,7 +227,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     (
                         items: new List<Epub2NcxHeadMeta>()
                         {
-                            new Epub2NcxHeadMeta
+                            new
                             (
                                 name: "dtb:uid",
                                 content: "9781234567890"
@@ -243,12 +243,12 @@ namespace VersOne.Epub.Test.Unit.Readers
                     (
                         items: new List<Epub2NcxNavigationPoint>()
                         {
-                            new Epub2NcxNavigationPoint
+                            new
                             (
                                 id: "navpoint-1",
                                 navigationLabels: new List<Epub2NcxNavigationLabel>()
                                 {
-                                    new Epub2NcxNavigationLabel
+                                    new
                                     (
                                         text: "Chapter 1"
                                     )
@@ -258,12 +258,12 @@ namespace VersOne.Epub.Test.Unit.Readers
                                     source: "chapter1.html"
                                 )
                             ),
-                            new Epub2NcxNavigationPoint
+                            new
                             (
                                 id: "navpoint-2",
                                 navigationLabels: new List<Epub2NcxNavigationLabel>()
                                 {
-                                    new Epub2NcxNavigationLabel
+                                    new
                                     (
                                         text: "Chapter 2"
                                     )
@@ -281,14 +281,14 @@ namespace VersOne.Epub.Test.Unit.Readers
                     filePath: NAV_FILE_PATH,
                     navs: new List<Epub3Nav>()
                     {
-                        new Epub3Nav
+                        new
                         (
                             type: Epub3StructuralSemanticsProperty.TOC,
                             ol: new Epub3NavOl
                             (
                                 lis: new List<Epub3NavLi>()
                                 {
-                                    new Epub3NavLi
+                                    new
                                     (
                                         anchor: new Epub3NavAnchor
                                         (
@@ -296,7 +296,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                             text: "Chapter 1"
                                         )
                                     ),
-                                    new Epub3NavLi
+                                    new
                                     (
                                         anchor: new Epub3NavAnchor
                                         (
@@ -311,7 +311,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                 ),
                 mediaOverlays: new List<Smil>()
                 {
-                    new Smil
+                    new
                     (
                         id: null,
                         version: SmilVersion.SMIL_3,
@@ -325,7 +325,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                             seqs: new List<SmilSeq>(),
                             pars: new List<SmilPar>()
                             {
-                                new SmilPar
+                                new
                                 (
                                     id: "sentence1",
                                     epubTypes: null,
@@ -342,7 +342,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                         clipEnd: "10s"
                                     )
                                 ),
-                                new SmilPar
+                                new
                                 (
                                     id: "sentence2",
                                     epubTypes: null,
@@ -359,7 +359,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                         clipEnd: "20s"
                                     )
                                 ),
-                                new SmilPar
+                                new
                                 (
                                     id: "sentence3",
                                     epubTypes: null,

--- a/Source/VersOne.Epub.Test/Unit/Readers/SmilReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SmilReaderTests.cs
@@ -163,7 +163,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     seqs: new List<SmilSeq>(),
                     pars: new List<SmilPar>()
                     {
-                        new SmilPar
+                        new
                         (
                             id: null,
                             epubTypes: null,
@@ -198,8 +198,8 @@ namespace VersOne.Epub.Test.Unit.Readers
                     (
                         items: new List<XElement>()
                         {
-                            new XElement(SmilXmlNamespace + "item1", "value1"),
-                            new XElement(SmilXmlNamespace + "item2", "value2")
+                            new(SmilXmlNamespace + "item1", "value1"),
+                            new(SmilXmlNamespace + "item2", "value2")
                         }
                     )
                 ),
@@ -213,7 +213,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     epubTextRef: "chapter1.html",
                     seqs: new List<SmilSeq>()
                     {
-                        new SmilSeq
+                        new
                         (
                             id: "seq1",
                             epubTypes: new List<Epub3StructuralSemanticsProperty>()
@@ -223,7 +223,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                             epubTextRef: "chapter1.html#section1",
                             seqs: new List<SmilSeq>()
                             {
-                                new SmilSeq
+                                new
                                 (
                                     id: "seq2",
                                     epubTypes: null,
@@ -231,7 +231,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                     seqs: new List<SmilSeq>(),
                                     pars: new List<SmilPar>()
                                     {
-                                        new SmilPar
+                                        new
                                         (
                                             id: "par3",
                                             epubTypes: new List<Epub3StructuralSemanticsProperty>()
@@ -251,7 +251,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                                 clipEnd: "0:24:28.764"
                                             )
                                         ),
-                                        new SmilPar
+                                        new
                                         (
                                             id: "par4",
                                             epubTypes: new List<Epub3StructuralSemanticsProperty>()
@@ -276,7 +276,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                             },
                             pars: new List<SmilPar>()
                             {
-                                new SmilPar
+                                new
                                 (
                                     id: "par1",
                                     epubTypes: null,
@@ -293,7 +293,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                                         clipEnd: "0:23:59.003"
                                     )
                                 ),
-                                new SmilPar
+                                new
                                 (
                                     id: "par2",
                                     epubTypes: null,
@@ -334,7 +334,7 @@ namespace VersOne.Epub.Test.Unit.Readers
                     seqs: new List<SmilSeq>(),
                     pars: new List<SmilPar>()
                     {
-                        new SmilPar
+                        new
                         (
                             id: null,
                             epubTypes: null,
@@ -369,19 +369,19 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "Reading a minimal SMIL file should succeed")]
-        public async void ReadSmilAsyncWithMinimalSmilFileTest()
+        public async Task ReadSmilAsyncWithMinimalSmilFileTest()
         {
             await TestSuccessfulReadOperation(MINIMAL_SMIL_FILE, MinimalSmil);
         }
 
         [Fact(DisplayName = "Reading a full SMIL file should succeed")]
-        public async void ReadSmilAsyncWithFullSmilFileTest()
+        public async Task ReadSmilAsyncWithFullSmilFileTest()
         {
             await TestSuccessfulReadOperation(FULL_SMIL_FILE, FullSmil);
         }
 
         [Fact(DisplayName = "Reading all SMIL documents in a EPUB package should succeed")]
-        public async void ReadAllSmilDocumentsAsyncTest()
+        public async Task ReadAllSmilDocumentsAsyncTest()
         {
             TestZipFile testZipFile = new();
             string chapter1SmilFileName = "chapter1.smil";
@@ -398,7 +398,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if EPUB file is missing the specified SMIL file")]
-        public async void ReadSmilAsyncWithoutSmilFileTest()
+        public async Task ReadSmilAsyncWithoutSmilFileTest()
         {
             TestZipFile testZipFile = new();
             SmilReader smilReader = new();
@@ -406,7 +406,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the SMIL file is larger than 2 GB")]
-        public async void ReadSmilAsyncWithLargeSmilFileTest()
+        public async Task ReadSmilAsyncWithLargeSmilFileTest()
         {
             TestZipFile testZipFile = new();
             testZipFile.AddEntry(SMIL_FILE_PATH, new Test4GbZipFileEntry());
@@ -415,55 +415,55 @@ namespace VersOne.Epub.Test.Unit.Readers
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the SMIL file has no 'smil' XML element")]
-        public async void ReadSmilAsyncWithoutSmilElementTest()
+        public async Task ReadSmilAsyncWithoutSmilElementTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITHOUT_SMIL_ELEMENT);
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the SMIL version in the file is not 3.0")]
-        public async void ReadSmilAsyncWithWrongSmilVersionTest()
+        public async Task ReadSmilAsyncWithWrongSmilVersionTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITH_WRONG_SMIL_VERSION);
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the 'smil' XML element has no 'body' element")]
-        public async void ReadSmilAsyncWithoutBodyElementTest()
+        public async Task ReadSmilAsyncWithoutBodyElementTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITHOUT_BODY_ELEMENT);
         }
 
         [Fact(DisplayName = "Non-metadata XML elements in the 'head' element should be ignored")]
-        public async void ReadSmilAsyncWithNonMetadataElementsInHeadTest()
+        public async Task ReadSmilAsyncWithNonMetadataElementsInHeadTest()
         {
             await TestSuccessfulReadOperation(MINIMAL_SMIL_FILE_WITH_NON_METADATA_ELEMENT_IN_HEAD, MinimalSmilWithEmptyHead);
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the 'body' XML element has neither 'seq' nor 'par' elements")]
-        public async void ReadSmilAsyncWithoutSeqAndParElementsInBodyTest()
+        public async Task ReadSmilAsyncWithoutSeqAndParElementsInBodyTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITHOUT_SEQ_AND_PAR_ELEMENTS_IN_BODY);
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the 'seq' XML element has neither 'seq' nor 'par' elements")]
-        public async void ReadSmilAsyncWithoutSeqAndParElementsInSeqTest()
+        public async Task ReadSmilAsyncWithoutSeqAndParElementsInSeqTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITHOUT_SEQ_AND_PAR_ELEMENTS_IN_SEQ);
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the 'par' XML element has no 'text' element")]
-        public async void ReadSmilAsyncWithoutTextElementInParTest()
+        public async Task ReadSmilAsyncWithoutTextElementInParTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITHOUT_TEXT_ELEMENT_IN_PAR);
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the 'text' XML element has no 'src' attribute")]
-        public async void ReadSmilAsyncWithoutTextSrcAttributeTest()
+        public async Task ReadSmilAsyncWithoutTextSrcAttributeTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITHOUT_TEXT_SRC_ATTRIBUTE);
         }
 
         [Fact(DisplayName = "ReadSmilAsync should throw EpubSmilException if the 'audio' XML element has no 'src' attribute")]
-        public async void ReadSmilAsyncWithoutAudioSrcAttributeTest()
+        public async Task ReadSmilAsyncWithoutAudioSrcAttributeTest()
         {
             await TestFailingReadOperation(SMIL_FILE_WITHOUT_AUDIO_SRC_ATTRIBUTE);
         }

--- a/Source/VersOne.Epub.Test/Unit/Schema/Opf/Common/EpubTextDirectionTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Schema/Opf/Common/EpubTextDirectionTests.cs
@@ -11,9 +11,9 @@ namespace VersOne.Epub.Test.Unit.Schema.Opf.Common
         [InlineData("test-unknown-property", EpubTextDirection.UNKNOWN)]
         [InlineData("", EpubTextDirection.UNKNOWN)]
         [InlineData(null, EpubTextDirection.UNKNOWN)]
-        public void ParseTest(string stringValue, EpubTextDirection expectedTextDirection)
+        public void ParseTest(string? stringValue, EpubTextDirection expectedTextDirection)
         {
-            EpubTextDirection actualTextDirection = EpubTextDirectionParser.Parse(stringValue);
+            EpubTextDirection actualTextDirection = EpubTextDirectionParser.Parse(stringValue!);
             Assert.Equal(expectedTextDirection, actualTextDirection);
         }
     }

--- a/Source/VersOne.Epub.Test/Unit/Schema/Opf/Spine/EpubPageProgressionDirectionTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Schema/Opf/Spine/EpubPageProgressionDirectionTests.cs
@@ -11,9 +11,9 @@ namespace VersOne.Epub.Test.Unit.Schema.Opf.Spine
         [InlineData("test-unknown-property", EpubPageProgressionDirection.UNKNOWN)]
         [InlineData("", EpubPageProgressionDirection.UNKNOWN)]
         [InlineData(null, EpubPageProgressionDirection.UNKNOWN)]
-        public void ParseTest(string stringValue, EpubPageProgressionDirection expectedPageProgressionDirection)
+        public void ParseTest(string? stringValue, EpubPageProgressionDirection expectedPageProgressionDirection)
         {
-            EpubPageProgressionDirection actualPageProgressionDirection = EpubPageProgressionDirectionParser.Parse(stringValue);
+            EpubPageProgressionDirection actualPageProgressionDirection = EpubPageProgressionDirectionParser.Parse(stringValue!);
             Assert.Equal(expectedPageProgressionDirection, actualPageProgressionDirection);
         }
     }

--- a/Source/VersOne.Epub.Test/Unit/Schema/Ops/Navigation/Epub3StructuralSemanticsPropertyTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Schema/Ops/Navigation/Epub3StructuralSemanticsPropertyTests.cs
@@ -139,9 +139,9 @@ namespace VersOne.Epub.Test.Unit.Schema.Ops.Navigation
         [InlineData("test-unknown-property", Epub3StructuralSemanticsProperty.UNKNOWN)]
         [InlineData("", Epub3StructuralSemanticsProperty.UNKNOWN)]
         [InlineData(null, Epub3StructuralSemanticsProperty.UNKNOWN)]
-        public void ParseTest(string stringValue, Epub3StructuralSemanticsProperty expectedStructuralSemanticsProperty)
+        public void ParseTest(string? stringValue, Epub3StructuralSemanticsProperty expectedStructuralSemanticsProperty)
         {
-            Epub3StructuralSemanticsProperty actualStructuralSemanticsProperty = Epub3StructuralSemanticsPropertyParser.ParseProperty(stringValue);
+            Epub3StructuralSemanticsProperty actualStructuralSemanticsProperty = Epub3StructuralSemanticsPropertyParser.ParseProperty(stringValue!);
             Assert.Equal(expectedStructuralSemanticsProperty, actualStructuralSemanticsProperty);
         }
     }

--- a/Source/VersOne.Epub.Test/Unit/Utils/ContentPathUtilsTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Utils/ContentPathUtilsTests.cs
@@ -48,9 +48,9 @@ namespace VersOne.Epub.Test.Unit.Utils
         [InlineData(null, "../File.html", "../File.html")]
         [InlineData("Directory", null, "Directory")]
         [InlineData(null, null, null)]
-        public void CombineTest(string directory, string fileName, string expectedResult)
+        public void CombineTest(string? directory, string? fileName, string? expectedResult)
         {
-            string actualResult = ContentPathUtils.Combine(directory, fileName);
+            string actualResult = ContentPathUtils.Combine(directory!, fileName!);
             Assert.Equal(expectedResult, actualResult);
         }
     }

--- a/Source/VersOne.Epub.Test/Unit/Utils/UrlParserTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Utils/UrlParserTests.cs
@@ -7,7 +7,7 @@ namespace VersOne.Epub.Test.Unit.Utils
         [Theory(DisplayName = "Parsing URLs with or without anchor should succeed")]
         [InlineData("file.html#anchor", "file.html", "anchor")]
         [InlineData("file.html", "file.html", null)]
-        public void ConstructorWithNonNullUrlTest(string url, string expectedPath, string expectedAnchor)
+        public void ConstructorWithNonNullUrlTest(string url, string expectedPath, string? expectedAnchor)
         {
             UrlParser urlParser = new(url);
             Assert.Equal(expectedPath, urlParser.Path);

--- a/Source/VersOne.Epub.Test/Unit/Utils/XmlUtilsTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Utils/XmlUtilsTests.cs
@@ -27,20 +27,20 @@ namespace VersOne.Epub.Test.Unit.Utils
             );
 
         [Fact(DisplayName = "Loading a regular XML 1.0 file should succeed")]
-        public async void TestXml10File()
+        public async Task TestXml10File()
         {
             XDocument actualXDocument = await XmlUtils.LoadDocumentAsync(StreamUtils.CreateMemoryStreamForString(XML_1_0_FILE), new XmlReaderOptions());
             CompareXDocuments(ExpectedXDocument, actualXDocument);
         }
 
         [Fact(DisplayName = "Loading an XML 1.1 file with XmlReaderOptions.SkipXmlHeaders = false should throw XmlException")]
-        public async void TestXml11FileThrowsException()
+        public async Task TestXml11FileThrowsException()
         {
             await Assert.ThrowsAsync<XmlException>(() => XmlUtils.LoadDocumentAsync(StreamUtils.CreateMemoryStreamForString(XML_1_1_FILE), new XmlReaderOptions()));
         }
 
         [Fact(DisplayName = "Loading an XML 1.1 file with null XmlReaderOptions should throw XmlException")]
-        public async void TestXml11FileWithNullXmlReaderOptionsThrowsException()
+        public async Task TestXml11FileWithNullXmlReaderOptionsThrowsException()
         {
             await Assert.ThrowsAsync<XmlException>(() => XmlUtils.LoadDocumentAsync(StreamUtils.CreateMemoryStreamForString(XML_1_1_FILE), null));
         }
@@ -48,7 +48,7 @@ namespace VersOne.Epub.Test.Unit.Utils
         [Theory(DisplayName = "Loading either an XML 1.1 file or an XML file without a header with XmlReaderOptions.SkipXmlHeaders = true should succeed")]
         [InlineData(XML_1_1_FILE)]
         [InlineData(XML_BODY)]
-        public async void TestXml11FileWorkaround(string xmlFileContent)
+        public async Task TestXml11FileWorkaround(string xmlFileContent)
         {
             XmlReaderOptions xmlReaderOptions = new()
             {
@@ -59,7 +59,7 @@ namespace VersOne.Epub.Test.Unit.Utils
         }
 
         [Fact(DisplayName = "Loading a file with just XML 1.1 header and no other content with XmlReaderOptions.SkipXmlHeaders = true should throw XmlException")]
-        public async void TestXml11EmptyFileThrowsException()
+        public async Task TestXml11EmptyFileThrowsException()
         {
             XmlReaderOptions xmlReaderOptions = new()
             {
@@ -68,13 +68,13 @@ namespace VersOne.Epub.Test.Unit.Utils
             await Assert.ThrowsAsync<XmlException>(() => XmlUtils.LoadDocumentAsync(StreamUtils.CreateMemoryStreamForString(XML_1_1_HEADER), xmlReaderOptions));
         }
 
-        private void CompareXDocuments(XDocument expected, XDocument actual)
+        private static void CompareXDocuments(XDocument expected, XDocument actual)
         {
             Assert.NotNull(actual);
             CompareXElements(expected.Root, actual.Root);
         }
 
-        private void CompareXElements(XElement? expected, XElement? actual)
+        private static void CompareXElements(XElement? expected, XElement? actual)
         {
             if (expected == null)
             {

--- a/Source/VersOne.Epub.Test/VersOne.Epub.Test.csproj
+++ b/Source/VersOne.Epub.Test/VersOne.Epub.Test.csproj
@@ -2,26 +2,27 @@
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <Authors>vers</Authors>
-        <Copyright>vers, 2015-2022</Copyright>
+        <Copyright>vers, 2015-2024</Copyright>
         <Version>3.3.1</Version>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+		<RunSettingsFilePath>$(MSBuildProjectDirectory)\coverlet.runsettings</RunSettingsFilePath>
     </PropertyGroup>
     <ItemGroup>
       <AdditionalFiles Include="stylecop.json" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.8.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Source/VersOne.Epub.WpfDemo/VersOne.Epub.WpfDemo.csproj
+++ b/Source/VersOne.Epub.WpfDemo/VersOne.Epub.WpfDemo.csproj
@@ -204,12 +204,12 @@
     <None Include="Licenses\PTSans\PT Free Font License_rus_1.2.txt" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.0.0.68202\analyzers\Google.Protobuf.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.0.0.68202\analyzers\SonarAnalyzer.CFG.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.0.0.68202\analyzers\SonarAnalyzer.CSharp.dll" />
-    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.0.0.68202\analyzers\SonarAnalyzer.dll" />
-    <Analyzer Include="..\packages\StyleCop.Analyzers.Unstable.1.2.0.435\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\StyleCop.Analyzers.Unstable.1.2.0.435\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.25.0.90414\analyzers\Google.Protobuf.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.25.0.90414\analyzers\SonarAnalyzer.CFG.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.25.0.90414\analyzers\SonarAnalyzer.CSharp.dll" />
+    <Analyzer Include="..\packages\SonarAnalyzer.CSharp.9.25.0.90414\analyzers\SonarAnalyzer.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.Unstable.1.2.0.556\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.Unstable.1.2.0.556\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/VersOne.Epub.WpfDemo/ViewModels/BookViewModel.cs
+++ b/Source/VersOne.Epub.WpfDemo/ViewModels/BookViewModel.cs
@@ -219,7 +219,7 @@ namespace VersOne.Epub.WpfDemo.ViewModels
             ReadingOrder = new ObservableCollection<HtmlContentFileViewModel>(bookModel.GetReadingOrder(epubBook));
             if (ReadingOrder.Any())
             {
-                CurrentHtmlContentFile = ReadingOrder.First();
+                CurrentHtmlContentFile = ReadingOrder[0];
                 if (ReadingOrder.Count > 1)
                 {
                     nextHtmlContentFile = ReadingOrder[1];

--- a/Source/VersOne.Epub.WpfDemo/WpfEnvironment/WindowManager.cs
+++ b/Source/VersOne.Epub.WpfDemo/WpfEnvironment/WindowManager.cs
@@ -107,7 +107,7 @@ namespace VersOne.Epub.WpfDemo.WpfEnvironment
                 throw new InvalidOperationException($"View {viewName} has been declared more than once.");
             }
             string viewModelTypeName = viewName + "ViewModel";
-            Type viewModelType = Assembly.GetExecutingAssembly().GetTypes().FirstOrDefault(type => String.Compare(type.Name, viewModelTypeName, StringComparison.OrdinalIgnoreCase) == 0);
+            Type viewModelType = Array.Find(Assembly.GetExecutingAssembly().GetTypes(), type => String.Compare(type.Name, viewModelTypeName, StringComparison.OrdinalIgnoreCase) == 0);
             WindowInfo windowInfo = new WindowInfo(viewName, windowType, viewModelType);
             registeredWindowsByViewName.Add(viewName, windowInfo);
             if (viewModelType != null)

--- a/Source/VersOne.Epub.WpfDemo/packages.config
+++ b/Source/VersOne.Epub.WpfDemo/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="HtmlRenderer.Core" version="1.5.0.6" targetFramework="net45" />
   <package id="HtmlRenderer.WPF" version="1.5.0.6" targetFramework="net45" />
-  <package id="SonarAnalyzer.CSharp" version="9.0.0.68202" targetFramework="net46" developmentDependency="true" />
+  <package id="SonarAnalyzer.CSharp" version="9.25.0.90414" targetFramework="net46" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.406" targetFramework="net46" developmentDependency="true" />
-  <package id="StyleCop.Analyzers.Unstable" version="1.2.0.435" targetFramework="net46" developmentDependency="true" />
+  <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net46" developmentDependency="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/Source/VersOne.Epub/Readers/BookCoverReader.cs
+++ b/Source/VersOne.Epub/Readers/BookCoverReader.cs
@@ -40,7 +40,7 @@ namespace VersOne.Epub.Internal
             {
                 return null;
             }
-            EpubMetadataMeta coverMetaItem = metaItems.FirstOrDefault(metaItem => metaItem.Name.CompareOrdinalIgnoreCase("cover"));
+            EpubMetadataMeta coverMetaItem = metaItems.Find(metaItem => metaItem.Name.CompareOrdinalIgnoreCase("cover"));
             if (coverMetaItem == null)
             {
                 return null;
@@ -50,7 +50,7 @@ namespace VersOne.Epub.Internal
                 throw new EpubPackageException("Incorrect EPUB metadata: cover item content is missing.");
             }
             EpubManifestItem coverManifestItem =
-                epubSchema.Package.Manifest.Items.FirstOrDefault(manifestItem => manifestItem.Id.CompareOrdinalIgnoreCase(coverMetaItem.Content)) ??
+                epubSchema.Package.Manifest.Items.Find(manifestItem => manifestItem.Id.CompareOrdinalIgnoreCase(coverMetaItem.Content)) ??
                 throw new EpubPackageException($"Incorrect EPUB manifest: item with ID = \"{coverMetaItem.Content}\" is missing.");
             EpubLocalByteContentFileRef result = GetCoverImageContentRef(imageContentRefs, coverManifestItem.Href) ??
                 throw new EpubPackageException($"Incorrect EPUB manifest: item with href = \"{coverManifestItem.Href}\" is missing.");
@@ -80,7 +80,7 @@ namespace VersOne.Epub.Internal
         private static EpubLocalByteContentFileRef? ReadEpub3Cover(
             EpubSchema epubSchema, EpubContentCollectionRef<EpubLocalByteContentFileRef, EpubRemoteByteContentFileRef> imageContentRefs)
         {
-            EpubManifestItem coverManifestItem = epubSchema.Package.Manifest.Items.FirstOrDefault(manifestItem => manifestItem.Properties != null &&
+            EpubManifestItem coverManifestItem = epubSchema.Package.Manifest.Items.Find(manifestItem => manifestItem.Properties != null &&
                 manifestItem.Properties.Contains(EpubManifestProperty.COVER_IMAGE));
             if (coverManifestItem == null || coverManifestItem.Href == null)
             {

--- a/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub2NcxReader.cs
@@ -27,7 +27,7 @@ namespace VersOne.Epub.Internal
             {
                 return null;
             }
-            EpubManifestItem tocManifestItem = package.Manifest.Items.FirstOrDefault(item => item.Id.CompareOrdinalIgnoreCase(tocId)) ??
+            EpubManifestItem tocManifestItem = package.Manifest.Items.Find(item => item.Id.CompareOrdinalIgnoreCase(tocId)) ??
                 throw new Epub2NcxException($"EPUB parsing error: TOC item {tocId} not found in EPUB manifest.");
             string tocFileEntryPath = ContentPathUtils.Combine(contentDirectoryPath, tocManifestItem.Href);
             IZipFileEntry? tocFileEntry = epubFile.GetEntry(tocFileEntryPath) ??

--- a/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using VersOne.Epub.Environment;
@@ -22,7 +21,7 @@ namespace VersOne.Epub.Internal
 
         public async Task<Epub3NavDocument?> ReadEpub3NavDocumentAsync(IZipFile epubFile, string contentDirectoryPath, EpubPackage package)
         {
-            EpubManifestItem navManifestItem = package.Manifest.Items.FirstOrDefault(item => item.Properties != null && item.Properties.Contains(EpubManifestProperty.NAV));
+            EpubManifestItem navManifestItem = package.Manifest.Items.Find(item => item.Properties != null && item.Properties.Contains(EpubManifestProperty.NAV));
             if (navManifestItem == null)
             {
                 if (package.EpubVersion == EpubVersion.EPUB_2)

--- a/Source/VersOne.Epub/Readers/NavigationReader.cs
+++ b/Source/VersOne.Epub/Readers/NavigationReader.cs
@@ -26,7 +26,7 @@ namespace VersOne.Epub.Internal
 
         public static List<EpubNavigationItemRef> GetNavigationItems(EpubSchema epubSchema, EpubContentRef epubContentRef, Epub3NavDocument epub3NavDocument)
         {
-            return GetNavigationItems(epubSchema, epubContentRef, epub3NavDocument.Navs.FirstOrDefault(nav => nav.Type == Epub3StructuralSemanticsProperty.TOC),
+            return GetNavigationItems(epubSchema, epubContentRef, epub3NavDocument.Navs.Find(nav => nav.Type == Epub3StructuralSemanticsProperty.TOC),
                 epub3NavDocument.FilePath);
         }
 

--- a/Source/VersOne.Epub/Readers/SpineReader.cs
+++ b/Source/VersOne.Epub/Readers/SpineReader.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using VersOne.Epub.Schema;
 
 namespace VersOne.Epub.Internal
@@ -11,7 +10,7 @@ namespace VersOne.Epub.Internal
             List<EpubLocalTextContentFileRef> result = new();
             foreach (EpubSpineItemRef spineItemRef in epubSchema.Package.Spine.Items)
             {
-                EpubManifestItem manifestItem = epubSchema.Package.Manifest.Items.FirstOrDefault(item => item.Id == spineItemRef.IdRef) ??
+                EpubManifestItem manifestItem = epubSchema.Package.Manifest.Items.Find(item => item.Id == spineItemRef.IdRef) ??
                     throw new EpubPackageException($"Incorrect EPUB spine: item with IdRef = \"{spineItemRef.IdRef}\" is missing in the manifest.");
                 if (epubContentRef.Html.ContainsRemoteFileRefWithUrl(manifestItem.Href))
                 {

--- a/Source/VersOne.Epub/VersOne.Epub.csproj
+++ b/Source/VersOne.Epub/VersOne.Epub.csproj
@@ -2,24 +2,24 @@
     <PropertyGroup>
         <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
         <Authors>vers</Authors>
-        <Copyright>vers, 2015-2022</Copyright>
+        <Copyright>vers, 2015-2024</Copyright>
         <Version>3.3.1</Version>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-		<DocumentationFile></DocumentationFile>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+        <DocumentationFile></DocumentationFile>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
         <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.0.0.68202">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
         <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />

--- a/Source/spell_exclusion.dic
+++ b/Source/spell_exclusion.dic
@@ -96,6 +96,7 @@ truetype'
 ttf'
 urls
 utils
+vers
 webp
 webp'
 woff


### PR DESCRIPTION
# Code cleanup

There are new code quality checks and rules added in the recent versions of StyleCop, Sonar, and xUnit C# analyzers. Those rules trigger warnings in the current codebase.

## Description

This is a code cleanup change to fix those code quality violations.

## Testing steps

Automated tests should pass.

## Known issues

There are three more [xUnit1042](https://xunit.net/xunit.analyzers/rules/xUnit1042) warnings for three tests because those tests use `[MemberData]` attribute with non-serializable test data. Making the test data serializable will require significant changes in the `VersOne.Epub.Schema` classes (all schema classes need to have an empty constructor and all their properties need to be writable), so it's better to leave such change for a separate PR.