### PR TITLE
Add `EpubReaderOptionsPreset` enum

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -28,6 +28,9 @@ dotnet_diagnostic.IDE0060.severity = error
 # IDE0090: Use 'new(...)'
 dotnet_diagnostic.IDE0090.severity = error
 
+# IDE0130: Namespace does not match folder structure
+dotnet_style_namespace_match_folder = false
+
 # S1168: Empty arrays and collections should be returned instead of null
 dotnet_diagnostic.S1168.severity = none
 

--- a/Source/VersOne.Epub/EpubReader.cs
+++ b/Source/VersOne.Epub/EpubReader.cs
@@ -23,9 +23,24 @@ namespace VersOne.Epub
         /// Opens the book synchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
         /// </summary>
         /// <param name="filePath">Path to the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
+        public static EpubBookRef OpenBook(string filePath, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookRefReader bookRefReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookRefReader.OpenBook(filePath);
+        }
+
+        /// <summary>
+        /// Opens the book synchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
+        /// </summary>
+        /// <param name="filePath">Path to the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
-        public static EpubBookRef OpenBook(string filePath, EpubReaderOptions? epubReaderOptions = null)
+        public static EpubBookRef OpenBook(string filePath, EpubReaderOptions? epubReaderOptions)
         {
             BookRefReader bookRefReader = new(environmentDependencies, epubReaderOptions);
             return bookRefReader.OpenBook(filePath);
@@ -35,9 +50,24 @@ namespace VersOne.Epub
         /// Opens the book synchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
         /// </summary>
         /// <param name="stream">Seekable stream containing the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
+        public static EpubBookRef OpenBook(Stream stream, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookRefReader bookRefReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookRefReader.OpenBook(stream);
+        }
+
+        /// <summary>
+        /// Opens the book synchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
+        /// </summary>
+        /// <param name="stream">Seekable stream containing the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
-        public static EpubBookRef OpenBook(Stream stream, EpubReaderOptions? epubReaderOptions = null)
+        public static EpubBookRef OpenBook(Stream stream, EpubReaderOptions? epubReaderOptions)
         {
             BookRefReader bookRefReader = new(environmentDependencies, epubReaderOptions);
             return bookRefReader.OpenBook(stream);
@@ -47,9 +77,24 @@ namespace VersOne.Epub
         /// Opens the book asynchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
         /// </summary>
         /// <param name="filePath">Path to the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
+        public static Task<EpubBookRef> OpenBookAsync(string filePath, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookRefReader bookRefReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookRefReader.OpenBookAsync(filePath);
+        }
+
+        /// <summary>
+        /// Opens the book asynchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
+        /// </summary>
+        /// <param name="filePath">Path to the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
-        public static Task<EpubBookRef> OpenBookAsync(string filePath, EpubReaderOptions? epubReaderOptions = null)
+        public static Task<EpubBookRef> OpenBookAsync(string filePath, EpubReaderOptions? epubReaderOptions)
         {
             BookRefReader bookRefReader = new(environmentDependencies, epubReaderOptions);
             return bookRefReader.OpenBookAsync(filePath);
@@ -59,9 +104,24 @@ namespace VersOne.Epub
         /// Opens the book asynchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
         /// </summary>
         /// <param name="stream">Seekable stream containing the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
+        public static Task<EpubBookRef> OpenBookAsync(Stream stream, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookRefReader bookRefReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookRefReader.OpenBookAsync(stream);
+        }
+
+        /// <summary>
+        /// Opens the book asynchronously without reading its content. The object returned by this method holds a handle to the EPUB file.
+        /// </summary>
+        /// <param name="stream">Seekable stream containing the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book reference. This object holds a handle to the EPUB file.</returns>
-        public static Task<EpubBookRef> OpenBookAsync(Stream stream, EpubReaderOptions? epubReaderOptions = null)
+        public static Task<EpubBookRef> OpenBookAsync(Stream stream, EpubReaderOptions? epubReaderOptions)
         {
             BookRefReader bookRefReader = new(environmentDependencies, epubReaderOptions);
             return bookRefReader.OpenBookAsync(stream);
@@ -71,9 +131,24 @@ namespace VersOne.Epub
         /// Opens the book synchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
         /// </summary>
         /// <param name="filePath">Path to the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
+        public static EpubBook ReadBook(string filePath, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookReader bookReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookReader.ReadBook(filePath);
+        }
+
+        /// <summary>
+        /// Opens the book synchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
+        /// </summary>
+        /// <param name="filePath">Path to the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
-        public static EpubBook ReadBook(string filePath, EpubReaderOptions? epubReaderOptions = null)
+        public static EpubBook ReadBook(string filePath, EpubReaderOptions? epubReaderOptions)
         {
             BookReader bookReader = new(environmentDependencies, epubReaderOptions);
             return bookReader.ReadBook(filePath);
@@ -83,9 +158,24 @@ namespace VersOne.Epub
         /// Opens the book synchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
         /// </summary>
         /// <param name="stream">Seekable stream containing the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
+        public static EpubBook ReadBook(Stream stream, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookReader bookReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookReader.ReadBook(stream);
+        }
+
+        /// <summary>
+        /// Opens the book synchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
+        /// </summary>
+        /// <param name="stream">Seekable stream containing the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
-        public static EpubBook ReadBook(Stream stream, EpubReaderOptions? epubReaderOptions = null)
+        public static EpubBook ReadBook(Stream stream, EpubReaderOptions? epubReaderOptions)
         {
             BookReader bookReader = new(environmentDependencies, epubReaderOptions);
             return bookReader.ReadBook(stream);
@@ -95,9 +185,24 @@ namespace VersOne.Epub
         /// Opens the book asynchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
         /// </summary>
         /// <param name="filePath">Path to the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
+        public static Task<EpubBook> ReadBookAsync(string filePath, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookReader bookReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookReader.ReadBookAsync(filePath);
+        }
+
+        /// <summary>
+        /// Opens the book asynchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
+        /// </summary>
+        /// <param name="filePath">Path to the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
-        public static Task<EpubBook> ReadBookAsync(string filePath, EpubReaderOptions? epubReaderOptions = null)
+        public static Task<EpubBook> ReadBookAsync(string filePath, EpubReaderOptions? epubReaderOptions)
         {
             BookReader bookReader = new(environmentDependencies, epubReaderOptions);
             return bookReader.ReadBookAsync(filePath);
@@ -107,9 +212,24 @@ namespace VersOne.Epub
         /// Opens the book asynchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
         /// </summary>
         /// <param name="stream">Seekable stream containing the EPUB file.</param>
+        /// <param name="epubReaderOptionsPreset">
+        /// A preset to configure the behavior of the EPUB reader.
+        /// Default value is <c>EpubReaderOptionsPreset.RELAXED</c>.
+        /// </param>
+        /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
+        public static Task<EpubBook> ReadBookAsync(Stream stream, EpubReaderOptionsPreset epubReaderOptionsPreset = EpubReaderOptionsPreset.RELAXED)
+        {
+            BookReader bookReader = new(environmentDependencies, new EpubReaderOptions(epubReaderOptionsPreset));
+            return bookReader.ReadBookAsync(stream);
+        }
+
+        /// <summary>
+        /// Opens the book asynchronously and reads all of its content into the memory. The object returned by this method does not retain a handle to the EPUB file.
+        /// </summary>
+        /// <param name="stream">Seekable stream containing the EPUB file.</param>
         /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <returns>EPUB book with all its content. This object does not retain a handle to the EPUB file.</returns>
-        public static Task<EpubBook> ReadBookAsync(Stream stream, EpubReaderOptions? epubReaderOptions = null)
+        public static Task<EpubBook> ReadBookAsync(Stream stream, EpubReaderOptions? epubReaderOptions)
         {
             BookReader bookReader = new(environmentDependencies, epubReaderOptions);
             return bookReader.ReadBookAsync(stream);

--- a/Source/VersOne.Epub/Options/ContentDownloaderOptions.cs
+++ b/Source/VersOne.Epub/Options/ContentDownloaderOptions.cs
@@ -1,4 +1,5 @@
-﻿using VersOne.Epub.Environment;
+﻿using System.Diagnostics.CodeAnalysis;
+using VersOne.Epub.Environment;
 
 namespace VersOne.Epub.Options
 {
@@ -7,6 +8,18 @@ namespace VersOne.Epub.Options
     /// </summary>
     public class ContentDownloaderOptions
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContentDownloaderOptions" /> class.
+        /// </summary>
+        /// <param name="preset">An optional preset to initialize the <see cref="ContentDownloaderOptions" /> class with a predefined set of options.</param>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Temporarily ignore unused 'preset' parameter.")]
+        public ContentDownloaderOptions(EpubReaderOptionsPreset? preset = null)
+        {
+            DownloadContent = false;
+            DownloaderUserAgent = null;
+            CustomContentDownloader = null;
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether the content downloader should download remote resources specified in the EPUB manifest.
         /// If it's set to <c>false</c>, then <see cref="EpubRemoteTextContentFile.Content" /> and <see cref="EpubRemoteByteContentFile.Content" /> will always be <c>null</c>

--- a/Source/VersOne.Epub/Options/ContentReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/ContentReaderOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace VersOne.Epub.Options
 {
@@ -7,6 +8,15 @@ namespace VersOne.Epub.Options
     /// </summary>
     public class ContentReaderOptions
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContentReaderOptions" /> class.
+        /// </summary>
+        /// <param name="preset">An optional preset to initialize the <see cref="ContentReaderOptions" /> class with a predefined set of options.</param>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Temporarily ignore unused 'preset' parameter.")]
+        public ContentReaderOptions(EpubReaderOptionsPreset? preset = null)
+        {
+        }
+
         /// <summary>
         /// Occurs when a local content file is listed in the EPUB manifest but the content reader is unable to find it in the EPUB archive.
         /// This event lets the application to be notified of such errors and to decide how EPUB content reader should handle the missing file.

--- a/Source/VersOne.Epub/Options/Epub2NcxReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/Epub2NcxReaderOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace VersOne.Epub.Options
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace VersOne.Epub.Options
 {
     /// <summary>
     /// Various options to configure the behavior of the EPUB 2 NCX navigation document reader.
@@ -8,7 +10,9 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Epub2NcxReaderOptions" /> class.
         /// </summary>
-        public Epub2NcxReaderOptions()
+        /// <param name="preset">An optional preset to initialize the <see cref="Epub2NcxReaderOptions" /> class with a predefined set of options.</param>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Temporarily ignore unused 'preset' parameter.")]
+        public Epub2NcxReaderOptions(EpubReaderOptionsPreset? preset = null)
         {
             IgnoreMissingContentForNavigationPoints = false;
         }

--- a/Source/VersOne.Epub/Options/EpubReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/EpubReaderOptions.cs
@@ -8,13 +8,14 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="EpubReaderOptions" /> class.
         /// </summary>
-        public EpubReaderOptions()
+        /// <param name="preset">An optional preset to initialize the <see cref="EpubReaderOptions" /> class with a predefined set of options.</param>
+        public EpubReaderOptions(EpubReaderOptionsPreset? preset = null)
         {
-            PackageReaderOptions = new PackageReaderOptions();
-            ContentReaderOptions = new ContentReaderOptions();
-            ContentDownloaderOptions = new ContentDownloaderOptions();
-            Epub2NcxReaderOptions = new Epub2NcxReaderOptions();
-            XmlReaderOptions = new XmlReaderOptions();
+            PackageReaderOptions = new PackageReaderOptions(preset);
+            ContentReaderOptions = new ContentReaderOptions(preset);
+            ContentDownloaderOptions = new ContentDownloaderOptions(preset);
+            Epub2NcxReaderOptions = new Epub2NcxReaderOptions(preset);
+            XmlReaderOptions = new XmlReaderOptions(preset);
         }
 
         /// <summary>

--- a/Source/VersOne.Epub/Options/EpubReaderOptionsPreset.cs
+++ b/Source/VersOne.Epub/Options/EpubReaderOptionsPreset.cs
@@ -1,0 +1,23 @@
+﻿namespace VersOne.Epub.Options
+{
+    /// <summary>
+    /// A predefined set of options for the <see cref="EpubReaderOptions" /> class.
+    /// </summary>
+    public enum EpubReaderOptionsPreset
+    {
+        /// <summary>
+        /// Ignore EPUB validation errors that are most common in the real-world EPUB books. This is the default option.
+        /// </summary>
+        RELAXED = 1,
+
+        /// <summary>
+        /// All EPUB validation checks are enabled. If the file doesn't conform to the EPUB standard, an exception will be thrown.
+        /// </summary>
+        STRICT = 2,
+
+        /// <summary>
+        /// Turn off all EPUB validation checks. EpubReader will try to salvage as much data as possible without throwing any EPUB validation exceptions.
+        /// </summary>
+        IGNORE_ALL_ERRORS = 3
+    }
+}

--- a/Source/VersOne.Epub/Options/PackageReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/PackageReaderOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace VersOne.Epub.Options
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace VersOne.Epub.Options
 {
     /// <summary>
     /// Various options to configure the behavior of the EPUB package reader.
@@ -8,7 +10,9 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="PackageReaderOptions" /> class.
         /// </summary>
-        public PackageReaderOptions()
+        /// <param name="preset">An optional preset to initialize the <see cref="PackageReaderOptions" /> class with a predefined set of options.</param>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Temporarily ignore unused 'preset' parameter.")]
+        public PackageReaderOptions(EpubReaderOptionsPreset? preset = null)
         {
             IgnoreMissingToc = false;
             SkipInvalidManifestItems = false;

--- a/Source/VersOne.Epub/Options/XmlReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/XmlReaderOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace VersOne.Epub.Options
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace VersOne.Epub.Options
 {
     /// <summary>
     /// Various options to configure how EPUB reader handles XML files.
@@ -8,7 +10,9 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlReaderOptions" /> class.
         /// </summary>
-        public XmlReaderOptions()
+        /// <param name="preset">An optional preset to initialize the <see cref="XmlReaderOptions" /> class with a predefined set of options.</param>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Temporarily ignore unused 'preset' parameter.")]
+        public XmlReaderOptions(EpubReaderOptionsPreset? preset = null)
         {
             SkipXmlHeaders = false;
         }


### PR DESCRIPTION
# Add `EpubReaderOptionsPreset` enum

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #95

## Description

This pull request creates the `EpubReaderOptionsPreset` enum that will be used to control the initialization of the `EpubReaderOptions` class in the subsequent PRs.

## Testing steps

No observable runtime changes yet.