### PR TITLE
Add the configuration option to ignore the error for missing manifest item referenced by EPUB spine item

### DIFF
--- a/Source/VersOne.Epub/Entities/EpubBookRef.cs
+++ b/Source/VersOne.Epub/Entities/EpubBookRef.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using VersOne.Epub.Environment;
 using VersOne.Epub.Internal;
+using VersOne.Epub.Options;
 
 namespace VersOne.Epub
 {
@@ -24,12 +25,15 @@ namespace VersOne.Epub
         /// <param name="description">The book's description or <c>null</c> if the description is not present in the book.</param>
         /// <param name="schema">The parsed EPUB schema of the book.</param>
         /// <param name="content">The collection of references to the book's content files within the EPUB archive.</param>
+        /// <param name="epubReaderOptions">Various options to configure the behavior of the EPUB reader.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="epubFile" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="title" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="author" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="schema" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="content" /> parameter is <c>null</c>.</exception>
-        public EpubBookRef(IZipFile epubFile, string? filePath, string title, string author, List<string>? authorList, string? description, EpubSchema schema, EpubContentRef content)
+        public EpubBookRef(
+            IZipFile epubFile, string? filePath, string title, string author, List<string>? authorList, string? description, EpubSchema schema,
+            EpubContentRef content, EpubReaderOptions? epubReaderOptions = null)
         {
             EpubFile = epubFile ?? throw new ArgumentNullException(nameof(epubFile));
             FilePath = filePath;
@@ -39,6 +43,7 @@ namespace VersOne.Epub
             Description = description;
             Schema = schema ?? throw new ArgumentNullException(nameof(schema));
             Content = content ?? throw new ArgumentNullException(nameof(content));
+            EpubReaderOptions = epubReaderOptions ?? new EpubReaderOptions();
             isDisposed = false;
         }
 
@@ -91,6 +96,11 @@ namespace VersOne.Epub
         public IZipFile EpubFile { get; }
 
         /// <summary>
+        /// Gets the options that configure the behavior of the EPUB reader.
+        /// </summary>
+        public EpubReaderOptions EpubReaderOptions { get; }
+
+        /// <summary>
         /// Loads the book's cover image from the EPUB file.
         /// </summary>
         /// <returns>Book's cover image or <c>null</c> if there is no cover.</returns>
@@ -132,7 +142,7 @@ namespace VersOne.Epub
         /// </returns>
         public async Task<List<EpubLocalTextContentFileRef>> GetReadingOrderAsync()
         {
-            return await Task.Run(() => SpineReader.GetReadingOrder(Schema, Content)).ConfigureAwait(false);
+            return await Task.Run(() => SpineReader.GetReadingOrder(Schema, Content, EpubReaderOptions.SpineReaderOptions)).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/VersOne.Epub/Options/EpubReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/EpubReaderOptions.cs
@@ -11,18 +11,14 @@
         /// <param name="preset">An optional preset to initialize the <see cref="EpubReaderOptions" /> class with a predefined set of options.</param>
         public EpubReaderOptions(EpubReaderOptionsPreset? preset = null)
         {
-            BookCoverReaderOptions = new BookCoverReaderOptions(preset);
             PackageReaderOptions = new PackageReaderOptions(preset);
             ContentReaderOptions = new ContentReaderOptions(preset);
             ContentDownloaderOptions = new ContentDownloaderOptions(preset);
+            BookCoverReaderOptions = new BookCoverReaderOptions(preset);
+            SpineReaderOptions = new SpineReaderOptions(preset);
             Epub2NcxReaderOptions = new Epub2NcxReaderOptions(preset);
             XmlReaderOptions = new XmlReaderOptions(preset);
         }
-
-        /// <summary>
-        /// Gets or sets EPUB content reader options which is used for loading the EPUB book cover image.
-        /// </summary>
-        public BookCoverReaderOptions BookCoverReaderOptions { get; set; }
 
         /// <summary>
         /// Gets or sets EPUB OPF package reader options.
@@ -38,6 +34,16 @@
         /// Gets or sets EPUB content downloader options which is used for downloading remote content files.
         /// </summary>
         public ContentDownloaderOptions ContentDownloaderOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets EPUB content reader options which is used for loading the EPUB book cover image.
+        /// </summary>
+        public BookCoverReaderOptions BookCoverReaderOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets EPUB spine reader options which is used for parsing the default reading order of the EPUB book.
+        /// </summary>
+        public SpineReaderOptions SpineReaderOptions { get; set; }
 
         /// <summary>
         /// Gets or sets EPUB 2 NCX navigation document reader options.

--- a/Source/VersOne.Epub/Options/SpineReaderOptions.cs
+++ b/Source/VersOne.Epub/Options/SpineReaderOptions.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace VersOne.Epub.Options
+{
+    /// <summary>
+    /// Various options to configure the behavior of the EPUB spine reader which is used for parsing the &lt;spine&gt; section
+    /// of the EPUB OPF package file. This section represents the default reading order of the EPUB book.
+    /// </summary>
+    public class SpineReaderOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpineReaderOptions"/> class.
+        /// </summary>
+        /// <param name="preset">An optional preset to initialize the <see cref="SpineReaderOptions" /> class with a predefined set of options.</param>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Temporarily ignore unused 'preset' parameter.")]
+        public SpineReaderOptions(EpubReaderOptionsPreset? preset = null)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether EPUB spine reader should ignore the error when the manifest item referenced by
+        /// a EPUB spine item is missing.
+        /// If it's set to <c>false</c> and the manifest item with the given ID is not present, then
+        /// the "Incorrect EPUB spine: item with IdRef = "..." is missing in the manifest" exception will be thrown.
+        /// Default value is <c>false</c>.
+        /// </summary>
+        public bool IgnoreMissingManifestItems { get; set; }
+    }
+}

--- a/Source/VersOne.Epub/Readers/BookRefReader.cs
+++ b/Source/VersOne.Epub/Readers/BookRefReader.cs
@@ -54,7 +54,7 @@ namespace VersOne.Epub.Internal
             string? description = schema.Package.Metadata.Descriptions.FirstOrDefault()?.Description;
             ContentReader contentReader = new(environmentDependencies, epubReaderOptions);
             EpubContentRef content = await Task.Run(() => contentReader.ParseContentMap(schema, epubFile)).ConfigureAwait(false);
-            return new(epubFile, filePath, title, author, authorList, description, schema, content);
+            return new(epubFile, filePath, title, author, authorList, description, schema, content, epubReaderOptions);
         }
 
         private IZipFile GetZipFile(string filePath)

--- a/Source/VersOne.Epub/Readers/SpineReader.cs
+++ b/Source/VersOne.Epub/Readers/SpineReader.cs
@@ -1,17 +1,26 @@
 ﻿using System.Collections.Generic;
+using VersOne.Epub.Options;
 using VersOne.Epub.Schema;
 
 namespace VersOne.Epub.Internal
 {
     internal static class SpineReader
     {
-        public static List<EpubLocalTextContentFileRef> GetReadingOrder(EpubSchema epubSchema, EpubContentRef epubContentRef)
+        public static List<EpubLocalTextContentFileRef> GetReadingOrder(
+            EpubSchema epubSchema, EpubContentRef epubContentRef, SpineReaderOptions spineReaderOptions)
         {
             List<EpubLocalTextContentFileRef> result = new();
             foreach (EpubSpineItemRef spineItemRef in epubSchema.Package.Spine.Items)
             {
-                EpubManifestItem manifestItem = epubSchema.Package.Manifest.Items.Find(item => item.Id == spineItemRef.IdRef) ??
+                EpubManifestItem? manifestItem = epubSchema.Package.Manifest.Items.Find(item => item.Id == spineItemRef.IdRef);
+                if (manifestItem == null)
+                {
+                    if (spineReaderOptions.IgnoreMissingManifestItems)
+                    {
+                        continue;
+                    }
                     throw new EpubPackageException($"Incorrect EPUB spine: item with IdRef = \"{spineItemRef.IdRef}\" is missing in the manifest.");
+                }
                 if (epubContentRef.Html.ContainsRemoteFileRefWithUrl(manifestItem.Href))
                 {
                     throw new EpubPackageException($"Incorrect EPUB manifest: EPUB spine item \"{manifestItem.Href}\" cannot be a remote resource.");


### PR DESCRIPTION
# Add the configuration option to ignore the error for missing manifest item referenced by EPUB spine item

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #109

## Description

The `<spine>` section in the EPUB OPF package file represents the default reading order of the EPUB book. Each item inside that section references a manifest item from the same OPF package file:
```xml
<itemref idref="manifest-item-id" />
```

(see this section in the EPUB specification for more details: https://www.w3.org/TR/epub/#sec-pkg-spine)

If the manifest item referenced by a spine item is missing, EpubReader is throwing a `EpubReader` with the following message:
```text
Incorrect EPUB spine: item with IdRef = "manifest-item-id" is missing in the manifest.
```

This pull request adds the `SpineReaderOptions.IgnoreMissingManifestItems` property to let the applications ignore this error. The default value of this property is `false`.

## Testing steps

Try to open a EPUB book with the spine item above.