### PR TITLE
Migrate tests, console demo app and GitHub actions to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
       Solution_Name: Source\EpubReader.sln
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9
+          dotnet-version: 10
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Restore dependencies

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9
+          dotnet-version: 10
       - name: Restore dependencies
         run: dotnet restore .\Source\VersOne.Epub\VersOne.Epub.csproj
       - name: Install DocFX
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './Documentation/docfx_output'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -10,13 +10,13 @@ jobs:
       Solution_Name: Source\EpubReader.sln
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9
+          dotnet-version: 10
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       Solution_Name: Source\EpubReader.sln
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9
+          dotnet-version: 10
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Restore dependencies
@@ -33,7 +33,7 @@ jobs:
         run: |
           7z a VersOne.Epub.Net46.zip .\Source\VersOne.Epub\bin\Release\net46\VersOne.Epub.dll
           7z a VersOne.Epub.NetStandard.zip .\Source\VersOne.Epub\bin\Release\netstandard1.3\VersOne.Epub.dll
-          7z a ConsoleDemo.zip .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net9.0\HtmlAgilityPack.dll .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net9.0\VersOne.Epub.dll .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net9.0\VersOne.Epub.ConsoleDemo.dll .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net9.0\VersOne.Epub.ConsoleDemo.exe .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net9.0\VersOne.Epub.ConsoleDemo.deps.json .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net9.0\VersOne.Epub.ConsoleDemo.runtimeconfig.json
+          7z a ConsoleDemo.zip .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net10.0\HtmlAgilityPack.dll .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net10.0\VersOne.Epub.dll .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net10.0\VersOne.Epub.ConsoleDemo.dll .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net10.0\VersOne.Epub.ConsoleDemo.exe .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net10.0\VersOne.Epub.ConsoleDemo.deps.json .\Source\VersOne.Epub.ConsoleDemo\bin\Release\net10.0\VersOne.Epub.ConsoleDemo.runtimeconfig.json
           7z a WpfDemo.zip .\Source\VersOne.Epub.WpfDemo\bin\Release\HtmlRenderer.dll .\Source\VersOne.Epub.WpfDemo\bin\Release\HtmlRenderer.WPF.dll .\Source\VersOne.Epub.WpfDemo\bin\Release\System.IO.Compression.dll .\Source\VersOne.Epub.WpfDemo\bin\Release\VersOne.Epub.dll .\Source\VersOne.Epub.WpfDemo\bin\Release\VersOne.Epub.WpfDemo.exe
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,19 @@ jobs:
       Configuration: Debug
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9
+          dotnet-version: 10
       - name: Build test project and its dependencies
         run: dotnet build Source\VersOne.Epub.Test -c $env:Configuration
       - name: Run unit tests
         run: dotnet test Source\VersOne.Epub.Test --filter Unit --no-restore --collect:"XPlat Code Coverage" --settings Source\VersOne.Epub.Test\coverlet.runsettings
       - name: Upload code coverage result to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run integration tests

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -14,10 +14,10 @@ jobs:
     name: Update versions
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Update project versions
         id: update
-        uses: vers-one/dotnet-project-version-updater@v1.6
+        uses: vers-one/dotnet-project-version-updater@v1.7
         with:
           file: |
             "Source/VersOne.Epub/VersOne.Epub.csproj", "Source/VersOne.Epub/VersOne.Epub.nuspec", "Source/VersOne.Epub.Test/VersOne.Epub.Test.csproj", "Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj", "Source/VersOne.Epub.WpfDemo/Properties/AssemblyInfo.cs"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supported runtimes:
 * .NET Standard >= 1.3 (includes .NET Core >= 1.0 and .NET >= 5)
 * .NET Framework >= 4.6
 
-[Download](#download-the-latest-stable-release) | [Documentation](https://os.vers.one/EpubReader/) | [WPF & .NET 9 console demo apps](#demo-apps)
+[Download](#download-the-latest-stable-release) | [Documentation](https://os.vers.one/EpubReader/) | [WPF & .NET 10 console demo apps](#demo-apps)
 
 ## EpubReader in a nutshell
 ![EpubReader in a nutshell](Documentation/images/epubreader-in-a-nutshell.png)
@@ -31,9 +31,9 @@ Supported runtimes:
 
   HTML renderer used in this demo app may have difficulties while rendering content for some of the books if the HTML structure is too complicated.
 
-* [Download .NET 9 console demo app](https://github.com/vers-one/EpubReader/releases/latest/download/ConsoleDemo.zip) (ConsoleDemo.zip)
+* [Download .NET 10 console demo app](https://github.com/vers-one/EpubReader/releases/latest/download/ConsoleDemo.zip) (ConsoleDemo.zip)
 
-  This .NET 9 console application demonstrates how to open EPUB books and retrieve their text content.
+  This .NET 10 console application demonstrates how to open EPUB books and retrieve their text content.
 
 ## Examples
 1. [How to extract the table of contents.](https://os.vers.one/EpubReader/examples/example-1.html)

--- a/Source/VersOne.Epub.ConsoleDemo/PrintNavigation.cs
+++ b/Source/VersOne.Epub.ConsoleDemo/PrintNavigation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace VersOne.Epub.ConsoleDemo
 {
@@ -9,9 +10,13 @@ namespace VersOne.Epub.ConsoleDemo
             using (EpubBookRef bookRef = EpubReader.OpenBook(filePath))
             {
                 Console.WriteLine("Navigation:");
-                foreach (EpubNavigationItemRef navigationItemRef in bookRef.GetNavigation())
+                List<EpubNavigationItemRef>? navigation = bookRef.GetNavigation();
+                if (navigation != null)
                 {
-                    PrintNavigationItem(navigationItemRef, 0);
+                    foreach (EpubNavigationItemRef navigationItemRef in navigation)
+                    {
+                        PrintNavigationItem(navigationItemRef, 0);
+                    }
                 }
             }
             Console.WriteLine();

--- a/Source/VersOne.Epub.ConsoleDemo/Program.cs
+++ b/Source/VersOne.Epub.ConsoleDemo/Program.cs
@@ -40,10 +40,14 @@ namespace VersOne.Epub.ConsoleDemo
 
         private static void RunFileExample(Action<string> example)
         {
-            Console.Write("Enter the path to the EPUB file: ");
-            string filePath = Console.ReadLine();
+            string? filePath = null;
+            while (filePath == null)
+            {
+                Console.Write("Enter the path to the EPUB file: ");
+                filePath = Console.ReadLine();
+            }
             Console.WriteLine();
-            if (File.Exists(filePath) && Path.GetExtension(filePath).ToLower() == ".epub")
+            if (File.Exists(filePath) && Path.GetExtension(filePath).Equals(".epub", StringComparison.CurrentCultureIgnoreCase))
             {
                 try
                 {
@@ -65,8 +69,12 @@ namespace VersOne.Epub.ConsoleDemo
 
         private static void RunDirectoryExample(Action<string> example)
         {
-            Console.Write("Enter the path to the directory with EPUB files: ");
-            string directoryPath = Console.ReadLine();
+            string? directoryPath = null;
+            while (directoryPath == null)
+            {
+                Console.Write("Enter the path to the directory with EPUB files: ");
+                directoryPath = Console.ReadLine();
+            }
             Console.WriteLine();
             if (Directory.Exists(directoryPath))
             {

--- a/Source/VersOne.Epub.ConsoleDemo/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/VersOne.Epub.ConsoleDemo/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,14 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121.
--->
 <Project>
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <TargetFramework>net9.0</TargetFramework>
-    <PublishDir>bin\Release\net9.0\publish\win-x64\</PublishDir>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishDir>bin\Release\net10.0\publish\win-x64\</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/Source/VersOne.Epub.ConsoleDemo/TestDirectory.cs
+++ b/Source/VersOne.Epub.ConsoleDemo/TestDirectory.cs
@@ -89,10 +89,14 @@ namespace VersOne.Epub.ConsoleDemo
                 Console.WriteLine($"Total files: {bookRef.Content.AllFiles.Local.Count}, HTML files: {bookRef.Content.Html.Local.Count}," +
                     $" CSS files: {bookRef.Content.Css.Local.Count}, image files: {bookRef.Content.Images.Local.Count}, font files: {bookRef.Content.Fonts.Local.Count}.");
                 Console.WriteLine($"Reading order: {bookRef.GetReadingOrder().Count} file(s).");
-                Console.WriteLine("Navigation:");
-                foreach (EpubNavigationItemRef navigationItemRef in bookRef.GetNavigation())
+                List<EpubNavigationItemRef>? navigation = bookRef.GetNavigation();
+                if (navigation != null && navigation.Count > 0)
                 {
-                    PrintNavigationItem(navigationItemRef, 0);
+                    Console.WriteLine("Navigation:");
+                    foreach (EpubNavigationItemRef navigationItemRef in navigation)
+                    {
+                        PrintNavigationItem(navigationItemRef, 0);
+                    }
                 }
             }
             catch (Exception exception)

--- a/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
+++ b/Source/VersOne.Epub.ConsoleDemo/VersOne.Epub.ConsoleDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Authors>vers</Authors>
 		<Copyright>vers, 2015-2024</Copyright>
 		<Version>3.3.4</Version>
@@ -9,6 +9,7 @@
 		<DocumentationFile></DocumentationFile>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
 		<AdditionalFiles Include="stylecop.json" />

--- a/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubLocalContentLoaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubLocalContentLoaderTests.cs
@@ -189,7 +189,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
             };
             EpubLocalContentLoader epubLocalContentLoader = CreateEpubLocalContentLoader(testZipFile, contentReaderOptions);
             byte[] byteContent = epubLocalContentLoader.LoadContentAsBytes(ByteFileRefMetadata);
-            Assert.Equal([], byteContent);
+            Assert.Equal(Array.Empty<byte>(), byteContent);
         }
 
         [Fact(DisplayName = "LoadContentAsBytesAsync should throw EpubContentException if the file is missing in the EPUB archive and no ContentReaderOptions are provided")]
@@ -210,7 +210,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
             };
             EpubLocalContentLoader epubLocalContentLoader = CreateEpubLocalContentLoader(testZipFile, contentReaderOptions);
             byte[] byteContent = await epubLocalContentLoader.LoadContentAsBytesAsync(ByteFileRefMetadata);
-            Assert.Equal([], byteContent);
+            Assert.Equal(Array.Empty<byte>(), byteContent);
         }
 
         [Fact(DisplayName = "GetContentStream should throw EpubContentException if the file is missing in the EPUB archive and no ContentReaderOptions are provided")]
@@ -321,7 +321,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
             };
             EpubLocalContentLoader epubLocalContentLoader = CreateEpubLocalContentLoader(testZipFile, contentReaderOptions);
             byte[] byteContent = epubLocalContentLoader.LoadContentAsBytes(ByteFileRefMetadata);
-            Assert.Equal([], byteContent);
+            Assert.Equal(Array.Empty<byte>(), byteContent);
         }
 
         [Fact(DisplayName = "LoadContentAsBytesAsync should throw EpubContentException if the file is larger than 2 GB and no ContentReaderOptions are provided")]
@@ -344,7 +344,7 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
             };
             EpubLocalContentLoader epubLocalContentLoader = CreateEpubLocalContentLoader(testZipFile, contentReaderOptions);
             byte[] byteContent = await epubLocalContentLoader.LoadContentAsBytesAsync(ByteFileRefMetadata);
-            Assert.Equal([], byteContent);
+            Assert.Equal(Array.Empty<byte>(), byteContent);
         }
 
         [Fact(DisplayName = "GetContentStream should throw EpubContentException if the file is larger than 2 GB and no ContentReaderOptions are provided")]

--- a/Source/VersOne.Epub.Test/VersOne.Epub.Test.csproj
+++ b/Source/VersOne.Epub.Test/VersOne.Epub.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Authors>vers</Authors>
         <Copyright>vers, 2015-2024</Copyright>
         <Version>3.3.4</Version>


### PR DESCRIPTION
# Migrate tests, console demo app, and GitHub actions to .NET 10

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #142

## Description

This pull request:
1. Changes the target framework for *VersOne.Epub.ConsoleDemo* and *VersOne.Epub.Test* projects from .NET 9 to .NET 10.
2. Updates all GitHub actions to use .NET 10 instead of .NET 9.
3. Enables nullable checks for the *VersOne.Epub.Test* project and fixes the compilation errors.

## Testing steps

Build and test actions should pass.