### PR TITLE
Provide access to ZIP archive entry in EpubLocalContentFileRef class

### DIFF
--- a/Source/VersOne.Epub.Test/Comparers/EpubContentRefComparer.cs
+++ b/Source/VersOne.Epub.Test/Comparers/EpubContentRefComparer.cs
@@ -26,6 +26,7 @@
             {
                 Assert.NotNull(actual);
                 Assert.Equal(expected.FilePath, actual.FilePath);
+                Assert.Equal(expected.ContentFileEntry, actual.ContentFileEntry);
             }
         }
 

--- a/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Base/EpubContentFileRefTests.cs
@@ -1,4 +1,5 @@
-﻿using VersOne.Epub.Test.Unit.Mocks;
+﻿using VersOne.Epub.Environment;
+using VersOne.Epub.Test.Unit.Mocks;
 
 namespace VersOne.Epub.Test.Unit.Content.Base
 {
@@ -17,7 +18,7 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         private const EpubContentType BYTE_FILE_CONTENT_TYPE = EpubContentType.IMAGE_JPEG;
         private const string BYTE_FILE_CONTENT_MIME_TYPE = "image/jpeg";
 
-        private static readonly byte[] BYTE_FILE_CONTENT = new byte[] { 0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46 };
+        private static readonly byte[] BYTE_FILE_CONTENT = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46];
 
         private static EpubContentFileRefMetadata LocalTextFileRefMetadata => new(LOCAL_TEXT_FILE_NAME, TEXT_FILE_CONTENT_TYPE, TEXT_FILE_CONTENT_MIME_TYPE);
 
@@ -30,8 +31,11 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "EpubLocalTextContentFileRef constructor should set correct property values")]
         public void LocalTextContentFileRefConstructorTest()
         {
-            EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, new TestEpubContentLoader());
+            IZipFileEntry testContentFileEntry = new TestZipFileEntry();
+            EpubLocalTextContentFileRef epubLocalTextContentFileRef =
+                new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testContentFileEntry, new TestEpubContentLoader());
             Assert.Equal(LOCAL_TEXT_FILE_NAME, epubLocalTextContentFileRef.Key);
+            Assert.Equal(testContentFileEntry, epubLocalTextContentFileRef.ContentFileEntry);
             Assert.Equal(TEXT_FILE_CONTENT_TYPE, epubLocalTextContentFileRef.ContentType);
             Assert.Equal(TEXT_FILE_CONTENT_MIME_TYPE, epubLocalTextContentFileRef.ContentMimeType);
             Assert.Equal(EpubContentLocation.LOCAL, epubLocalTextContentFileRef.ContentLocation);
@@ -42,8 +46,11 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "EpubLocalByteContentFileRef constructor should set correct property values")]
         public void LocalByteContentFileRefConstructorTest()
         {
-            EpubLocalByteContentFileRef epubLocalByteContentFileRef = new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, new TestEpubContentLoader());
+            IZipFileEntry testContentFileEntry = new TestZipFileEntry();
+            EpubLocalByteContentFileRef epubLocalByteContentFileRef =
+                new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testContentFileEntry, new TestEpubContentLoader());
             Assert.Equal(LOCAL_BYTE_FILE_NAME, epubLocalByteContentFileRef.Key);
+            Assert.Equal(testContentFileEntry, epubLocalByteContentFileRef.ContentFileEntry);
             Assert.Equal(BYTE_FILE_CONTENT_TYPE, epubLocalByteContentFileRef.ContentType);
             Assert.Equal(BYTE_FILE_CONTENT_MIME_TYPE, epubLocalByteContentFileRef.ContentMimeType);
             Assert.Equal(EpubContentLocation.LOCAL, epubLocalByteContentFileRef.ContentLocation);
@@ -78,13 +85,13 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "EpubLocalTextContentFileRef constructor should throw ArgumentNullException if the supplied metadata parameter is null")]
         public void CreateEpubLocalTextContentFileRefWithNullMetadataTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubLocalTextContentFileRef(null!, LOCAL_TEXT_FILE_PATH, new TestEpubContentLoader()));
+            Assert.Throws<ArgumentNullException>(() => new EpubLocalTextContentFileRef(null!, LOCAL_TEXT_FILE_PATH, null, new TestEpubContentLoader()));
         }
 
         [Fact(DisplayName = "EpubLocalByteContentFileRef constructor should throw ArgumentNullException if the supplied metadata parameter is null")]
         public void CreateEpubLocalByteContentFileRefWithNullMetadataTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubLocalByteContentFileRef(null!, LOCAL_BYTE_FILE_PATH, new TestEpubContentLoader()));
+            Assert.Throws<ArgumentNullException>(() => new EpubLocalByteContentFileRef(null!, LOCAL_BYTE_FILE_PATH, null, new TestEpubContentLoader()));
         }
 
         [Fact(DisplayName = "EpubRemoteTextContentFileRef constructor should throw ArgumentNullException if the supplied metadata parameter is null")]
@@ -102,13 +109,13 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "EpubLocalTextContentFileRef constructor should throw ArgumentNullException if the supplied epubContentLoader parameter is null")]
         public void CreateEpubLocalTextContentFileRefWithNullContentLoaderTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubLocalTextContentFileRef(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, null!));
+            Assert.Throws<ArgumentNullException>(() => new EpubLocalTextContentFileRef(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, null, null!));
         }
 
         [Fact(DisplayName = "EpubLocalByteContentFileRef constructor should throw ArgumentNullException if the supplied epubContentLoader parameter is null")]
         public void CreateEpubLocalByteContentFileRefWithNullContentLoaderTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubLocalByteContentFileRef(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, null!));
+            Assert.Throws<ArgumentNullException>(() => new EpubLocalByteContentFileRef(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, null, null!));
         }
 
         [Fact(DisplayName = "EpubRemoteTextContentFileRef constructor should throw ArgumentNullException if the supplied epubContentLoader parameter is null")]
@@ -126,20 +133,22 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "EpubLocalTextContentFileRef constructor should throw ArgumentNullException if the supplied file path is null")]
         public void CreateEpubLocalTextContentFileRefWithNullFilePathTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubLocalTextContentFileRef(LocalTextFileRefMetadata, null!, new TestEpubContentLoader()));
+            Assert.Throws<ArgumentNullException>(() => new EpubLocalTextContentFileRef(LocalTextFileRefMetadata, null!, null, new TestEpubContentLoader()));
         }
 
         [Fact(DisplayName = "EpubLocalByteContentFileRef constructor should throw ArgumentNullException if the supplied file path is null")]
         public void CreateEpubLocalByteContentFileRefWithNullFilePathTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubLocalByteContentFileRef(LocalByteFileRefMetadata, null!, new TestEpubContentLoader()));
+            Assert.Throws<ArgumentNullException>(() => new EpubLocalByteContentFileRef(LocalByteFileRefMetadata, null!, null, new TestEpubContentLoader()));
         }
 
         [Fact(DisplayName = "Reading local text content file synchronously should succeed")]
         public void LocalTextContentFileRefReadContentTest()
         {
+            TestZipFileEntry testZipFileEntry = new(TEXT_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
-            EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
+            EpubLocalTextContentFileRef epubLocalTextContentFileRef =
+                new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             string content = epubLocalTextContentFileRef.ReadContent();
             Assert.Equal(TEXT_FILE_CONTENT, content);
         }
@@ -147,8 +156,10 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Reading local text content file asynchronously should succeed")]
         public async Task LocalTextContentFileRefReadContentAsyncTest()
         {
+            TestZipFileEntry testZipFileEntry = new(TEXT_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
-            EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
+            EpubLocalTextContentFileRef epubLocalTextContentFileRef =
+                new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             string content = await epubLocalTextContentFileRef.ReadContentAsync();
             Assert.Equal(TEXT_FILE_CONTENT, content);
         }
@@ -156,8 +167,10 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Reading local byte content file synchronously should succeed")]
         public void LocalByteContentFileRefReadContentTest()
         {
+            TestZipFileEntry testZipFileEntry = new(BYTE_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
-            EpubLocalByteContentFileRef epubLocalByteContentFileRef = new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testEpubContentLoader);
+            EpubLocalByteContentFileRef epubLocalByteContentFileRef =
+                new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             byte[] content = epubLocalByteContentFileRef.ReadContent();
             Assert.Equal(BYTE_FILE_CONTENT, content);
         }
@@ -165,8 +178,10 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Reading local byte content file asynchronously should succeed")]
         public async Task LocalByteContentFileRefReadContentAsyncTest()
         {
+            TestZipFileEntry testZipFileEntry = new(BYTE_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
-            EpubLocalByteContentFileRef epubLocalByteContentFileRef = new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testEpubContentLoader);
+            EpubLocalByteContentFileRef epubLocalByteContentFileRef =
+                new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             byte[] content = await epubLocalByteContentFileRef.ReadContentAsync();
             Assert.Equal(BYTE_FILE_CONTENT, content);
         }
@@ -174,8 +189,10 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Reading local content file as text synchronously should succeed")]
         public void LocalContentFileRefReadContentAsTextTest()
         {
+            TestZipFileEntry testZipFileEntry = new(TEXT_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
-            EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
+            EpubLocalTextContentFileRef epubLocalTextContentFileRef =
+                new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             string content = epubLocalTextContentFileRef.ReadContentAsText();
             Assert.Equal(TEXT_FILE_CONTENT, content);
         }
@@ -183,8 +200,10 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Reading local content file as text asynchronously should succeed")]
         public async Task LocalContentFileRefReadContentAsTextAsyncTest()
         {
+            TestZipFileEntry testZipFileEntry = new(TEXT_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(TEXT_FILE_CONTENT);
-            EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
+            EpubLocalTextContentFileRef epubLocalTextContentFileRef =
+                new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             string content = await epubLocalTextContentFileRef.ReadContentAsTextAsync();
             Assert.Equal(TEXT_FILE_CONTENT, content);
         }
@@ -192,8 +211,10 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Reading local content file as bytes synchronously should succeed")]
         public void LocalContentFileRefReadContentAsBytesTest()
         {
+            TestZipFileEntry testZipFileEntry = new(BYTE_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
-            EpubLocalByteContentFileRef epubLocalByteContentFileRef = new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testEpubContentLoader);
+            EpubLocalByteContentFileRef epubLocalByteContentFileRef =
+                new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             byte[] content = epubLocalByteContentFileRef.ReadContentAsBytes();
             Assert.Equal(BYTE_FILE_CONTENT, content);
         }
@@ -201,8 +222,10 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Reading local content file as bytes asynchronously should succeed")]
         public async Task LocalContentFileRefReadContentAsBytesAsyncTest()
         {
+            TestZipFileEntry testZipFileEntry = new(BYTE_FILE_CONTENT);
             TestEpubContentLoader testEpubContentLoader = new(BYTE_FILE_CONTENT);
-            EpubLocalByteContentFileRef epubLocalByteContentFileRef = new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testEpubContentLoader);
+            EpubLocalByteContentFileRef epubLocalByteContentFileRef =
+                new(LocalByteFileRefMetadata, LOCAL_BYTE_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             byte[] content = await epubLocalByteContentFileRef.ReadContentAsBytesAsync();
             Assert.Equal(BYTE_FILE_CONTENT, content);
         }
@@ -210,9 +233,11 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Getting local content file stream synchronously should succeed")]
         public void LocalContentFileRefGetContentStreamTest()
         {
+            TestZipFileEntry testZipFileEntry = new(TEXT_FILE_CONTENT);
             using MemoryStream testStream = new();
             TestEpubContentLoader testEpubContentLoader = new(testStream);
-            EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
+            EpubLocalTextContentFileRef epubLocalTextContentFileRef =
+                new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             Stream contentStream = epubLocalTextContentFileRef.GetContentStream();
             Assert.Equal(testStream, contentStream);
         }
@@ -220,9 +245,11 @@ namespace VersOne.Epub.Test.Unit.Content.Base
         [Fact(DisplayName = "Getting local content file stream asynchronously should succeed")]
         public async Task LocalContentFileRefGetContentStreamAsyncTest()
         {
+            TestZipFileEntry testZipFileEntry = new(TEXT_FILE_CONTENT);
             using MemoryStream testStream = new();
             TestEpubContentLoader testEpubContentLoader = new(testStream);
-            EpubLocalTextContentFileRef epubLocalTextContentFileRef = new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testEpubContentLoader);
+            EpubLocalTextContentFileRef epubLocalTextContentFileRef =
+                new(LocalTextFileRefMetadata, LOCAL_TEXT_FILE_PATH, testZipFileEntry, testEpubContentLoader);
             Stream contentStream = await epubLocalTextContentFileRef.GetContentStreamAsync();
             Assert.Equal(testStream, contentStream);
         }

--- a/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionRefTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using VersOne.Epub.Environment;
 using VersOne.Epub.Options;
 using VersOne.Epub.Test.Comparers;
 using VersOne.Epub.Test.Unit.Mocks;
@@ -52,6 +53,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                                 contentMimeType: HTML_CONTENT_MIME_TYPE
                             ),
                             filePath: CHAPTER1_FILE_PATH,
+                            contentFileEntry: ContentFileEntry,
                             epubContentLoader: ContentLoader
                         ),
                         new
@@ -63,6 +65,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                                 contentMimeType: HTML_CONTENT_MIME_TYPE
                             ),
                             filePath: CHAPTER2_FILE_PATH,
+                            contentFileEntry: ContentFileEntry,
                             epubContentLoader: ContentLoader
                         )
                     ]
@@ -87,6 +90,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                                 contentMimeType: HTML_CONTENT_MIME_TYPE
                             ),
                             filePath: duplicateFilePath,
+                            contentFileEntry: ContentFileEntry,
                             epubContentLoader: ContentLoader
                         ),
                         new
@@ -98,6 +102,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                                 contentMimeType: HTML_CONTENT_MIME_TYPE
                             ),
                             filePath: duplicateFilePath,
+                            contentFileEntry: ContentFileEntry,
                             epubContentLoader: ContentLoader
                         )
                     ]
@@ -137,6 +142,8 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                 );
             }
         }
+
+        private static IZipFileEntry ContentFileEntry => new TestZipFileEntry();
 
         private static IEpubContentLoader ContentLoader => new TestEpubContentLoader();
 
@@ -262,6 +269,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                             contentMimeType: HTML_CONTENT_MIME_TYPE
                         ),
                         filePath: CHAPTER1_FILE_PATH,
+                        contentFileEntry: ContentFileEntry,
                         epubContentLoader: ContentLoader
                     )
                 ]
@@ -291,6 +299,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                     contentMimeType: HTML_CONTENT_MIME_TYPE
                 ),
                 filePath: CHAPTER1_FILE_PATH,
+                contentFileEntry: ContentFileEntry,
                 epubContentLoader: ContentLoader
             );
             ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
@@ -321,6 +330,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                             contentMimeType: HTML_CONTENT_MIME_TYPE
                         ),
                         filePath: CHAPTER1_FILE_PATH,
+                        contentFileEntry: ContentFileEntry,
                         epubContentLoader: ContentLoader
                     )
                 ]
@@ -350,6 +360,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                     contentMimeType: HTML_CONTENT_MIME_TYPE
                 ),
                 filePath: CHAPTER1_FILE_PATH,
+                contentFileEntry: ContentFileEntry,
                 epubContentLoader: ContentLoader
             );
             ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
@@ -390,6 +401,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                             contentMimeType: HTML_CONTENT_MIME_TYPE
                         ),
                         filePath: existingFilePath,
+                        contentFileEntry: ContentFileEntry,
                         epubContentLoader: ContentLoader
                     )
                 ]
@@ -420,6 +432,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                     contentMimeType: HTML_CONTENT_MIME_TYPE
                 ),
                 filePath: existingFilePath,
+                contentFileEntry: ContentFileEntry,
                 epubContentLoader: ContentLoader
             );
             ReadOnlyCollection<EpubLocalTextContentFileRef> local = new
@@ -450,6 +463,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                             contentMimeType: HTML_CONTENT_MIME_TYPE
                         ),
                         filePath: CHAPTER1_FILE_PATH,
+                        contentFileEntry: ContentFileEntry,
                         epubContentLoader: ContentLoader
                     )
                 ]
@@ -480,6 +494,7 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
                     contentMimeType: HTML_CONTENT_MIME_TYPE
                 ),
                 filePath: existingFilePath,
+                contentFileEntry: ContentFileEntry,
                 epubContentLoader: ContentLoader
             );
             ReadOnlyCollection<EpubLocalTextContentFileRef> local = new

--- a/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Collections/EpubContentCollectionRefTests.cs
@@ -14,10 +14,11 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
         {
             get
             {
+                TestEpubContentRef testEpubContentRef = new(new TestZipFile());
                 List<EpubLocalTextContentFileRef> list =
                 [
-                    TestEpubContentRef.Chapter1FileRef,
-                    TestEpubContentRef.Chapter2FileRef
+                    testEpubContentRef.Chapter1FileRef,
+                    testEpubContentRef.Chapter2FileRef
                 ];
                 return list.AsReadOnly();
             }
@@ -169,8 +170,9 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
         [Fact(DisplayName = "Constructing a EpubContentCollectionRef instance with null remote parameter should succeed")]
         public void ConstructorWithNullRemoteParameterTest()
         {
-            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, null);
-            EpubContentRefComparer.CompareEpubLocalTextContentFileRefLists(Local, epubContentCollectionRef.Local);
+            ReadOnlyCollection<EpubLocalTextContentFileRef> testLocalCollection = Local;
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(testLocalCollection, null);
+            EpubContentRefComparer.CompareEpubLocalTextContentFileRefLists(testLocalCollection, epubContentCollectionRef.Local);
             Assert.NotNull(epubContentCollectionRef.Remote);
             Assert.Empty(epubContentCollectionRef.Remote);
         }
@@ -178,18 +180,23 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
         [Fact(DisplayName = "Constructing a EpubContentCollectionRef instance with null contentReaderOptions parameter should succeed")]
         public void ConstructorWithNullContentReaderOptionsParameterTest()
         {
-            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef = new(Local, Remote, null);
-            EpubContentRefComparer.CompareEpubLocalTextContentFileRefLists(Local, epubContentCollectionRef.Local);
-            EpubContentRefComparer.CompareEpubRemoteTextContentFileRefLists(Remote, epubContentCollectionRef.Remote);
+            ReadOnlyCollection<EpubLocalTextContentFileRef> testLocalCollection = Local;
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remoteLocalCollection = Remote;
+            EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef =
+                new(testLocalCollection, remoteLocalCollection, null);
+            EpubContentRefComparer.CompareEpubLocalTextContentFileRefLists(testLocalCollection, epubContentCollectionRef.Local);
+            EpubContentRefComparer.CompareEpubRemoteTextContentFileRefLists(remoteLocalCollection, epubContentCollectionRef.Remote);
         }
 
         [Fact(DisplayName = "Constructing a EpubContentCollectionRef instance with all non-null parameters should succeed")]
         public void ConstructorWithNonNullParametersTest()
         {
+            ReadOnlyCollection<EpubLocalTextContentFileRef> testLocalCollection = Local;
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remoteLocalCollection = Remote;
             EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef =
-                new(Local, Remote, new ContentReaderOptions());
-            EpubContentRefComparer.CompareEpubLocalTextContentFileRefLists(Local, epubContentCollectionRef.Local);
-            EpubContentRefComparer.CompareEpubRemoteTextContentFileRefLists(Remote, epubContentCollectionRef.Remote);
+                new(testLocalCollection, remoteLocalCollection, new ContentReaderOptions());
+            EpubContentRefComparer.CompareEpubLocalTextContentFileRefLists(testLocalCollection, epubContentCollectionRef.Local);
+            EpubContentRefComparer.CompareEpubRemoteTextContentFileRefLists(remoteLocalCollection, epubContentCollectionRef.Remote);
         }
 
         [Fact(DisplayName = "Constructor should throw EpubPackageException if local parameter contains content files with duplicate keys and no ContentReaderOptions are provided")]
@@ -206,10 +213,11 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
             {
                 SkipItemsWithDuplicateHrefs = true
             };
+            ReadOnlyCollection<EpubLocalTextContentFileRef> testLocalCollectionWithDuplicateKeys = LocalWithDuplicateKeys;
             EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef =
-                new(LocalWithDuplicateKeys, Remote, contentReaderOptions);
+                new(testLocalCollectionWithDuplicateKeys, Remote, contentReaderOptions);
             Assert.Single(epubContentCollectionRef.Local);
-            EpubContentRefComparer.CompareEpubLocalContentFileRefs(LocalWithDuplicateKeys[0], epubContentCollectionRef.Local[0]);
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(testLocalCollectionWithDuplicateKeys[0], epubContentCollectionRef.Local[0]);
         }
 
         [Fact(DisplayName = "Constructor should throw EpubPackageException if local parameter contains content files with duplicate file paths and no ContentReaderOptions are provided")]
@@ -226,10 +234,11 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
             {
                 SkipItemsWithDuplicateFilePaths = true
             };
+            ReadOnlyCollection<EpubLocalTextContentFileRef> testLocalCollectionWithDuplicateFilePaths = LocalWithDuplicateFilePaths;
             EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef =
-                new(LocalWithDuplicateFilePaths, Remote, contentReaderOptions);
+                new(testLocalCollectionWithDuplicateFilePaths, Remote, contentReaderOptions);
             Assert.Single(epubContentCollectionRef.Local);
-            EpubContentRefComparer.CompareEpubLocalContentFileRefs(LocalWithDuplicateFilePaths[0], epubContentCollectionRef.Local[0]);
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(testLocalCollectionWithDuplicateFilePaths[0], epubContentCollectionRef.Local[0]);
         }
 
         [Fact(DisplayName = "Constructor should throw EpubPackageException if remote parameter contains content files with duplicate URLs and no ContentReaderOptions are provided")]
@@ -246,10 +255,11 @@ namespace VersOne.Epub.Test.Unit.Content.Collections
             {
                 SkipItemsWithDuplicateUrls = true
             };
+            ReadOnlyCollection<EpubRemoteTextContentFileRef> remoteLocalCollectionWithDuplicateKeys = RemoteWithDuplicateKeys;
             EpubContentCollectionRef<EpubLocalTextContentFileRef, EpubRemoteTextContentFileRef> epubContentCollectionRef =
-                new(Local, RemoteWithDuplicateKeys, contentReaderOptions);
+                new(Local, remoteLocalCollectionWithDuplicateKeys, contentReaderOptions);
             Assert.Single(epubContentCollectionRef.Remote);
-            EpubContentRefComparer.CompareEpubRemoteContentFileRefs(RemoteWithDuplicateKeys[0], epubContentCollectionRef.Remote[0]);
+            EpubContentRefComparer.CompareEpubRemoteContentFileRefs(remoteLocalCollectionWithDuplicateKeys[0], epubContentCollectionRef.Remote[0]);
         }
 
         [Fact(DisplayName = "ContainsLocalFileRefWithKey should return true if the local file reference with the given key exists and false otherwise")]

--- a/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubRemoteContentLoaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Content/Loaders/EpubRemoteContentLoaderTests.cs
@@ -193,10 +193,10 @@ namespace VersOne.Epub.Test.Unit.Content.Loaders
         public void LoadContentWithNonSpecifiedUserAgentTest()
         {
             TestContentDownloader testContentDownloader = new(TEXT_FILE_HREF, TEXT_FILE_CONTENT);
-            AssemblyInformationalVersionAttribute? assemblyInformationalVersionAttribute =
-                typeof(EpubRemoteContentLoaderTests).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            Assert.NotNull(assemblyInformationalVersionAttribute);
-            string expectedUserAgent = "EpubReader/" + assemblyInformationalVersionAttribute.InformationalVersion;
+            AssemblyFileVersionAttribute? assemblyFileVersionAttribute =
+                typeof(EpubRemoteContentLoaderTests).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+            Assert.NotNull(assemblyFileVersionAttribute);
+            string expectedUserAgent = "EpubReader/" + assemblyFileVersionAttribute.Version;
             ContentDownloaderOptions contentDownloaderOptions = new()
             {
                 DownloadContent = true,

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
@@ -254,6 +254,7 @@ namespace VersOne.Epub.Test.Unit.Entities
                     (
                         metadata: new EpubContentFileRefMetadata(COVER_FILE_NAME, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE),
                         filePath: COVER_FILE_PATH,
+                        contentFileEntry: new TestZipFileEntry(coverFileContent),
                         epubContentLoader: new TestEpubContentLoader(coverFileContent)
                     )
                 )
@@ -263,35 +264,35 @@ namespace VersOne.Epub.Test.Unit.Entities
         private static EpubBookRef CreateEpubBookRefWithReadingOrder(string htmlFileName, string htmlFilePath)
         {
             EpubLocalTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName, htmlFilePath);
-            List<EpubLocalTextContentFileRef> htmlLocal = new()
-            {
+            List<EpubLocalTextContentFileRef> htmlLocal =
+            [
                 htmlFileRef
-            };
+            ];
             return CreateEpubBookRef
             (
                 epubFile: new TestZipFile(),
                 epubVersion: EpubVersion.EPUB_3,
                 manifest: new EpubManifest
                 (
-                    items: new List<EpubManifestItem>()
-                    {
+                    items:
+                    [
                         new
                         (
                             id: "item-1",
                             href: htmlFileName,
                             mediaType: "application/xhtml+xml"
                         )
-                    }
+                    ]
                 ),
                 spine: new EpubSpine
                 (
-                    items: new List<EpubSpineItemRef>()
-                    {
+                    items:
+                    [
                         new
                         (
                             idRef: "item-1"
                         )
-                    }
+                    ]
                 ),
                 content: new EpubContentRef
                 (
@@ -304,10 +305,10 @@ namespace VersOne.Epub.Test.Unit.Entities
         {
             EpubLocalTextContentFileRef htmlFileRef = CreateTestHtmlFileRef(htmlFileName, htmlFilePath);
             EpubLocalTextContentFileRef navigationFileRef = CreateTestHtmlFileRef("toc.html", $"{CONTENT_DIRECTORY_PATH}/toc.html");
-            List<EpubLocalTextContentFileRef> htmlLocal = new()
-            {
+            List<EpubLocalTextContentFileRef> htmlLocal =
+            [
                 htmlFileRef
-            };
+            ];
             return CreateEpubBookRef
             (
                 epubFile: new TestZipFile(),
@@ -315,15 +316,15 @@ namespace VersOne.Epub.Test.Unit.Entities
                 epub3NavDocument: new Epub3NavDocument
                 (
                     filePath: navigationFileRef.FilePath,
-                    navs: new List<Epub3Nav>()
-                    {
+                    navs:
+                    [
                         new
                         (
                             type: Epub3StructuralSemanticsProperty.TOC,
                             ol: new Epub3NavOl
                             (
-                                lis: new List<Epub3NavLi>()
-                                {
+                                lis:
+                                [
                                     new
                                     (
                                         anchor: new Epub3NavAnchor
@@ -332,10 +333,10 @@ namespace VersOne.Epub.Test.Unit.Entities
                                             href: htmlFileName
                                         )
                                     )
-                                }
+                                ]
                             )
                         )
-                    }
+                    ]
                 ),
                 content: new EpubContentRef
                 (
@@ -379,7 +380,7 @@ namespace VersOne.Epub.Test.Unit.Entities
         private static EpubLocalTextContentFileRef CreateTestHtmlFileRef(string fileName, string filePath)
         {
             EpubContentFileRefMetadata htmlFileRefMetadata = new(fileName, EpubContentType.XHTML_1_1, "application/xhtml+xml");
-            return new(htmlFileRefMetadata, filePath, new TestEpubContentLoader());
+            return new(htmlFileRefMetadata, filePath, new TestZipFileEntry(), new TestEpubContentLoader());
         }
 
         private static EpubNavigationItemRef CreateTestNavigationLink(string title, string htmlFileUrl, EpubLocalTextContentFileRef htmlFileRef)

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubBookRefTests.cs
@@ -17,23 +17,30 @@ namespace VersOne.Epub.Test.Unit.Entities
         private const string HTML_FILE_PATH = $"{CONTENT_DIRECTORY_PATH}/{HTML_FILE_NAME}";
         private const string TEST_ANCHOR_TEXT = "Test anchor";
 
-        private static readonly byte[] COVER_FILE_CONTENT = new byte[] { 0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46 };
+        private static readonly byte[] COVER_FILE_CONTENT = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46];
 
         private static List<string> AuthorList =>
-            new()
-            {
+            [
                 BOOK_AUTHOR
-            };
+            ];
 
         private static EpubSchema Schema => TestEpubSchemas.CreateFullTestEpubSchema();
 
-        private static EpubContentRef Content => TestEpubContentRef.CreateFullTestEpubContentRef();
+        private static EpubContentRef Content
+        {
+            get
+            {
+                TestEpubContentRef testEpubContentRef = new(new TestZipFile());
+                return testEpubContentRef.CreateFullTestEpubContentRef();
+            }
+        }
 
         [Fact(DisplayName = "Constructing a EpubBookRef instance with non-null parameters should succeed")]
         public void ConstructorWithNonNullParametersTest()
         {
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = new(testZipFile, EPUB_FILE_PATH, BOOK_TITLE, BOOK_AUTHOR, AuthorList, BOOK_DESCRIPTION, Schema, Content);
+            EpubContentRef testContent = Content;
+            EpubBookRef epubBookRef = new(testZipFile, EPUB_FILE_PATH, BOOK_TITLE, BOOK_AUTHOR, AuthorList, BOOK_DESCRIPTION, Schema, testContent);
             Assert.Equal(testZipFile, epubBookRef.EpubFile);
             Assert.Equal(EPUB_FILE_PATH, epubBookRef.FilePath);
             Assert.Equal(BOOK_TITLE, epubBookRef.Title);
@@ -41,7 +48,7 @@ namespace VersOne.Epub.Test.Unit.Entities
             Assert.Equal(AuthorList, epubBookRef.AuthorList);
             Assert.Equal(BOOK_DESCRIPTION, epubBookRef.Description);
             EpubSchemaComparer.CompareEpubSchemas(Schema, epubBookRef.Schema);
-            EpubContentRefComparer.CompareEpubContentRefs(Content, epubBookRef.Content);
+            EpubContentRefComparer.CompareEpubContentRefs(testContent, epubBookRef.Content);
         }
 
         [Fact(DisplayName = "Constructor should throw ArgumentNullException if epubFile parameter is null")]
@@ -78,7 +85,8 @@ namespace VersOne.Epub.Test.Unit.Entities
         public void ConstructorWithNullFilePathTest()
         {
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = new(testZipFile, null, BOOK_TITLE, BOOK_AUTHOR, AuthorList, BOOK_DESCRIPTION, Schema, Content);
+            EpubContentRef testContent = Content;
+            EpubBookRef epubBookRef = new(testZipFile, null, BOOK_TITLE, BOOK_AUTHOR, AuthorList, BOOK_DESCRIPTION, Schema, testContent);
             Assert.Equal(testZipFile, epubBookRef.EpubFile);
             Assert.Null(epubBookRef.FilePath);
             Assert.Equal(BOOK_TITLE, epubBookRef.Title);
@@ -86,14 +94,15 @@ namespace VersOne.Epub.Test.Unit.Entities
             Assert.Equal(AuthorList, epubBookRef.AuthorList);
             Assert.Equal(BOOK_DESCRIPTION, epubBookRef.Description);
             EpubSchemaComparer.CompareEpubSchemas(Schema, epubBookRef.Schema);
-            EpubContentRefComparer.CompareEpubContentRefs(Content, epubBookRef.Content);
+            EpubContentRefComparer.CompareEpubContentRefs(testContent, epubBookRef.Content);
         }
 
         [Fact(DisplayName = "Constructing a EpubBookRef instance with null authorList parameter should succeed")]
         public void ConstructorWithNullAuthorListTest()
         {
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = new(testZipFile, EPUB_FILE_PATH, BOOK_TITLE, BOOK_AUTHOR, null, BOOK_DESCRIPTION, Schema, Content);
+            EpubContentRef testContent = Content;
+            EpubBookRef epubBookRef = new(testZipFile, EPUB_FILE_PATH, BOOK_TITLE, BOOK_AUTHOR, null, BOOK_DESCRIPTION, Schema, testContent);
             Assert.Equal(testZipFile, epubBookRef.EpubFile);
             Assert.Equal(EPUB_FILE_PATH, epubBookRef.FilePath);
             Assert.Equal(BOOK_TITLE, epubBookRef.Title);
@@ -101,14 +110,15 @@ namespace VersOne.Epub.Test.Unit.Entities
             Assert.Equal(new List<string>(), epubBookRef.AuthorList);
             Assert.Equal(BOOK_DESCRIPTION, epubBookRef.Description);
             EpubSchemaComparer.CompareEpubSchemas(Schema, epubBookRef.Schema);
-            EpubContentRefComparer.CompareEpubContentRefs(Content, epubBookRef.Content);
+            EpubContentRefComparer.CompareEpubContentRefs(testContent, epubBookRef.Content);
         }
 
         [Fact(DisplayName = "Constructing a EpubBookRef instance with null description parameter should succeed")]
         public void ConstructorWithNullDescriptionTest()
         {
             TestZipFile testZipFile = new();
-            EpubBookRef epubBookRef = new(testZipFile, EPUB_FILE_PATH, BOOK_TITLE, BOOK_AUTHOR, AuthorList, null, Schema, Content);
+            EpubContentRef testContent = Content;
+            EpubBookRef epubBookRef = new(testZipFile, EPUB_FILE_PATH, BOOK_TITLE, BOOK_AUTHOR, AuthorList, null, Schema, testContent);
             Assert.Equal(testZipFile, epubBookRef.EpubFile);
             Assert.Equal(EPUB_FILE_PATH, epubBookRef.FilePath);
             Assert.Equal(BOOK_TITLE, epubBookRef.Title);
@@ -116,7 +126,7 @@ namespace VersOne.Epub.Test.Unit.Entities
             Assert.Equal(AuthorList, epubBookRef.AuthorList);
             Assert.Null(epubBookRef.Description);
             EpubSchemaComparer.CompareEpubSchemas(Schema, epubBookRef.Schema);
-            EpubContentRefComparer.CompareEpubContentRefs(Content, epubBookRef.Content);
+            EpubContentRefComparer.CompareEpubContentRefs(testContent, epubBookRef.Content);
         }
 
         [Fact(DisplayName = "Reading the existing cover synchronously should succeed")]

--- a/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemRefTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Entities/EpubNavigationItemRefTests.cs
@@ -1,4 +1,5 @@
 ﻿using VersOne.Epub.Test.Comparers;
+using VersOne.Epub.Test.Unit.Mocks;
 using VersOne.Epub.Test.Unit.TestData;
 
 namespace VersOne.Epub.Test.Unit.Entities
@@ -16,40 +17,45 @@ namespace VersOne.Epub.Test.Unit.Entities
             );
 
         private static List<EpubNavigationItemRef> NestedItems =>
-            new()
-            {
+            [
                 new EpubNavigationItemRef
                 (
                     type: EpubNavigationItemType.HEADER,
                     title: "Nested item"
                 )
-            };
+            ];
 
         [Fact(DisplayName = "Constructing a EpubNavigationItemRef instance with non-null parameters should succeed")]
         public void ConstructorWithNonNullParametersTest()
         {
-            EpubNavigationItemRef epubNavigationItemRef = new(TYPE, TITLE, Link, TestEpubContentRef.Chapter1FileRef, NestedItems);
+            TestEpubContentRef testEpubContentRef = new(new TestZipFile());
+            EpubLocalTextContentFileRef testNavigationContentFileRef = testEpubContentRef.Chapter1FileRef;
+            EpubNavigationItemRef epubNavigationItemRef = new(TYPE, TITLE, Link, testNavigationContentFileRef, NestedItems);
             Assert.Equal(TYPE, epubNavigationItemRef.Type);
             Assert.Equal(TITLE, epubNavigationItemRef.Title);
             EpubNavigationItemComparer.CompareNavigationItemLinks(Link, epubNavigationItemRef.Link);
-            EpubContentRefComparer.CompareEpubLocalContentFileRefs(TestEpubContentRef.Chapter1FileRef, epubNavigationItemRef.HtmlContentFileRef);
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(testNavigationContentFileRef, epubNavigationItemRef.HtmlContentFileRef);
             EpubNavigationItemRefComparer.CompareNavigationItemRefLists(NestedItems, epubNavigationItemRef.NestedItems);
         }
 
         [Fact(DisplayName = "Constructor should throw ArgumentNullException if title parameter is null")]
         public void ConstructorWithNullTitleTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemRef(TYPE, null!, Link, TestEpubContentRef.Chapter1FileRef, NestedItems));
+            TestEpubContentRef testEpubContentRef = new(new TestZipFile());
+            EpubLocalTextContentFileRef testNavigationContentFileRef = testEpubContentRef.Chapter1FileRef;
+            Assert.Throws<ArgumentNullException>(() => new EpubNavigationItemRef(TYPE, null!, Link, testNavigationContentFileRef, NestedItems));
         }
 
         [Fact(DisplayName = "Constructing a EpubNavigationItemRef instance with null link parameter should succeed")]
         public void ConstructorWithNullLinkParameterTest()
         {
-            EpubNavigationItemRef epubNavigationItemRef = new(TYPE, TITLE, null, TestEpubContentRef.Chapter1FileRef, NestedItems);
+            TestEpubContentRef testEpubContentRef = new(new TestZipFile());
+            EpubLocalTextContentFileRef testNavigationContentFileRef = testEpubContentRef.Chapter1FileRef;
+            EpubNavigationItemRef epubNavigationItemRef = new(TYPE, TITLE, null, testNavigationContentFileRef, NestedItems);
             Assert.Equal(TYPE, epubNavigationItemRef.Type);
             Assert.Equal(TITLE, epubNavigationItemRef.Title);
             EpubNavigationItemComparer.CompareNavigationItemLinks(null, epubNavigationItemRef.Link);
-            EpubContentRefComparer.CompareEpubLocalContentFileRefs(TestEpubContentRef.Chapter1FileRef, epubNavigationItemRef.HtmlContentFileRef);
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(testNavigationContentFileRef, epubNavigationItemRef.HtmlContentFileRef);
             EpubNavigationItemRefComparer.CompareNavigationItemRefLists(NestedItems, epubNavigationItemRef.NestedItems);
         }
 
@@ -67,12 +73,14 @@ namespace VersOne.Epub.Test.Unit.Entities
         [Fact(DisplayName = "Constructing a EpubNavigationItemRef instance with null nestedItems parameter should succeed")]
         public void ConstructorWithNullNestedItemsParameterTest()
         {
-            EpubNavigationItemRef epubNavigationItemRef = new(TYPE, TITLE, Link, TestEpubContentRef.Chapter1FileRef, null);
+            TestEpubContentRef testEpubContentRef = new(new TestZipFile());
+            EpubLocalTextContentFileRef testNavigationContentFileRef = testEpubContentRef.Chapter1FileRef;
+            EpubNavigationItemRef epubNavigationItemRef = new(TYPE, TITLE, Link, testNavigationContentFileRef, null);
             Assert.Equal(TYPE, epubNavigationItemRef.Type);
             Assert.Equal(TITLE, epubNavigationItemRef.Title);
             EpubNavigationItemComparer.CompareNavigationItemLinks(Link, epubNavigationItemRef.Link);
-            EpubContentRefComparer.CompareEpubLocalContentFileRefs(TestEpubContentRef.Chapter1FileRef, epubNavigationItemRef.HtmlContentFileRef);
-            EpubNavigationItemRefComparer.CompareNavigationItemRefLists(new List<EpubNavigationItemRef>(), epubNavigationItemRef.NestedItems);
+            EpubContentRefComparer.CompareEpubLocalContentFileRefs(testNavigationContentFileRef, epubNavigationItemRef.HtmlContentFileRef);
+            EpubNavigationItemRefComparer.CompareNavigationItemRefLists([], epubNavigationItemRef.NestedItems);
         }
 
         [Fact(DisplayName = "ToString method should produce a string with the type, the title, and the number of nested items")]

--- a/Source/VersOne.Epub.Test/Unit/Mocks/TestEpubContentLoader.cs
+++ b/Source/VersOne.Epub.Test/Unit/Mocks/TestEpubContentLoader.cs
@@ -9,7 +9,7 @@ namespace VersOne.Epub.Test.Unit.Mocks
 
         public TestEpubContentLoader()
         {
-            byteContent = Array.Empty<byte>();
+            byteContent = [];
             stream = null;
         }
 
@@ -33,7 +33,7 @@ namespace VersOne.Epub.Test.Unit.Mocks
 
         public byte[] LoadContentAsBytes(EpubContentFileRefMetadata contentFileRefMetadata)
         {
-            return byteContent ?? Array.Empty<byte>();
+            return byteContent ?? [];
         }
 
         public Task<byte[]> LoadContentAsBytesAsync(EpubContentFileRefMetadata contentFileRefMetadata)

--- a/Source/VersOne.Epub.Test/Unit/Mocks/TestZipFileEntry.cs
+++ b/Source/VersOne.Epub.Test/Unit/Mocks/TestZipFileEntry.cs
@@ -8,6 +8,12 @@ namespace VersOne.Epub.Test.Unit.Mocks
         private readonly byte[]? byteContent;
         private readonly MemoryStream? memoryStream;
 
+        public TestZipFileEntry()
+        {
+            byteContent = [];
+            memoryStream = null;
+        }
+
         public TestZipFileEntry(string textContent)
         {
             byteContent = Encoding.UTF8.GetBytes(textContent);

--- a/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/BookCoverReaderTests.cs
@@ -555,7 +555,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         private static EpubLocalByteContentFileRef CreateLocalTestImageFileRef()
         {
             EpubContentFileRefMetadata localImageFileRefMetadata = new(LOCAL_COVER_FILE_NAME, COVER_FILE_CONTENT_TYPE, COVER_FILE_CONTENT_MIME_TYPE);
-            return new(localImageFileRefMetadata, LOCAL_COVER_FILE_NAME, new TestEpubContentLoader());
+            return new(localImageFileRefMetadata, LOCAL_COVER_FILE_NAME, new TestZipFileEntry(), new TestEpubContentLoader());
         }
 
         private static EpubRemoteByteContentFileRef CreateRemoteTestImageFileRef()

--- a/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
@@ -661,12 +661,12 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private static EpubLocalTextContentFileRef CreateLocalTextFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, new TestZipFileEntry(), new TestEpubContentLoader());
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, null, new TestEpubContentLoader());
         }
 
         private static EpubLocalByteContentFileRef CreateLocalByteFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, new TestZipFileEntry(), new TestEpubContentLoader());
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, null, new TestEpubContentLoader());
         }
 
         private static EpubRemoteTextContentFileRef CreateRemoteTextFileRef(string href, EpubContentType contentType, string contentMimeType)

--- a/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/ContentReaderTests.cs
@@ -661,12 +661,12 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private static EpubLocalTextContentFileRef CreateLocalTextFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, new TestEpubContentLoader());
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, new TestZipFileEntry(), new TestEpubContentLoader());
         }
 
         private static EpubLocalByteContentFileRef CreateLocalByteFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, new TestEpubContentLoader());
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), fileName, new TestZipFileEntry(), new TestEpubContentLoader());
         }
 
         private static EpubRemoteTextContentFileRef CreateRemoteTextFileRef(string href, EpubContentType contentType, string contentMimeType)

--- a/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/NavigationReaderTests.cs
@@ -1074,7 +1074,7 @@ namespace VersOne.Epub.Test.Unit.Readers
         private static EpubLocalTextContentFileRef CreateTestHtmlFile(string? directory, string htmlFileName)
         {
             return new(new EpubContentFileRefMetadata(htmlFileName, EpubContentType.XHTML_1_1, "application/xhtml+xml"),
-                directory != null ? $"{directory}/{htmlFileName}" : htmlFileName, new TestEpubContentLoader());
+                directory != null ? $"{directory}/{htmlFileName}" : htmlFileName, new TestZipFileEntry(), new TestEpubContentLoader());
         }
 
         private static EpubPackage CreateEmptyPackage(EpubVersion epubVersion)

--- a/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
+++ b/Source/VersOne.Epub.Test/Unit/Readers/SpineReaderTests.cs
@@ -244,7 +244,8 @@ namespace VersOne.Epub.Test.Unit.Readers
 
         private static EpubLocalTextContentFileRef CreateTestHtmlFileRef(string fileName)
         {
-            return new(new EpubContentFileRefMetadata(fileName, EpubContentType.XHTML_1_1, "application/xhtml+xml"), fileName, new TestEpubContentLoader());
+            return new(new EpubContentFileRefMetadata(fileName, EpubContentType.XHTML_1_1, "application/xhtml+xml"), fileName, new TestZipFileEntry(),
+                new TestEpubContentLoader());
         }
 
         private static EpubContentRef CreateEpubContentRefForTestRemoteFile(string fileUrl)

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubBookRefs.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubBookRefs.cs
@@ -7,31 +7,33 @@ namespace VersOne.Epub.Test.Unit.TestData
     {
         public static EpubBookRef CreateMinimalTestEpubBookRef(TestZipFile epubFile, string epubFilePath)
         {
+            TestEpubContentRef testEpubContentRef = new(epubFile);
             return new
             (
                 epubFile: epubFile,
                 filePath: epubFilePath,
                 title: String.Empty,
                 author: String.Empty,
-                authorList: new List<string>(),
+                authorList: [],
                 description: null,
                 schema: TestEpubSchemas.CreateMinimalTestEpubSchema(),
-                content: TestEpubContentRef.CreateMinimalTestEpubContentRefWithNavigation()
+                content: testEpubContentRef.CreateMinimalTestEpubContentRefWithNavigation()
             );
         }
 
         public static EpubBookRef CreateFullTestEpubBookRef(TestZipFile epubFile, string? epubFilePath)
         {
+            TestEpubContentRef testEpubContentRef = new(epubFile);
             return new
             (
                 epubFile: epubFile,
                 filePath: epubFilePath,
                 title: BOOK_TITLE,
                 author: BOOK_AUTHOR,
-                authorList: new List<string> { BOOK_AUTHOR },
+                authorList: [BOOK_AUTHOR],
                 description: BOOK_DESCRIPTION,
                 schema: TestEpubSchemas.CreateFullTestEpubSchema(),
-                content: TestEpubContentRef.CreateFullTestEpubContentRef()
+                content: testEpubContentRef.CreateFullTestEpubContentRef()
             );
         }
     }

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContentRef.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContentRef.cs
@@ -182,12 +182,14 @@ namespace VersOne.Epub.Test.Unit.TestData
 
         private static EpubLocalTextContentFileRef CreateLocalTextContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), $"{CONTENT_DIRECTORY_PATH}/{fileName}", new TestEpubContentLoader());
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), $"{CONTENT_DIRECTORY_PATH}/{fileName}", new TestZipFileEntry(),
+                new TestEpubContentLoader());
         }
 
         private static EpubLocalByteContentFileRef CreateLocalByteContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), $"{CONTENT_DIRECTORY_PATH}/{fileName}", new TestEpubContentLoader());
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), $"{CONTENT_DIRECTORY_PATH}/{fileName}", new TestZipFileEntry(),
+                new TestEpubContentLoader());
         }
 
         private static EpubRemoteTextContentFileRef CreateRemoteTextContentFileRef(string href, EpubContentType contentType, string contentMimeType)

--- a/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContentRef.cs
+++ b/Source/VersOne.Epub.Test/Unit/TestData/TestEpubContentRef.cs
@@ -3,18 +3,20 @@ using static VersOne.Epub.Test.Unit.TestData.TestEpubData;
 
 namespace VersOne.Epub.Test.Unit.TestData
 {
-    internal static class TestEpubContentRef
+    internal class TestEpubContentRef(TestZipFile testZipFile)
     {
-        public static EpubContentRef CreateMinimalTestEpubContentRefWithNavigation()
+        private readonly TestZipFile testZipFile = testZipFile;
+
+        public EpubContentRef CreateMinimalTestEpubContentRefWithNavigation()
         {
-            List<EpubLocalTextContentFileRef> htmlLocal = new()
-            {
+            List<EpubLocalTextContentFileRef> htmlLocal =
+            [
                 NavFileRef
-            };
-            List<EpubLocalContentFileRef> allFilesLocal = new()
-            {
+            ];
+            List<EpubLocalContentFileRef> allFilesLocal =
+            [
                 NavFileRef
-            };
+            ];
             return new
             (
                 cover: null,
@@ -28,57 +30,57 @@ namespace VersOne.Epub.Test.Unit.TestData
             );
         }
 
-        public static EpubContentRef CreateFullTestEpubContentRef()
+        public EpubContentRef CreateFullTestEpubContentRef()
         {
-            List<EpubLocalTextContentFileRef> htmlLocal = new()
-            {
+            List<EpubLocalTextContentFileRef> htmlLocal =
+            [
                 Chapter1FileRef,
                 Chapter2FileRef,
                 NavFileRef
-            };
-            List<EpubRemoteTextContentFileRef> htmlRemote = new()
-            {
+            ];
+            List<EpubRemoteTextContentFileRef> htmlRemote =
+            [
                 RemoteHtmlContentFileRef
-            };
-            List<EpubLocalTextContentFileRef> cssLocal = new()
-            {
+            ];
+            List<EpubLocalTextContentFileRef> cssLocal =
+            [
                 Styles1FileRef,
                 Styles2FileRef
-            };
-            List<EpubRemoteTextContentFileRef> cssRemote = new()
-            {
+            ];
+            List<EpubRemoteTextContentFileRef> cssRemote =
+            [
                 RemoteCssContentFileRef
-            };
-            List<EpubLocalByteContentFileRef> imagesLocal = new()
-            {
+            ];
+            List<EpubLocalByteContentFileRef> imagesLocal =
+            [
                 Image1FileRef,
                 Image2FileRef,
                 CoverFileRef
-            };
-            List<EpubRemoteByteContentFileRef> imagesRemote = new()
-            {
+            ];
+            List<EpubRemoteByteContentFileRef> imagesRemote =
+            [
                 RemoteImageContentFileRef
-            };
-            List<EpubLocalByteContentFileRef> fontsLocal = new()
-            {
+            ];
+            List<EpubLocalByteContentFileRef> fontsLocal =
+            [
                 Font1FileRef,
                 Font2FileRef
-            };
-            List<EpubRemoteByteContentFileRef> fontsRemote = new()
-            {
+            ];
+            List<EpubRemoteByteContentFileRef> fontsRemote =
+            [
                 RemoteFontContentFileRef
-            };
-            List<EpubLocalByteContentFileRef> audioLocal = new()
-            {
+            ];
+            List<EpubLocalByteContentFileRef> audioLocal =
+            [
                 Audio1FileRef,
                 Audio2FileRef
-            };
-            List<EpubRemoteByteContentFileRef> audioRemote = new()
-            {
+            ];
+            List<EpubRemoteByteContentFileRef> audioRemote =
+            [
                 RemoteAudioContentFileRef
-            };
-            List<EpubLocalContentFileRef> allFilesLocal = new()
-            {
+            ];
+            List<EpubLocalContentFileRef> allFilesLocal =
+            [
                 Chapter1FileRef,
                 Chapter2FileRef,
                 Styles1FileRef,
@@ -93,9 +95,9 @@ namespace VersOne.Epub.Test.Unit.TestData
                 NavFileRef,
                 CoverFileRef,
                 NcxFileRef
-            };
-            List<EpubRemoteContentFileRef> allFilesRemote = new()
-            {
+            ];
+            List<EpubRemoteContentFileRef> allFilesRemote =
+            [
                 RemoteHtmlContentFileRef,
                 RemoteCssContentFileRef,
                 RemoteImageContentFileRef,
@@ -103,7 +105,7 @@ namespace VersOne.Epub.Test.Unit.TestData
                 RemoteXmlContentFileRef,
                 RemoteAudioContentFileRef,
                 RemoteVideoContentFileRef
-            };
+            ];
             return new EpubContentRef
             (
                 cover: CoverFileRef,
@@ -117,78 +119,80 @@ namespace VersOne.Epub.Test.Unit.TestData
             );
         }
 
-        public static EpubLocalTextContentFileRef Chapter1FileRef =>
+        public EpubLocalTextContentFileRef Chapter1FileRef =>
             CreateLocalTextContentFileRef(CHAPTER1_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
 
-        public static EpubLocalTextContentFileRef Chapter2FileRef =>
+        public EpubLocalTextContentFileRef Chapter2FileRef =>
             CreateLocalTextContentFileRef(CHAPTER2_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalTextContentFileRef Styles1FileRef =>
+
+        public EpubLocalTextContentFileRef Styles1FileRef =>
             CreateLocalTextContentFileRef(STYLES1_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalTextContentFileRef Styles2FileRef =>
+
+        public EpubLocalTextContentFileRef Styles2FileRef =>
             CreateLocalTextContentFileRef(STYLES2_FILE_NAME, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalByteContentFileRef Image1FileRef =>
+
+        public EpubLocalByteContentFileRef Image1FileRef =>
             CreateLocalByteContentFileRef(IMAGE1_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalByteContentFileRef Image2FileRef =>
+
+        public EpubLocalByteContentFileRef Image2FileRef =>
             CreateLocalByteContentFileRef(IMAGE2_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalByteContentFileRef Font1FileRef =>
+
+        public EpubLocalByteContentFileRef Font1FileRef =>
             CreateLocalByteContentFileRef(FONT1_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalByteContentFileRef Font2FileRef =>
+
+        public EpubLocalByteContentFileRef Font2FileRef =>
             CreateLocalByteContentFileRef(FONT2_FILE_NAME, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalByteContentFileRef Audio1FileRef =>
+
+        public EpubLocalByteContentFileRef Audio1FileRef =>
             CreateLocalByteContentFileRef(AUDIO1_FILE_NAME, AUDIO_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
 
-        public static EpubLocalByteContentFileRef Audio2FileRef =>
+        public EpubLocalByteContentFileRef Audio2FileRef =>
             CreateLocalByteContentFileRef(AUDIO2_FILE_NAME, AUDIO_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
 
-        public static EpubLocalByteContentFileRef VideoFileRef =>
+        public EpubLocalByteContentFileRef VideoFileRef =>
             CreateLocalByteContentFileRef(VIDEO_FILE_NAME, OTHER_CONTENT_TYPE, VIDEO_MP4_CONTENT_MIME_TYPE);
 
         public static EpubRemoteTextContentFileRef RemoteHtmlContentFileRef =>
             CreateRemoteTextContentFileRef(REMOTE_HTML_CONTENT_FILE_HREF, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-        
+
         public static EpubRemoteTextContentFileRef RemoteCssContentFileRef =>
             CreateRemoteTextContentFileRef(REMOTE_CSS_CONTENT_FILE_HREF, CSS_CONTENT_TYPE, CSS_CONTENT_MIME_TYPE);
-        
+
         public static EpubRemoteByteContentFileRef RemoteImageContentFileRef =>
             CreateRemoteByteContentFileRef(REMOTE_IMAGE_CONTENT_FILE_HREF, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-        
+
         public static EpubRemoteByteContentFileRef RemoteFontContentFileRef =>
             CreateRemoteByteContentFileRef(REMOTE_FONT_CONTENT_FILE_HREF, FONT_CONTENT_TYPE, FONT_CONTENT_MIME_TYPE);
-        
+
         public static EpubRemoteTextContentFileRef RemoteXmlContentFileRef =>
             CreateRemoteTextContentFileRef(REMOTE_XML_CONTENT_FILE_HREF, XML_CONTENT_TYPE, XML_CONTENT_MIME_TYPE);
-        
+
         public static EpubRemoteByteContentFileRef RemoteAudioContentFileRef =>
             CreateRemoteByteContentFileRef(REMOTE_AUDIO_CONTENT_FILE_HREF, AUDIO_CONTENT_TYPE, AUDIO_MPEG_CONTENT_MIME_TYPE);
 
         public static EpubRemoteByteContentFileRef RemoteVideoContentFileRef =>
             CreateRemoteByteContentFileRef(REMOTE_VIDEO_CONTENT_FILE_HREF, OTHER_CONTENT_TYPE, VIDEO_MP4_CONTENT_MIME_TYPE);
 
-        public static EpubLocalTextContentFileRef NavFileRef =>
+        public EpubLocalTextContentFileRef NavFileRef =>
             CreateLocalTextContentFileRef(NAV_FILE_NAME, HTML_CONTENT_TYPE, HTML_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalByteContentFileRef CoverFileRef =>
+
+        public EpubLocalByteContentFileRef CoverFileRef =>
             CreateLocalByteContentFileRef(COVER_FILE_NAME, IMAGE_CONTENT_TYPE, IMAGE_CONTENT_MIME_TYPE);
-        
-        public static EpubLocalTextContentFileRef NcxFileRef =>
+
+        public EpubLocalTextContentFileRef NcxFileRef =>
             CreateLocalTextContentFileRef(NCX_FILE_NAME, NCX_CONTENT_TYPE, NCX_CONTENT_MIME_TYPE);
 
-        private static EpubLocalTextContentFileRef CreateLocalTextContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
+        private EpubLocalTextContentFileRef CreateLocalTextContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), $"{CONTENT_DIRECTORY_PATH}/{fileName}", new TestZipFileEntry(),
+            string filePath = $"{CONTENT_DIRECTORY_PATH}/{fileName}";
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), filePath, testZipFile.GetEntry(filePath),
                 new TestEpubContentLoader());
         }
 
-        private static EpubLocalByteContentFileRef CreateLocalByteContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
+        private EpubLocalByteContentFileRef CreateLocalByteContentFileRef(string fileName, EpubContentType contentType, string contentMimeType)
         {
-            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), $"{CONTENT_DIRECTORY_PATH}/{fileName}", new TestZipFileEntry(),
+            string filePath = $"{CONTENT_DIRECTORY_PATH}/{fileName}";
+            return new(new EpubContentFileRefMetadata(fileName, contentType, contentMimeType), filePath, testZipFile.GetEntry(filePath), 
                 new TestEpubContentLoader());
         }
 

--- a/Source/VersOne.Epub/Content/Loaders/EpubRemoteContentLoader.cs
+++ b/Source/VersOne.Epub/Content/Loaders/EpubRemoteContentLoader.cs
@@ -18,7 +18,7 @@ namespace VersOne.Epub.Internal
             this.contentDownloaderOptions = contentDownloaderOptions ?? new ContentDownloaderOptions();
             contentDownloader = this.contentDownloaderOptions.CustomContentDownloader ?? EnvironmentDependencies.ContentDownloader;
             userAgent = this.contentDownloaderOptions.DownloaderUserAgent ??
-                "EpubReader/" + typeof(EpubRemoteContentLoader).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+                "EpubReader/" + typeof(EpubRemoteContentLoader).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()!.Version;
         }
 
         public override async Task<byte[]> LoadContentAsBytesAsync(EpubContentFileRefMetadata contentFileRefMetadata)

--- a/Source/VersOne.Epub/Content/Local/EpubLocalByteContentFileRef.cs
+++ b/Source/VersOne.Epub/Content/Local/EpubLocalByteContentFileRef.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using VersOne.Epub.Environment;
 
 namespace VersOne.Epub
 {
@@ -15,12 +16,14 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="metadata">Metadata of this content file reference.</param>
         /// <param name="filePath">The absolute path of the local content file in the EPUB archive.</param>
+        /// <param name="contentFileEntry">The reference to the underlying local content file in the EPUB archive.</param>
         /// <param name="epubContentLoader">A reference to the EPUB content loader which provides methods to load the content of this file.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="metadata" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="filePath" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="epubContentLoader" /> parameter is <c>null</c>.</exception>
-        public EpubLocalByteContentFileRef(EpubContentFileRefMetadata metadata, string filePath, IEpubContentLoader epubContentLoader)
-            : base(metadata, filePath, epubContentLoader)
+        public EpubLocalByteContentFileRef(EpubContentFileRefMetadata metadata, string filePath, IZipFileEntry? contentFileEntry,
+            IEpubContentLoader epubContentLoader)
+            : base(metadata, filePath, contentFileEntry, epubContentLoader)
         {
         }
 

--- a/Source/VersOne.Epub/Content/Local/EpubLocalContentFileRef.cs
+++ b/Source/VersOne.Epub/Content/Local/EpubLocalContentFileRef.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using VersOne.Epub.Environment;
 
 namespace VersOne.Epub
 {
@@ -16,20 +17,28 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="metadata">Metadata of this content file reference.</param>
         /// <param name="filePath">The absolute path of the local content file in the EPUB archive.</param>
+        /// <param name="contentFileEntry">The reference to the underlying local content file in the EPUB archive.</param>
         /// <param name="epubContentLoader">A reference to the EPUB content loader which provides methods to load the content of this file.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="metadata" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="filePath" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="epubContentLoader" /> parameter is <c>null</c>.</exception>
-        protected EpubLocalContentFileRef(EpubContentFileRefMetadata metadata, string filePath, IEpubContentLoader epubContentLoader)
+        protected EpubLocalContentFileRef(EpubContentFileRefMetadata metadata, string filePath, IZipFileEntry? contentFileEntry,
+            IEpubContentLoader epubContentLoader)
             : base(metadata, epubContentLoader)
         {
             FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+            ContentFileEntry = contentFileEntry;
         }
 
         /// <summary>
         /// Gets the absolute path of the local content file in the EPUB archive.
         /// </summary>
         public string FilePath { get; }
+
+        /// <summary>
+        /// Gets the reference to the underlying local content file in the EPUB archive or <c>null</c> if the file is not present in the EPUB archive.
+        /// </summary>
+        public IZipFileEntry? ContentFileEntry { get; }
 
         /// <summary>
         /// Gets the location of the content file which is always <see cref="EpubContentLocation.LOCAL" /> for local content file references.

--- a/Source/VersOne.Epub/Content/Local/EpubLocalTextContentFileRef.cs
+++ b/Source/VersOne.Epub/Content/Local/EpubLocalTextContentFileRef.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using VersOne.Epub.Environment;
 
 namespace VersOne.Epub
 {
@@ -15,12 +16,14 @@ namespace VersOne.Epub
         /// </summary>
         /// <param name="metadata">Metadata of this content file reference.</param>
         /// <param name="filePath">The absolute path of the local content file in the EPUB archive.</param>
+        /// <param name="contentFileEntry">The reference to the underlying local content file in the EPUB archive.</param>
         /// <param name="epubContentLoader">A reference to the EPUB content loader which provides methods to load the content of this file.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="metadata" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="filePath" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="epubContentLoader" /> parameter is <c>null</c>.</exception>
-        public EpubLocalTextContentFileRef(EpubContentFileRefMetadata metadata, string filePath, IEpubContentLoader epubContentLoader)
-            : base(metadata, filePath, epubContentLoader)
+        public EpubLocalTextContentFileRef(EpubContentFileRefMetadata metadata, string filePath, IZipFileEntry? contentFileEntry,
+            IEpubContentLoader epubContentLoader)
+            : base(metadata, filePath, contentFileEntry, epubContentLoader)
         {
         }
 

--- a/Source/VersOne.Epub/Readers/ContentReader.cs
+++ b/Source/VersOne.Epub/Readers/ContentReader.cs
@@ -33,7 +33,8 @@ namespace VersOne.Epub.Internal
             List<EpubRemoteByteContentFileRef> audioRemote = new();
             List<EpubLocalContentFileRef> allFilesLocal = new();
             List<EpubRemoteContentFileRef> allFilesRemote = new();
-            EpubLocalContentLoader localContentLoader = new(environmentDependencies, epubFile, epubSchema.ContentDirectoryPath, epubReaderOptions.ContentReaderOptions);
+            EpubLocalContentLoader localContentLoader =
+                new(environmentDependencies, epubFile, epubSchema.ContentDirectoryPath, epubReaderOptions.ContentReaderOptions);
             EpubRemoteContentLoader? remoteContentLoader = null;
             foreach (EpubManifestItem manifestItem in epubSchema.Package.Manifest.Items)
             {
@@ -57,7 +58,9 @@ namespace VersOne.Epub.Internal
                         if (contentLocation == EpubContentLocation.LOCAL)
                         {
                             string contentFilePath = ContentPathUtils.Combine(contentDirectoryPath, href);
-                            EpubLocalTextContentFileRef localTextContentFile = new(contentFileRefMetadata, contentFilePath, localContentLoader);
+                            IZipFileEntry? contentFileEntry = epubFile.GetEntry(contentFilePath);
+                            EpubLocalTextContentFileRef localTextContentFile =
+                                new(contentFileRefMetadata, contentFilePath, contentFileEntry, localContentLoader);
                             switch (contentType)
                             {
                                 case EpubContentType.XHTML_1_1:
@@ -98,7 +101,9 @@ namespace VersOne.Epub.Internal
                         if (contentLocation == EpubContentLocation.LOCAL)
                         {
                             string contentFilePath = ContentPathUtils.Combine(contentDirectoryPath, href);
-                            EpubLocalByteContentFileRef localByteContentFile = new(contentFileRefMetadata, contentFilePath, localContentLoader);
+                            IZipFileEntry? contentFileEntry = epubFile.GetEntry(contentFilePath);
+                            EpubLocalByteContentFileRef localByteContentFile =
+                                new(contentFileRefMetadata, contentFilePath, contentFileEntry, localContentLoader);
                             switch (contentType)
                             {
                                 case EpubContentType.IMAGE_GIF:


### PR DESCRIPTION
# Provide access to ZIP archive entry in EpubLocalContentFileRef class

This is:
- [ ] a bug fix
- [x] an enhancement

Related issue: #144

## Description

This pull request adds the `ContentFileEntry` property to the `EpubLocalContentFileRef` class. This property provides access to the underlying ZIP archive entry that corresponds to the content file.

## Testing steps

Use the following code to test the new property:
```cs
string filePath = ...
using (EpubBookRef bookRef = EpubReader.OpenBook(filePath))
{
    IZipFileEntry firstHtmlEntry = bookRef.Content.Html.Local[0].ContentFileEntry!;
    Console.WriteLine($"Length: {firstHtmlEntry.Length}");
    Console.WriteLine($"CompressedLength: {firstHtmlEntry.CompressedLength}");
}
```