### PR TITLE
Migrate from docfx.console package to docfx tool

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore .\Source\VersOne.Epub\VersOne.Epub.csproj
       - name: Install DocFX
-        run: nuget install docfx.console -x
+        run: dotnet tool install -g docfx
       - name: Run DocFX
-        run: docfx.console\tools\docfx.exe Documentation\docfx.json
+        run: docfx build Documentation\docfx.json
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
Migrate from docfx.console package to docfx tool

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #124

## Description

This pull request replaces the `docfx.console` package with the `docfx` tool in the "Generate documentation" action.

## Testing steps

Run the "Generate documentation" action and check the documentation website.