### PR TITLE
Migrate to codecov-action@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Run unit tests
         run: dotnet test Source\VersOne.Epub.Test --filter Unit --no-restore --collect:"XPlat Code Coverage" --settings Source\VersOne.Epub.Test\coverlet.runsettings
       - name: Upload code coverage result to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run integration tests
         run: dotnet test Source\VersOne.Epub.Test --filter Integration --no-restore


### PR DESCRIPTION
# Migrate to codecov-action@v4

Currently, all test coverage reports are uploaded to Codecov using `codecov-action@v3` that doesn't require a codecov token. These uploads fail sometimes with the following error:
```text
Rate limit reached ... code='throttled'
```

## Description

This pull request migrates the `test.yml` action from `codecov-action@v3` to `codecov-action@v4` and adds a codecov token.

## Testing steps

Coverage report upload should succeed.