### PR TITLE
Update documentation API links

### DIFF
--- a/Documentation/docfx.json
+++ b/Documentation/docfx.json
@@ -23,13 +23,13 @@
                 "files": [
                     "*.md",
                     "toc.yml",
-                    "getting-started/**.md",
-                    "reference/**.md",
-                    "reference/**.yml",
-                    "examples/**.md",
+                    "getting-started/*.md",
+                    "reference/*.md",
+                    "reference/*.yml",
+                    "examples/*.md",
                     "examples/toc.yml",
-                    "malformed-epub/**.md",
-                    "faq/**.md"
+                    "malformed-epub/*.md",
+                    "faq/*.md"
                 ]
             }
         ],
@@ -49,8 +49,8 @@
             "default",
             "templates/default"
         ],
-        "xrefService": [
-            "https://xref.docs.microsoft.com/query?uid={uid}"
+        "xref": [
+            "https://learn.microsoft.com/en-us/dotnet/.xrefmap.json"
         ],
         "postProcessors": [],
         "markdownEngineName": "markdig",

--- a/Documentation/malformed-epub/index.md
+++ b/Documentation/malformed-epub/index.md
@@ -37,18 +37,18 @@ EpubReaderOptions options = new()
 ## Missing content files
 
 The [`item` element](https://www.w3.org/publishing/epub32/epub-packages.html#sec-item-elem) within the EPUB manifest has a required `href` attribute which points to a content file in the EPUB archive. There are [some EPUB books](https://github.com/vers-one/EpubReader/issues/25) that declare content files in the EPUB manifest which do not exist in the actual EPUB archive. This causes EpubReader to throw the *"EPUB parsing error: file ... was not found in the EPUB file"* exception. Such exception is thrown immediately, if application uses [`EpubReader.ReadBook`](xref:VersOne.Epub.EpubReader#VersOne_Epub_EpubReader_ReadBook_System_IO_Stream_VersOne_Epub_Options_EpubReaderOptions_) / [`EpubReader.ReadBookAsync`](xref:VersOne.Epub.EpubReader#VersOne_Epub_EpubReader_ReadBookAsync_System_IO_Stream_VersOne_Epub_Options_EpubReaderOptions_) methods because they try to load the whole content of the book into memory. [`EpubReader.OpenBook`](xref:VersOne.Epub.EpubReader#VersOne_Epub_EpubReader_OpenBook_System_IO_Stream_VersOne_Epub_Options_EpubReaderOptions_) and [`EpubReader.OpenBookAsync`](xref:VersOne.Epub.EpubReader#VersOne_Epub_EpubReader_OpenBookAsync_System_IO_Stream_VersOne_Epub_Options_EpubReaderOptions_) methods don't load the content, so the exception will be thrown only during an attempt to call any of those methods for a missing file:
-* [`EpubContentFileRef`](xref:VersOne.Epub.EpubContentFileRef) class:
-  * [`GetContentStream`](xref:VersOne.Epub.EpubContentFileRef#VersOne_Epub_EpubContentFileRef_GetContentStream)
-  * [`ReadContentAsBytes`](xref:VersOne.Epub.EpubContentFileRef#VersOne_Epub_EpubContentFileRef_ReadContentAsBytes)
-  * [`ReadContentAsBytesAsync`](xref:VersOne.Epub.EpubContentFileRef#VersOne_Epub_EpubContentFileRef_ReadContentAsBytesAsync)
-  * [`ReadContentAsText`](xref:VersOne.Epub.EpubContentFileRef#VersOne_Epub_EpubContentFileRef_ReadContentAsText)
-  * [`ReadContentAsTextAsync`](xref:VersOne.Epub.EpubContentFileRef#VersOne_Epub_EpubContentFileRef_ReadContentAsTextAsync)
-* [`EpubByteContentFileRef`](xref:VersOne.Epub.EpubByteContentFileRef) class:
-  * [`ReadContent`](xref:VersOne.Epub.EpubByteContentFileRef#VersOne_Epub_EpubByteContentFileRef_ReadContent)
-  * [`ReadContentAsync`](xref:VersOne.Epub.EpubByteContentFileRef#VersOne_Epub_EpubByteContentFileRef_ReadContentAsync)
-* [`EpubTextContentFileRef`](xref:VersOne.Epub.EpubTextContentFileRef) class:
-  * [`ReadContent`](xref:VersOne.Epub.EpubTextContentFileRef#VersOne_Epub_EpubTextContentFileRef_ReadContent)
-  * [`ReadContentAsync`](xref:VersOne.Epub.EpubTextContentFileRef#VersOne_Epub_EpubTextContentFileRef_ReadContentAsync)
+* [`EpubLocalContentFileRef`](xref:VersOne.Epub.EpubLocalContentFileRef) class:
+  * [`GetContentStream`](xref:VersOne.Epub.EpubLocalContentFileRef#VersOne_Epub_EpubLocalContentFileRef_GetContentStream)
+  * [`ReadContentAsBytes`](xref:VersOne.Epub.EpubLocalContentFileRef#VersOne_Epub_EpubLocalContentFileRef_ReadContentAsBytes)
+  * [`ReadContentAsBytesAsync`](xref:VersOne.Epub.EpubLocalContentFileRef#VersOne_Epub_EpubLocalContentFileRef_ReadContentAsBytesAsync)
+  * [`ReadContentAsText`](xref:VersOne.Epub.EpubLocalContentFileRef#VersOne_Epub_EpubLocalContentFileRef_ReadContentAsText)
+  * [`ReadContentAsTextAsync`](xref:VersOne.Epub.EpubLocalContentFileRef#VersOne_Epub_EpubLocalContentFileRef_ReadContentAsTextAsync)
+* [`EpubLocalByteContentFileRef`](xref:VersOne.Epub.EpubLocalByteContentFileRef) class:
+  * [`ReadContent`](xref:VersOne.Epub.EpubLocalByteContentFileRef#VersOne_Epub_EpubLocalByteContentFileRef_ReadContent)
+  * [`ReadContentAsync`](xref:VersOne.Epub.EpubLocalByteContentFileRef#VersOne_Epub_EpubLocalByteContentFileRef_ReadContentAsync)
+* [`EpubLocalTextContentFileRef`](xref:VersOne.Epub.EpubLocalTextContentFileRef) class:
+  * [`ReadContent`](xref:VersOne.Epub.EpubLocalTextContentFileRef#VersOne_Epub_EpubLocalTextContentFileRef_ReadContent)
+  * [`ReadContentAsync`](xref:VersOne.Epub.EpubLocalTextContentFileRef#VersOne_Epub_EpubLocalTextContentFileRef_ReadContentAsync)
 
 [`ContentReaderOptions.ContentFileMissing`](xref:VersOne.Epub.Options.ContentReaderOptions#VersOne_Epub_Options_ContentReaderOptions_ContentFileMissing) event can be used to detect those issues and to instruct EpubReader how to handle missing content files. Application can choose one of the following options:
 


### PR DESCRIPTION
Update documentation API links

This is:
- [x] a bug fix
- [ ] an enhancement

Related issue: #129

## Description

Some of the API documentation links got outdated. This pull request fixes those links.

## Testing steps

Run the "Generate documentation" action and check the documentation website.