### PR TITLE
Parse <nav> elements nested in other HTML elements in EPUB 3 navigation documents

### DIFF
--- a/Source/VersOne.Epub.Test/Unit/Readers/Epub3NavDocumentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/Epub3NavDocumentReaderTests.cs
@@ -159,6 +159,19 @@ namespace VersOne.Epub.Test.Unit.Readers
             </html>
             """;
 
+        private const string NAV_FILE_WITH_WITH_NON_TOP_LEVEL_NAV_ELEMENT = """
+            <html xmlns="http://www.w3.org/1999/xhtml">
+              <body>
+                <div>
+                  <nav>
+                    <h1>Test header</h1>
+                    <ol />
+                  </nav>
+                </div>
+              </body>
+            </html>
+            """;
+
         private static EpubPackage MinimalEpubPackageWithNav =>
             new
             (
@@ -445,6 +458,12 @@ namespace VersOne.Epub.Test.Unit.Readers
                 }
             );
             await TestSuccessfulReadOperation(NAV_FILE_WITH_ESCAPED_HREF_IN_A_ELEMENT, expectedEpub3NavDocument);
+        }
+
+        [Fact(DisplayName = "Reading a NAV file with non-top-level 'nav' element should succeed")]
+        public async Task ReadEpub3NavDocumentAsyncWithNonTopLevelNavElementTest()
+        {
+            await TestSuccessfulReadOperation(NAV_FILE_WITH_WITH_NON_TOP_LEVEL_NAV_ELEMENT, MinimalEpub3NavDocumentWithHeader);
         }
 
         private static async Task TestSuccessfulReadOperation(string navFileContent, Epub3NavDocument expectedEpub3NavDocument, EpubReaderOptions? epubReaderOptions = null)

--- a/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
+++ b/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs
@@ -49,12 +49,24 @@ namespace VersOne.Epub.Internal
             XElement htmlNode = navDocument.Element(xhtmlNamespace + "html") ?? throw new Epub3NavException("EPUB parsing error: navigation file does not contain html element.");
             XElement bodyNode = htmlNode.Element(xhtmlNamespace + "body") ?? throw new Epub3NavException("EPUB parsing error: navigation file does not contain body element.");
             List<Epub3Nav> navs = new();
-            foreach (XElement navNode in bodyNode.Elements(xhtmlNamespace + "nav"))
-            {
-                Epub3Nav epub3Nav = ReadEpub3Nav(navNode);
-                navs.Add(epub3Nav);
-            }
+            ReadEpub3NavsWithinContainerElement(bodyNode, navs);
             return new(navFileEntryPath, navs);
+        }
+
+        private static void ReadEpub3NavsWithinContainerElement(XElement containerElement, List<Epub3Nav> resultNavs)
+        {
+            foreach (XElement childElement in containerElement.Elements())
+            {
+                if (childElement.GetLowerCaseLocalName() == "nav")
+                {
+                    Epub3Nav epub3Nav = ReadEpub3Nav(childElement);
+                    resultNavs.Add(epub3Nav);
+                }
+                else
+                {
+                    ReadEpub3NavsWithinContainerElement(childElement, resultNavs);
+                }
+            }
         }
 
         private static Epub3Nav ReadEpub3Nav(XElement navNode)


### PR DESCRIPTION
# Parse `<nav>` elements nested in other HTML elements in EPUB 3 navigation documents

This is:
- [x] a bug fix
- [ ] an enhancement

Related issue: #106

## Description

When EpubReader parses a EPUB 3 navigation file, it expects to find a `<nav epub:type="toc">` element [among the children](https://github.com/vers-one/EpubReader/blob/8b7376de6a3f00eb4659acb1bcbf1d25adf07cb0/Source/VersOne.Epub/Readers/Epub3NavDocumentReader.cs#L53) of the `<body>` element. However, if the `<nav>` element is wrapped in another HTML element (e.g. `<div>`), EpubReader won't be able to find it. The EPUB 3 specification doesn't specify whether `<nav>` elements can be wrapped in other elements, but since it doesn't prohibit it, EpubReader should support this case.

This pull request adds a recursive search for all `<nav>` elements within the EPUB 3 navigation file.

## Testing steps

1. Use the **toc.xhtml** file from the linked issue to test the parsing of a `<nav>` element is wrapped in a `<div>`.
2. Run the newly added unit test (`Epub3NavDocumentReaderTests.ReadEpub3NavDocumentAsyncWithNonTopLevelNavElementTest`).