### PR TITLE
Migrate tests, console demo app, and GitHub actions to .NET 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7
+          dotnet-version: 9
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Restore dependencies

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7
+          dotnet-version: 9
       - name: Restore dependencies
         run: dotnet restore .\Source\VersOne.Epub\VersOne.Epub.csproj
       - name: Install DocFX

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7
+          dotnet-version: 9
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7
+          dotnet-version: 9
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Restore dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7
+          dotnet-version: 9
       - name: Build test project and its dependencies
         run: dotnet build Source\VersOne.Epub.Test -c $env:Configuration
       - name: Run unit tests

--- a/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
+++ b/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
-		<RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+		<TargetFramework>net9.0</TargetFramework>
 		<Authors>vers</Authors>
 		<Copyright>vers, 2015-2024</Copyright>
 		<Version>3.3.2</Version>

--- a/Source/VersOne.Epub.Test/VersOne.Epub.Test.csproj
+++ b/Source/VersOne.Epub.Test/VersOne.Epub.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Authors>vers</Authors>
         <Copyright>vers, 2015-2024</Copyright>
         <Version>3.3.2</Version>

--- a/Source/VersOne.Epub/VersOne.Epub.csproj
+++ b/Source/VersOne.Epub/VersOne.Epub.csproj
@@ -11,6 +11,7 @@
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
         <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
+        <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414">


### PR DESCRIPTION
# Migrate tests, console demo app, and GitHub actions to .NET 9

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #117

## Description

This pull request:
1. Changes the target framework for *VersOne.Epub.ConsoleDemo* and *VersOne.Epub.Test* projects from .NET 7 to .NET 9.
2. Updates all GitHub actions to use .NET 9 instead of .NET 7.
3. Sets the `CheckNotRecommendedTargetFramework` property to `false` in the *VersOne.Epub* project to disable the build warning because we still need to support .NET Standard 1.3 for some time.

## Testing steps

Build and test actions should pass.